### PR TITLE
Remove Empty Array From Address Endpoint

### DIFF
--- a/docs/entities/transactions/abstract-transaction.schema.json
+++ b/docs/entities/transactions/abstract-transaction.schema.json
@@ -19,7 +19,6 @@
         "canonical",
         "tx_status",
         "tx_result",
-        "events",
         "event_count",
         "parent_block_hash",
         "is_unanchored",

--- a/docs/entities/transactions/abstract-transaction.schema.json
+++ b/docs/entities/transactions/abstract-transaction.schema.json
@@ -128,13 +128,6 @@
         "execution_cost_write_length": {
           "type": "integer",
           "description": "Execution cost write length."
-        },
-        "events" : {
-          "type": "array",
-          "description": "List of transaction events",
-          "items": {
-            "$ref": "../transaction-events/transaction-event.schema.json"
-          }
         }
       }
     }

--- a/docs/entities/transactions/transaction-with-events.schema.json
+++ b/docs/entities/transactions/transaction-with-events.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "TransactionWithEvents",
+  "description": "Describes all transaction types on Stacks 2.0 blockchain",
+  "allOf": [
+    {
+      "$ref": "./transaction.schema.json"
+    },
+    {
+      "additionalProperties": false,
+      "required": ["events"],
+      "properties": {
+        "events": {
+          "type": "array",
+          "description": "List of transaction events",
+          "items": {
+            "$ref": "../transaction-events/transaction-event.schema.json"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -765,13 +765,6 @@ export type TransactionStatus1 = "success" | "abort_by_response" | "abort_by_pos
  * String literal of all Stacks 2.0 transaction types
  */
 export type TransactionType = "token_transfer" | "smart_contract" | "contract_call" | "poison_microblock" | "coinbase";
-export type RpcSubscriptionType =
-  | "tx_update"
-  | "address_tx_update"
-  | "address_balance_update"
-  | "block"
-  | "microblock"
-  | "mempool";
 /**
  * Describes all transaction types on Stacks 2.0 blockchain
  */
@@ -781,6 +774,13 @@ export type TransactionWithEvents = Transaction & {
    */
   events: TransactionEvent[];
 };
+export type RpcSubscriptionType =
+  | "tx_update"
+  | "address_tx_update"
+  | "address_balance_update"
+  | "block"
+  | "microblock"
+  | "mempool";
 
 /**
  * GET request that returns address assets

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -233,6 +233,7 @@ export type SchemaMergeRootStub =
   | TransactionNotFound
   | TransactionStatus1
   | TransactionType
+  | TransactionWithEvents
   | Transaction
   | InboundStxTransfer
   | RpcAddressBalanceNotificationParams
@@ -484,10 +485,6 @@ export type AbstractTransaction = BaseTransaction & {
    * Execution cost write length.
    */
   execution_cost_write_length: number;
-  /**
-   * List of transaction events
-   */
-  events?: TransactionEvent[];
 };
 export type PostConditionMode = "allow" | "deny";
 /**
@@ -775,6 +772,15 @@ export type RpcSubscriptionType =
   | "block"
   | "microblock"
   | "mempool";
+/**
+ * Describes all transaction types on Stacks 2.0 blockchain
+ */
+export type TransactionWithEvents = Transaction & {
+  /**
+   * List of transaction events
+   */
+  events: TransactionEvent[];
+};
 
 /**
  * GET request that returns address assets

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -487,7 +487,7 @@ export type AbstractTransaction = BaseTransaction & {
   /**
    * List of transaction events
    */
-  events: TransactionEvent[];
+  events?: TransactionEvent[];
 };
 export type PostConditionMode = "allow" | "deny";
 /**

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -305,7 +305,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: ./entities/transactions/transaction.schema.json
+                $ref: ./entities/transactions/transaction-with-events.schema.json
               example:
                 $ref: ./entities/transactions/transaction-4-coinbase.example.json
         404:

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -909,6 +909,8 @@ export async function getTxFromDataStore(
       offset: args.eventOffset,
     });
     parsedTx.events = eventsQuery.results.map(event => parseDbEvent(event));
+  } else {
+    delete parsedTx.events;
   }
 
   return {

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -169,9 +169,14 @@ export function getTxStatus(txStatus: DbTxStatus | string): string {
   }
 }
 
-type HasEventTransaction = SmartContractTransaction | ContractCallTransaction;
+type EventTypeString =
+  | 'smart_contract_log'
+  | 'stx_asset'
+  | 'fungible_token_asset'
+  | 'non_fungible_token_asset'
+  | 'stx_lock';
 
-export function getEventTypeString(eventTypeId: DbEventTypeId) {
+export function getEventTypeString(eventTypeId: DbEventTypeId): EventTypeString {
   switch (eventTypeId) {
     case DbEventTypeId.SmartContractLog:
       return 'smart_contract_log';

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -2483,7 +2483,6 @@ describe('api tests', () => {
               amount: '35',
               memo: '0x6869',
             },
-            events: [],
             event_count: 0,
             execution_cost_read_count: 1,
             execution_cost_read_length: 2,
@@ -2564,7 +2563,6 @@ describe('api tests', () => {
               amount: '250',
               memo: '0x6869',
             },
-            events: [],
             event_count: 0,
             execution_cost_read_count: 1,
             execution_cost_read_length: 2,
@@ -2622,7 +2620,6 @@ describe('api tests', () => {
               amount: '100',
               memo: '0x6869',
             },
-            events: [],
             event_count: 0,
             execution_cost_read_count: 1,
             execution_cost_read_length: 2,
@@ -2703,7 +2700,6 @@ describe('api tests', () => {
           amount: '35',
           memo: '0x6869',
         },
-        events: [],
         event_count: 0,
         execution_cost_read_count: 1,
         execution_cost_read_length: 2,
@@ -2775,7 +2771,6 @@ describe('api tests', () => {
               amount: '35',
               memo: '0x6869',
             },
-            events: [],
             event_count: 0,
             execution_cost_read_count: 1,
             execution_cost_read_length: 2,
@@ -2856,7 +2851,6 @@ describe('api tests', () => {
               amount: '15',
               memo: '0x6869',
             },
-            events: [],
             event_count: 0,
             execution_cost_read_count: 1,
             execution_cost_read_length: 2,
@@ -3395,7 +3389,6 @@ describe('api tests', () => {
             memo: '0x6869',
           },
           event_count: 0,
-          events: [],
           execution_cost_read_count: 0,
           execution_cost_read_length: 0,
           execution_cost_runtime: 0,
@@ -3436,7 +3429,6 @@ describe('api tests', () => {
             memo: '0x6869',
           },
           event_count: 0,
-          events: [],
           execution_cost_read_count: 0,
           execution_cost_read_length: 0,
           execution_cost_runtime: 0,
@@ -3477,7 +3469,6 @@ describe('api tests', () => {
             memo: '0x6869',
           },
           event_count: 0,
-          events: [],
           execution_cost_read_count: 0,
           execution_cost_read_length: 0,
           execution_cost_runtime: 0,
@@ -3940,12 +3931,12 @@ describe('api tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    expect(txQuery.result).toEqual(expectedResp);
-
+    const { events, ...excludedEvents } = expectedResp;
     const fetchTx = await supertest(api.server).get(`/extended/v1/tx/${dbTx.tx_id}`);
     expect(fetchTx.status).toBe(200);
     expect(fetchTx.type).toBe('application/json');
     expect(JSON.parse(fetchTx.text)).toEqual(expectedResp);
+    expect(txQuery.result).toEqual(excludedEvents);
   });
 
   test('tx store and processing', async () => {
@@ -4153,7 +4144,8 @@ describe('api tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    expect(txQuery.result).toEqual(expectedResp);
+    const { events, ...excludedEvents } = expectedResp;
+    expect(txQuery.result).toEqual(excludedEvents);
 
     const fetchTx = await supertest(api.server).get(`/extended/v1/tx/${dbTx.tx_id}`);
     expect(fetchTx.status).toBe(200);
@@ -4277,7 +4269,8 @@ describe('api tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    expect(txQuery.result).toEqual(expectedResp);
+    const { events, ...excludedEvents } = expectedResp;
+    expect(txQuery.result).toEqual(excludedEvents);
 
     const fetchTx = await supertest(api.server).get(`/extended/v1/tx/${dbTx.tx_id}`);
     expect(fetchTx.status).toBe(200);
@@ -4401,7 +4394,8 @@ describe('api tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    expect(txQuery.result).toEqual(expectedResp);
+    const { events, ...excludedEvents } = expectedResp;
+    expect(txQuery.result).toEqual(excludedEvents);
 
     const fetchTx = await supertest(api.server).get(`/extended/v1/tx/${dbTx.tx_id}`);
     expect(fetchTx.status).toBe(200);

--- a/src/tests/microblocks-tests.ts
+++ b/src/tests/microblocks-tests.ts
@@ -25,6 +25,7 @@ import {
   MicroblockListResponse,
   Transaction,
   TransactionResults,
+  TransactionWithEvents,
 } from '@stacks/stacks-blockchain-api-types';
 import { useWithCleanup } from './test-helpers';
 import { startEventServer } from '../event-stream/event-server';
@@ -149,7 +150,7 @@ describe('microblock tests', () => {
           }
         }
         const txResult2 = await supertest(api.server).get(`/extended/v1/tx/${lostTx}`);
-        const { body: txBody }: { body: Transaction } = txResult2;
+        const { body: txBody }: { body: TransactionWithEvents } = txResult2;
         expect(txBody.canonical).toBe(true);
         expect(txBody.microblock_canonical).toBe(true);
         expect(txBody.tx_id).toBe(lostTx);
@@ -215,7 +216,7 @@ describe('microblock tests', () => {
           }
         }
         const txResult2 = await supertest(api.server).get(`/extended/v1/tx/${lostTx}`);
-        const { body: txBody }: { body: Transaction } = txResult2;
+        const { body: txBody }: { body: TransactionWithEvents } = txResult2;
         expect(txBody.canonical).toBe(true);
         expect(txBody.microblock_canonical).toBe(true);
         expect(txBody.tx_id).toBe(lostTx);
@@ -440,7 +441,7 @@ describe('microblock tests', () => {
         const txResult2 = await supertest(api.server).get(
           `/extended/v1/tx/${mbTx1.tx_id}?unanchored`
         );
-        const { body: txBody2 }: { body: Transaction } = txResult2;
+        const { body: txBody2 }: { body: TransactionWithEvents } = txResult2;
         expect(txBody2.tx_id).toBe(mbTx1.tx_id);
         expect(txBody2.tx_status).toBe('success');
         expect(txBody2.events).toHaveLength(1);


### PR DESCRIPTION
## Description

The transaction's history endpoint returned transaction with event_count non zero. However, the transaction events contained an empty list. This PR removed the unnecessary events object from the response.

For details refer to issue #668 

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @kyranjamie or @zone117x for review
