### PR TITLE
NodeJS cluster workers (multiple cpu core support)

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,7 @@
 PG_HOST=127.0.0.1
-#PG_PORT=5432
 PG_PORT=5490
 PG_USER=postgres
 PG_PASSWORD=postgres
-#PG_DATABASE=postgres
 PG_DATABASE=stacks_blockchain_api
 PG_SCHEMA=public
 PG_SSL=false

--- a/.env
+++ b/.env
@@ -1,7 +1,9 @@
 PG_HOST=127.0.0.1
+#PG_PORT=5432
 PG_PORT=5490
 PG_USER=postgres
 PG_PASSWORD=postgres
+#PG_DATABASE=postgres
 PG_DATABASE=stacks_blockchain_api
 PG_SCHEMA=public
 PG_SSL=false
@@ -20,6 +22,12 @@ PG_SSL=false
 # Initializes the API in read-only mode i.e. without an event server that listens to events from a node and writes them
 # to the local database. The API will only read data from the PG database specified above to respond to requests.
 # STACKS_READ_ONLY_MODE=true
+
+# Enables Node.JS cluster workers for the public API server in order to take advantage of multiple CPU cores.
+# STACKS_ENABLE_CLUSTER=true
+
+# Specify the number of cluster worker processes to spawn, if unspecifed, the number of system CPU cores will be used.
+# STACKS_CLUSTER_WORKERS=4
 
 STACKS_CORE_EVENT_PORT=3700
 STACKS_CORE_EVENT_HOST=127.0.0.1

--- a/.github/workflows/stacks-blockchain-api.yml
+++ b/.github/workflows/stacks-blockchain-api.yml
@@ -314,6 +314,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2.5.0

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -318,7 +318,7 @@ export async function startApiServer(opts: {
   const terminate = async () => {
     const serverClose = new Promise<void>(resolve => {
       // In cluster mode, the http server may already be closed in a given worker
-      if (cluster.isWorker && !server.listening) {
+      if (!server.listening) {
         return resolve();
       }
       logger.info('Closing API http server...');
@@ -328,7 +328,7 @@ export async function startApiServer(opts: {
       });
     });
     await new Promise<void>((resolve, reject) => {
-      if (cluster.isWorker && !server.listening) {
+      if (!server.listening) {
         return resolve();
       }
       logger.info('Closing Socket.io server...');

--- a/src/api/routes/ws-rpc.ts
+++ b/src/api/routes/ws-rpc.ts
@@ -9,6 +9,7 @@ import {
 } from 'jsonrpc-lite';
 import * as WebSocket from 'ws';
 import * as http from 'http';
+import * as net from 'net';
 import PQueue from 'p-queue';
 import {
   RpcTxUpdateSubscriptionParams,
@@ -62,7 +63,7 @@ export function createWsRpcRouter(db: DataStore, server: http.Server): WebSocket
   // Use `noServer` and the `upgrade` event to prevent the ws lib from hijacking the http.Server error event
   const wsPath = '/extended/v1/ws';
   const wsServer = new WebSocket.Server({ noServer: true, path: wsPath });
-  server.on('upgrade', (request: http.IncomingMessage, socket, head) => {
+  server.on('upgrade', (request: http.IncomingMessage, socket: net.Socket, head) => {
     if (request.url?.startsWith(wsPath)) {
       wsServer.handleUpgrade(request, socket, head, ws => {
         wsServer.emit('connection', ws, request);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -40,6 +40,22 @@ export const EMPTY_HASH_256 = '0x00000000000000000000000000000000000000000000000
 
 export const pipelineAsync = util.promisify(stream.pipeline);
 
+let didLoadDotEnv = false;
+export function loadDotEnv(): void {
+  if (didLoadDotEnv) {
+    return;
+  }
+  const dotenvConfig = dotenv.config();
+  if (dotenvConfig.error) {
+    logError(`Error loading .env file: ${dotenvConfig.error}`, dotenvConfig.error);
+    throw dotenvConfig.error;
+  }
+  didLoadDotEnv = true;
+}
+
+// Ensure the `.env` file is loaded before some of the below consts do a one-time read from `process.env`
+loadDotEnv();
+
 function createEnumChecker<T extends string, TEnumValue extends number>(
   enumVariable: { [key in T]: TEnumValue }
 ): (value: number) => value is TEnumValue {
@@ -120,20 +136,6 @@ export function getEnumDescription<T extends string, TEnumValue extends number>(
   const newEnumMap = new Map(enumValues);
   enumMaps.set(enumVariable, newEnumMap);
   return getEnumDescription(enumVariable, value);
-}
-
-let didLoadDotEnv = false;
-
-export function loadDotEnv(): void {
-  if (didLoadDotEnv) {
-    return;
-  }
-  const dotenvConfig = dotenv.config();
-  if (dotenvConfig.error) {
-    logError(`Error loading .env file: ${dotenvConfig.error}`, dotenvConfig.error);
-    throw dotenvConfig.error;
-  }
-  didLoadDotEnv = true;
 }
 
 type EqualsTest<T> = <A>() => A extends T ? 1 : 0;

--- a/src/shutdown-handler.ts
+++ b/src/shutdown-handler.ts
@@ -56,6 +56,17 @@ async function startShutdown(exitCode?: number) {
   }
 }
 
+/**
+ * The error exit codes used by this app.
+ * Note: safe exit code values are 0 to 125 (in many cases, only 8 bits are available for exit code,
+ * and in some shells values 126 to 255 are used to encode signal numbers).
+ * See https://unix.stackexchange.com/a/418802
+ */
+export const ExitCodes = {
+  UncaughtException: 2,
+  UnhandledRejection: 3,
+} as const;
+
 let shutdownSignalsRegistered = false;
 function registerShutdownSignals() {
   if (shutdownSignalsRegistered) {
@@ -72,12 +83,12 @@ function registerShutdownSignals() {
   process.once('unhandledRejection', error => {
     logError(`unhandledRejection ${(error as any)?.message ?? error}`, error as Error);
     logger.error(`Shutting down... received unhandledRejection.`);
-    void startShutdown(11);
+    void startShutdown(ExitCodes.UnhandledRejection);
   });
   process.once('uncaughtException', error => {
     logError(`Received uncaughtException: ${error}`, error);
     logger.error(`Shutting down... received uncaughtException.`);
-    void startShutdown(12);
+    void startShutdown(ExitCodes.UncaughtException);
   });
   process.once('beforeExit', () => {
     logger.info(`Shutting down... received beforeExit.`);

--- a/src/shutdown-handler.ts
+++ b/src/shutdown-handler.ts
@@ -14,7 +14,7 @@ const shutdownConfigs: ShutdownConfig[] = [];
 
 export let isShuttingDown = false;
 
-async function startShutdown() {
+async function startShutdown(exitCode?: number) {
   if (isShuttingDown) {
     return;
   }
@@ -49,10 +49,10 @@ async function startShutdown() {
     }
   }
   if (errorEncountered) {
-    process.exit(1);
+    process.exit(exitCode ?? 1);
   } else {
     logger.info('App shutdown successful.');
-    process.exit();
+    process.exit(exitCode);
   }
 }
 
@@ -72,12 +72,12 @@ function registerShutdownSignals() {
   process.once('unhandledRejection', error => {
     logError(`unhandledRejection ${(error as any)?.message ?? error}`, error as Error);
     logger.error(`Shutting down... received unhandledRejection.`);
-    void startShutdown();
+    void startShutdown(11);
   });
   process.once('uncaughtException', error => {
     logError(`Received uncaughtException: ${error}`, error);
     logger.error(`Shutting down... received uncaughtException.`);
-    void startShutdown();
+    void startShutdown(12);
   });
   process.once('beforeExit', () => {
     logger.info(`Shutting down... received beforeExit.`);


### PR DESCRIPTION
While working on CPU profiling support, it became apparent that various approaches have an impact on how future nodejs [`cluster`](https://nodejs.org/api/cluster.html#cluster_cluster) support would work. I took a stab at implementing support and it turned out to be pretty straightforward (mostly due to Rafael's readonly mode work).

Clustering is disabled by default, and can be enabled with an env var `STACKS_ENABLE_CLUSTER=true`.

For context, see nodejs docs: https://nodejs.org/api/cluster.html#cluster_cluster
> A single instance of Node.js runs in a single thread. To take advantage of multi-core systems, the user will sometimes want to launch a cluster of Node.js processes to handle the load.
> The cluster module allows easy creation of child processes that all share server ports.