### PR TITLE
Add `at_block` query param for `/address` endpoints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1034,6 +1034,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: at_block
+          in: query
+          description: returned data representing the state at that point in time, rather than the current block.
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: Success
@@ -1064,6 +1070,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: at_block
+          in: query
+          description: returned data representing the state at that point in time, rather than the current block.
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: Success
@@ -1081,6 +1093,12 @@ paths:
         - Accounts
       operationId: get_account_transactions
       parameters:
+        - name: principal
+          in: path
+          description: Stacks address or a Contract identifier (e.g. `SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0.get-info`)
+          required: true
+          schema:
+            type: string
         - name: limit
           in: query
           description: max number of account transactions to fetch
@@ -1093,12 +1111,6 @@ paths:
           required: false
           schema:
             type: integer
-        - name: principal
-          in: path
-          description: Stacks address or a Contract identifier (e.g. `SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0.get-info`)
-          required: true
-          schema:
-            type: string
         - name: height
           in: query
           description: Filter for transactions only at this given block height
@@ -1112,6 +1124,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: at_block
+          in: query
+          description: returned data representing the state at that point in time, rather than the current block.
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: Success
@@ -1164,6 +1182,12 @@ paths:
         - Accounts
       operationId: get_account_transactions_with_transfers
       parameters:
+        - name: principal
+          in: path
+          description: Stacks address or a Contract identifier (e.g. `SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0.get-info`)
+          required: true
+          schema:
+            type: string
         - name: limit
           in: query
           description: max number of account transactions to fetch
@@ -1176,12 +1200,6 @@ paths:
           required: false
           schema:
             type: integer
-        - name: principal
-          in: path
-          description: Stacks address or a Contract identifier (e.g. `SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0.get-info`)
-          required: true
-          schema:
-            type: string
         - name: height
           in: query
           description: Filter for transactions only at this given block height
@@ -1195,6 +1213,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: at_block
+          in: query
+          description: returned data representing the state at that point in time, rather than the current block.
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: Success
@@ -1235,6 +1259,12 @@ paths:
         - Accounts
       operationId: get_account_assets
       parameters:
+        - name: principal
+          in: path
+          description: Stacks address or a Contract identifier (e.g. `SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0.get-info`)
+          required: true
+          schema:
+            type: string
         - name: limit
           in: query
           description: max number of account assets to fetch
@@ -1247,12 +1277,6 @@ paths:
           required: false
           schema:
             type: integer
-        - name: principal
-          in: path
-          description: Stacks address or a Contract identifier (e.g. `SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0.get-info`)
-          required: true
-          schema:
-            type: string
         - name: unanchored
           in: query
           description: Include transaction data from unanchored (i.e. unconfirmed) microblocks
@@ -1260,6 +1284,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: at_block
+          in: query
+          description: returned data representing the state at that point in time, rather than the current block.
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: Success
@@ -1280,6 +1310,12 @@ paths:
         - Accounts
       operationId: get_account_inbound
       parameters:
+        - name: principal
+          in: path
+          description: Stacks address or a Contract identifier (e.g. `SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0.get-info`)
+          required: true
+          schema:
+            type: string
         - name: limit
           in: query
           description: number of items to return
@@ -1292,12 +1328,6 @@ paths:
           required: false
           schema:
             type: integer
-        - name: principal
-          in: path
-          description: Stacks address or a Contract identifier (e.g. `SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0.get-info`)
-          required: true
-          schema:
-            type: string
         - name: height
           in: query
           description: Filter for transfers only at this given block height
@@ -1311,6 +1341,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: at_block
+          in: query
+          description: returned data representing the state at that point in time, rather than the current block.
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: Success
@@ -1330,6 +1366,12 @@ paths:
         - Accounts
       operationId: get_account_nft
       parameters:
+        - name: principal
+          in: path
+          description: Stacks address or a Contract identifier (e.g. `SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0.get-info`)
+          required: true
+          schema:
+            type: string
         - name: limit
           in: query
           description: number of items to return
@@ -1342,12 +1384,6 @@ paths:
           required: false
           schema:
             type: integer
-        - name: principal
-          in: path
-          description: Stacks address or a Contract identifier (e.g. `SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0.get-info`)
-          required: true
-          schema:
-            type: string
         - name: unanchored
           in: query
           description: Include transaction data from unanchored (i.e. unconfirmed) microblocks
@@ -1355,6 +1391,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: at_block
+          in: query
+          description: returned data representing the state at that point in time, rather than the current block.
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: Success

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1034,7 +1034,7 @@ paths:
           schema:
             type: boolean
             default: false
-        - name: at_block
+        - name: until_block
           in: query
           description: returned data representing the state at that point in time, rather than the current block.
           required: false
@@ -1070,7 +1070,7 @@ paths:
           schema:
             type: boolean
             default: false
-        - name: at_block
+        - name: until_block
           in: query
           description: returned data representing the state at that point in time, rather than the current block.
           required: false
@@ -1124,7 +1124,7 @@ paths:
           schema:
             type: boolean
             default: false
-        - name: at_block
+        - name: until_block
           in: query
           description: returned data representing the state at that point in time, rather than the current block.
           required: false
@@ -1213,7 +1213,7 @@ paths:
           schema:
             type: boolean
             default: false
-        - name: at_block
+        - name: until_block
           in: query
           description: returned data representing the state at that point in time, rather than the current block.
           required: false
@@ -1284,7 +1284,7 @@ paths:
           schema:
             type: boolean
             default: false
-        - name: at_block
+        - name: until_block
           in: query
           description: returned data representing the state at that point in time, rather than the current block.
           required: false
@@ -1341,7 +1341,7 @@ paths:
           schema:
             type: boolean
             default: false
-        - name: at_block
+        - name: until_block
           in: query
           description: returned data representing the state at that point in time, rather than the current block.
           required: false
@@ -1391,7 +1391,7 @@ paths:
           schema:
             type: boolean
             default: false
-        - name: at_block
+        - name: until_block
           in: query
           description: returned data representing the state at that point in time, rather than the current block.
           required: false

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1036,7 +1036,7 @@ paths:
             default: false
         - name: until_block
           in: query
-          description: returned data representing the state at that point in time, rather than the current block.
+          description: returned data representing the state up until that point in time, rather than the current block.
           required: false
           schema:
             type: string
@@ -1072,7 +1072,7 @@ paths:
             default: false
         - name: until_block
           in: query
-          description: returned data representing the state at that point in time, rather than the current block.
+          description: returned data representing the state up until that point in time, rather than the current block.
           required: false
           schema:
             type: string
@@ -1126,7 +1126,7 @@ paths:
             default: false
         - name: until_block
           in: query
-          description: returned data representing the state at that point in time, rather than the current block.
+          description: returned data representing the state up until that point in time, rather than the current block.
           required: false
           schema:
             type: string
@@ -1215,7 +1215,7 @@ paths:
             default: false
         - name: until_block
           in: query
-          description: returned data representing the state at that point in time, rather than the current block.
+          description: returned data representing the state up until that point in time, rather than the current block.
           required: false
           schema:
             type: string
@@ -1343,7 +1343,7 @@ paths:
             default: false
         - name: until_block
           in: query
-          description: returned data representing the state at that point in time, rather than the current block.
+          description: returned data representing the state up until that point in time, rather than the current block.
           required: false
           schema:
             type: string
@@ -1393,7 +1393,7 @@ paths:
             default: false
         - name: until_block
           in: query
-          description: returned data representing the state at that point in time, rather than the current block.
+          description: returned data representing the state up until that point in time, rather than the current block.
           required: false
           schema:
             type: string

--- a/src/api/query-helpers.ts
+++ b/src/api/query-helpers.ts
@@ -139,10 +139,9 @@ export function getBlockHeightPathParam(
 /**
  * Determine if at_block query parameter exists or is an integer or string or if it is a valid height
  * if it is a string with "0x" prefix consider it a block_hash if it is integer consider it block_height
- * If type is not string or block_height is not valid or it also has mutually exclusive "unechored" property a 400 bad requst is send and function throws.
+ * If type is not string or block_height is not valid or it also has mutually exclusive "unanchored" property a 400 bad requst is send and function throws.
  * @returns - undefined  if  param does not exist || block_height if number || block_hash if string || never if error
  */
-
 export function parseAtBlockQuery(
   req: Request,
   res: Response,

--- a/src/api/query-helpers.ts
+++ b/src/api/query-helpers.ts
@@ -147,9 +147,9 @@ export function parseUntilBlockQuery(
   res: Response,
   next: NextFunction
 ): undefined | number | string | never {
-  const until_block = req.query.until_block;
-  if (!until_block) return;
-  if (typeof until_block === 'string') {
+  const untilBlock = req.query.until_block;
+  if (!untilBlock) return;
+  if (typeof untilBlock === 'string') {
     //if mutually exclusive unachored is also specified, throw bad request error
     if (isUnanchoredRequest(req, res, next)) {
       handleBadRequest(
@@ -158,12 +158,12 @@ export function parseUntilBlockQuery(
         `can't handle both 'unanchored' and 'until_block' in the same request `
       );
     }
-    if (has0xPrefix(until_block)) {
+    if (has0xPrefix(untilBlock)) {
       //case for block_hash
-      return until_block;
+      return untilBlock;
     } else {
       //parse int to check if it is a block_height
-      const block_height = Number.parseInt(until_block, 10);
+      const block_height = Number.parseInt(untilBlock, 10);
       if (isNaN(block_height) || block_height < 1) {
         handleBadRequest(
           res,

--- a/src/api/query-helpers.ts
+++ b/src/api/query-helpers.ts
@@ -137,33 +137,33 @@ export function getBlockHeightPathParam(
 }
 
 /**
- * Determine if at_block query parameter exists or is an integer or string or if it is a valid height
+ * Determine if until_block query parameter exists or is an integer or string or if it is a valid height
  * if it is a string with "0x" prefix consider it a block_hash if it is integer consider it block_height
  * If type is not string or block_height is not valid or it also has mutually exclusive "unanchored" property a 400 bad requst is send and function throws.
  * @returns - undefined  if  param does not exist || block_height if number || block_hash if string || never if error
  */
-export function parseAtBlockQuery(
+export function parseUntilBlockQuery(
   req: Request,
   res: Response,
   next: NextFunction
 ): undefined | number | string | never {
-  const at_block = req.query.at_block;
-  if (!at_block) return;
-  if (typeof at_block === 'string') {
+  const until_block = req.query.until_block;
+  if (!until_block) return;
+  if (typeof until_block === 'string') {
     //if mutually exclusive unachored is also specified, throw bad request error
     if (isUnanchoredRequest(req, res, next)) {
       handleBadRequest(
         res,
         next,
-        `can't handle both 'unanchored' and 'at_block' in the same request `
+        `can't handle both 'unanchored' and 'until_block' in the same request `
       );
     }
-    if (has0xPrefix(at_block)) {
+    if (has0xPrefix(until_block)) {
       //case for block_hash
-      return at_block;
+      return until_block;
     } else {
       //parse int to check if it is a block_height
-      const block_height = Number.parseInt(at_block, 10);
+      const block_height = Number.parseInt(until_block, 10);
       if (isNaN(block_height) || block_height < 1) {
         handleBadRequest(
           res,
@@ -174,5 +174,5 @@ export function parseAtBlockQuery(
       return block_height;
     }
   }
-  handleBadRequest(res, next, 'at_block must be either `string` or `number`');
+  handleBadRequest(res, next, 'until_block must be either `string` or `number`');
 }

--- a/src/api/query-helpers.ts
+++ b/src/api/query-helpers.ts
@@ -140,7 +140,7 @@ export function getBlockHeightPathParam(
  * Determine if until_block query parameter exists or is an integer or string or if it is a valid height
  * if it is a string with "0x" prefix consider it a block_hash if it is integer consider it block_height
  * If type is not string or block_height is not valid or it also has mutually exclusive "unanchored" property a 400 bad requst is send and function throws.
- * @returns - undefined  if  param does not exist || block_height if number || block_hash if string || never if error
+ * @returns `undefined` if param does not exist || block_height if number || block_hash if string || never if error
  */
 export function parseUntilBlockQuery(
   req: Request,

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -52,7 +52,7 @@ const parseStxInboundLimit = parseLimitQuery({
 });
 
 async function getBlockHeight(
-  at_block: any,
+  at_block: number | string | undefined,
   req: Request,
   res: Response,
   next: NextFunction,
@@ -71,7 +71,6 @@ async function getBlockHeight(
     }
     blockHeight = block.result.block_height;
   } else {
-    // Get balance info for STX token
     const includeUnanchored = isUnanchoredRequest(req, res, next);
     const currentBlockHeight = await db.getCurrentBlockHeight();
     if (!currentBlockHeight.found) {
@@ -106,6 +105,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
 
     const blockHeight = await getBlockHeight(at_block, req, res, next, db);
 
+    // Get balance info for STX token
     const stxBalanceResult = await db.getStxBalanceAtBlock(stxAddress, blockHeight);
     const tokenOfferingLocked = await db.getTokenOfferingLocked(stxAddress, blockHeight);
     const result: AddressStxBalanceResponse = {

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -3,7 +3,7 @@ import { addAsync, RouterWithAsync } from '@awaitjs/express';
 import * as Bluebird from 'bluebird';
 import { DataStore } from '../../datastore/common';
 import { parseLimitQuery, parsePagingQueryInput } from '../pagination';
-import { isUnanchoredRequest, getBlockParams } from '../query-helpers';
+import { isUnanchoredRequest, getBlockParams, parseAtBlockQuery } from '../query-helpers';
 import {
   bufferToHexPrefixString,
   formatMapToObject,
@@ -30,6 +30,7 @@ import {
 } from '@stacks/stacks-blockchain-api-types';
 import { ChainID, cvToString, deserializeCV } from '@stacks/transactions';
 import { validate } from '../validate';
+import { NextFunction, Request, Response } from 'express';
 
 const MAX_TX_PER_REQUEST = 50;
 const MAX_ASSETS_PER_REQUEST = 50;
@@ -50,6 +51,42 @@ const parseStxInboundLimit = parseLimitQuery({
   errorMsg: '`limit` must be equal to or less than ' + MAX_STX_INBOUND_PER_REQUEST,
 });
 
+async function getBlockHeight(
+  at_block: any,
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  db: DataStore
+): Promise<number> {
+  let blockHeight = 0;
+  if (typeof at_block === 'number') {
+    blockHeight = at_block;
+  } else if (typeof at_block === 'string') {
+    const block = await db.getBlock({ hash: at_block });
+    if (!block.found) {
+      const error = `block not found with hash ${at_block}`;
+      res.status(404).json({ error: error });
+      next(error);
+      throw new Error(error);
+    }
+    blockHeight = block.result.block_height;
+  } else {
+    // Get balance info for STX token
+    const includeUnanchored = isUnanchoredRequest(req, res, next);
+    const currentBlockHeight = await db.getCurrentBlockHeight();
+    if (!currentBlockHeight.found) {
+      const error = `no current block`;
+      res.status(404).json({ error: error });
+      next(error);
+      throw new Error(error);
+    }
+
+    blockHeight = currentBlockHeight.result + (includeUnanchored ? 1 : 0);
+  }
+
+  return blockHeight;
+}
+
 interface AddressAssetEvents {
   results: TransactionEvent[];
   limit: number;
@@ -65,14 +102,9 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
     if (!isValidPrincipal(stxAddress)) {
       return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
     }
-    // Get balance info for STX token
-    const includeUnanchored = isUnanchoredRequest(req, res, next);
-    const currentBlockHeight = await db.getCurrentBlockHeight();
-    if (!currentBlockHeight.found) {
-      return res.status(500).json({ error: `no current block` });
-    }
+    const at_block = parseAtBlockQuery(req, res, next);
 
-    const blockHeight = currentBlockHeight.result + (includeUnanchored ? 1 : 0);
+    const blockHeight = await getBlockHeight(at_block, req, res, next, db);
 
     const stxBalanceResult = await db.getStxBalanceAtBlock(stxAddress, blockHeight);
     const tokenOfferingLocked = await db.getTokenOfferingLocked(stxAddress, blockHeight);
@@ -102,20 +134,18 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
       return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
     }
 
-    const includeUnanchored = isUnanchoredRequest(req, res, next);
-    const currentBlockHeight = await db.getCurrentBlockHeight();
-    if (!currentBlockHeight.found) {
-      return res.status(500).json({ error: `no current block` });
-    }
-
-    const blockHeight = currentBlockHeight.result + (includeUnanchored ? 1 : 0);
+    const at_block = parseAtBlockQuery(req, res, next);
+    const blockHeight = await getBlockHeight(at_block, req, res, next, db);
 
     // Get balance info for STX token
     const stxBalanceResult = await db.getStxBalanceAtBlock(stxAddress, blockHeight);
     const tokenOfferingLocked = await db.getTokenOfferingLocked(stxAddress, blockHeight);
 
     // Get balances for fungible tokens
-    const ftBalancesResult = await db.getFungibleTokenBalances({ stxAddress, includeUnanchored });
+    const ftBalancesResult = await db.getFungibleTokenBalances({
+      stxAddress,
+      atBlock: blockHeight,
+    });
     const ftBalances = formatMapToObject(ftBalancesResult, val => {
       return {
         balance: val.balance.toString(),
@@ -125,7 +155,10 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
     });
 
     // Get counts for non-fungible tokens
-    const nftBalancesResult = await db.getNonFungibleTokenCounts({ stxAddress, includeUnanchored });
+    const nftBalancesResult = await db.getNonFungibleTokenCounts({
+      stxAddress,
+      atBlock: blockHeight,
+    });
     const nftBalances = formatMapToObject(nftBalancesResult, val => {
       return {
         count: val.count.toString(),
@@ -165,14 +198,29 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
       return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
     }
 
+    const at_block = parseAtBlockQuery(req, res, next);
     const blockParams = getBlockParams(req, res, next);
+    let atSingleBlock = false;
+    let blockHeight = 0;
+    if (blockParams.blockHeight) {
+      if (at_block) {
+        return res
+          .status(400)
+          .json({ error: `can't handle at_block and block_height in the same request` });
+      }
+      atSingleBlock = true;
+      blockHeight = blockParams.blockHeight;
+    } else {
+      blockHeight = await getBlockHeight(at_block, req, res, next, db);
+    }
     const limit = parseTxQueryLimit(req.query.limit ?? 20);
     const offset = parsePagingQueryInput(req.query.offset ?? 0);
     const { results: txResults, total } = await db.getAddressTxs({
       stxAddress: stxAddress,
       limit,
       offset,
-      ...blockParams,
+      blockHeight,
+      atSingleBlock,
     });
     // TODO: use getBlockWithMetadata or similar to avoid transaction integrity issues from lazy resolving block tx data (primarily the contract-call ABI data)
     const results = await Bluebird.mapSeries(txResults, async tx => {
@@ -229,14 +277,29 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
       return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
     }
 
+    const at_block = parseAtBlockQuery(req, res, next);
     const blockParams = getBlockParams(req, res, next);
+    let atSingleBlock = false;
+    let blockHeight = 0;
+    if (blockParams.blockHeight) {
+      if (at_block) {
+        return res
+          .status(400)
+          .json({ error: `can't handle at_block and block_height in the same request` });
+      }
+      atSingleBlock = true;
+      blockHeight = blockParams.blockHeight;
+    } else {
+      blockHeight = await getBlockHeight(at_block, req, res, next, db);
+    }
     const limit = parseTxQueryLimit(req.query.limit ?? 20);
     const offset = parsePagingQueryInput(req.query.offset ?? 0);
     const { results: txResults, total } = await db.getAddressTxsWithAssetTransfers({
       stxAddress: stxAddress,
       limit,
       offset,
-      ...blockParams,
+      blockHeight,
+      atSingleBlock,
     });
 
     // TODO: use getBlockWithMetadata or similar to avoid transaction integrity issues from lazy resolving block tx data (primarily the contract-call ABI data)
@@ -289,14 +352,16 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
     if (!isValidPrincipal(stxAddress)) {
       return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
     }
-    const includeUnanchored = isUnanchoredRequest(req, res, next);
+    const at_block = parseAtBlockQuery(req, res, next);
+    const blockHeight = await getBlockHeight(at_block, req, res, next, db);
+
     const limit = parseAssetsQueryLimit(req.query.limit ?? 20);
     const offset = parsePagingQueryInput(req.query.offset ?? 0);
     const { results: assetEvents, total } = await db.getAddressAssetEvents({
       stxAddress,
       limit,
       offset,
-      includeUnanchored,
+      blockHeight,
     });
     const results = assetEvents.map(event => parseDbEvent(event));
     const response: AddressAssetEvents = { limit, offset, total, results };
@@ -315,15 +380,32 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
       if (!isValidPrincipal(stxAddress)) {
         return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
       }
+
+      let atSingleBlock = false;
+      const at_block = parseAtBlockQuery(req, res, next);
+      const blockParams = getBlockParams(req, res, next);
+      let blockHeight = 0;
+      if (blockParams.blockHeight) {
+        if (at_block) {
+          return res
+            .status(400)
+            .json({ error: `can't handle at_block and block_height in the same request` });
+        }
+        atSingleBlock = true;
+        blockHeight = blockParams.blockHeight;
+      } else {
+        blockHeight = await getBlockHeight(at_block, req, res, next, db);
+      }
+
       const limit = parseStxInboundLimit(req.query.limit ?? 20);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
-      const blockParams = getBlockParams(req, res, next);
       const { results, total } = await db.getInboundTransfers({
         stxAddress,
         limit,
         offset,
         sendManyContractId,
-        ...blockParams,
+        blockHeight,
+        atSingleBlock,
       });
       const transfers: InboundStxTransfer[] = results.map(r => ({
         sender: r.sender,
@@ -354,15 +436,16 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
       return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
     }
 
+    const at_block = parseAtBlockQuery(req, res, next);
+    const blockHeight = await getBlockHeight(at_block, req, res, next, db);
     const limit = parseAssetsQueryLimit(req.query.limit ?? 20);
     const offset = parsePagingQueryInput(req.query.offset ?? 0);
 
-    const includeUnanchored = isUnanchoredRequest(req, res, next);
     const response = await db.getAddressNFTEvent({
       stxAddress,
       limit,
       offset,
-      includeUnanchored,
+      blockHeight,
     });
     const nft_events = response.results.map(row => ({
       sender: row.sender,

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -52,19 +52,19 @@ const parseStxInboundLimit = parseLimitQuery({
 });
 
 async function getBlockHeight(
-  until_block: number | string | undefined,
+  untilBlock: number | string | undefined,
   req: Request,
   res: Response,
   next: NextFunction,
   db: DataStore
 ): Promise<number> {
   let blockHeight = 0;
-  if (typeof until_block === 'number') {
-    blockHeight = until_block;
-  } else if (typeof until_block === 'string') {
-    const block = await db.getBlock({ hash: until_block });
+  if (typeof untilBlock === 'number') {
+    blockHeight = untilBlock;
+  } else if (typeof untilBlock === 'string') {
+    const block = await db.getBlock({ hash: untilBlock });
     if (!block.found) {
-      const error = `block not found with hash ${until_block}`;
+      const error = `block not found with hash ${untilBlock}`;
       res.status(404).json({ error: error });
       next(error);
       throw new Error(error);
@@ -101,9 +101,9 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
     if (!isValidPrincipal(stxAddress)) {
       return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
     }
-    const until_block = parseUntilBlockQuery(req, res, next);
+    const untilBlock = parseUntilBlockQuery(req, res, next);
 
-    const blockHeight = await getBlockHeight(until_block, req, res, next, db);
+    const blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
 
     // Get balance info for STX token
     const stxBalanceResult = await db.getStxBalanceAtBlock(stxAddress, blockHeight);
@@ -134,8 +134,8 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
       return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
     }
 
-    const until_block = parseUntilBlockQuery(req, res, next);
-    const blockHeight = await getBlockHeight(until_block, req, res, next, db);
+    const untilBlock = parseUntilBlockQuery(req, res, next);
+    const blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
 
     // Get balance info for STX token
     const stxBalanceResult = await db.getStxBalanceAtBlock(stxAddress, blockHeight);
@@ -198,12 +198,12 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
       return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
     }
 
-    const until_block = parseUntilBlockQuery(req, res, next);
+    const untilBlock = parseUntilBlockQuery(req, res, next);
     const blockParams = getBlockParams(req, res, next);
     let atSingleBlock = false;
     let blockHeight = 0;
     if (blockParams.blockHeight) {
-      if (until_block) {
+      if (untilBlock) {
         return res
           .status(400)
           .json({ error: `can't handle until_block and block_height in the same request` });
@@ -211,7 +211,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
       atSingleBlock = true;
       blockHeight = blockParams.blockHeight;
     } else {
-      blockHeight = await getBlockHeight(until_block, req, res, next, db);
+      blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
     }
     const limit = parseTxQueryLimit(req.query.limit ?? 20);
     const offset = parsePagingQueryInput(req.query.offset ?? 0);
@@ -277,12 +277,12 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
       return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
     }
 
-    const until_block = parseUntilBlockQuery(req, res, next);
+    const untilBlock = parseUntilBlockQuery(req, res, next);
     const blockParams = getBlockParams(req, res, next);
     let atSingleBlock = false;
     let blockHeight = 0;
     if (blockParams.blockHeight) {
-      if (until_block) {
+      if (untilBlock) {
         return res
           .status(400)
           .json({ error: `can't handle until_block and block_height in the same request` });
@@ -290,7 +290,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
       atSingleBlock = true;
       blockHeight = blockParams.blockHeight;
     } else {
-      blockHeight = await getBlockHeight(until_block, req, res, next, db);
+      blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
     }
     const limit = parseTxQueryLimit(req.query.limit ?? 20);
     const offset = parsePagingQueryInput(req.query.offset ?? 0);
@@ -352,8 +352,8 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
     if (!isValidPrincipal(stxAddress)) {
       return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
     }
-    const until_block = parseUntilBlockQuery(req, res, next);
-    const blockHeight = await getBlockHeight(until_block, req, res, next, db);
+    const untilBlock = parseUntilBlockQuery(req, res, next);
+    const blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
 
     const limit = parseAssetsQueryLimit(req.query.limit ?? 20);
     const offset = parsePagingQueryInput(req.query.offset ?? 0);
@@ -382,11 +382,11 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
       }
 
       let atSingleBlock = false;
-      const until_block = parseUntilBlockQuery(req, res, next);
+      const untilBlock = parseUntilBlockQuery(req, res, next);
       const blockParams = getBlockParams(req, res, next);
       let blockHeight = 0;
       if (blockParams.blockHeight) {
-        if (until_block) {
+        if (untilBlock) {
           return res
             .status(400)
             .json({ error: `can't handle until_block and block_height in the same request` });
@@ -394,7 +394,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
         atSingleBlock = true;
         blockHeight = blockParams.blockHeight;
       } else {
-        blockHeight = await getBlockHeight(until_block, req, res, next, db);
+        blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
       }
 
       const limit = parseStxInboundLimit(req.query.limit ?? 20);
@@ -436,8 +436,8 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
       return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
     }
 
-    const until_block = parseUntilBlockQuery(req, res, next);
-    const blockHeight = await getBlockHeight(until_block, req, res, next, db);
+    const untilBlock = parseUntilBlockQuery(req, res, next);
+    const blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
     const limit = parseAssetsQueryLimit(req.query.limit ?? 20);
     const offset = parsePagingQueryInput(req.query.offset ?? 0);
 

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -440,12 +440,14 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
     const blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
     const limit = parseAssetsQueryLimit(req.query.limit ?? 20);
     const offset = parsePagingQueryInput(req.query.offset ?? 0);
+    const includeUnanchored = isUnanchoredRequest(req, res, next);
 
     const response = await db.getAddressNFTEvent({
       stxAddress,
       limit,
       offset,
       blockHeight,
+      includeUnanchored,
     });
     const nft_events = response.results.map(row => ({
       sender: row.sender,

--- a/src/api/routes/ws/socket-io.ts
+++ b/src/api/routes/ws/socket-io.ts
@@ -212,6 +212,7 @@ export function createSocketIORouter(db: DataStore, server: http.Server) {
     const dbTxsQuery = await db.getAddressTxsWithAssetTransfers({
       stxAddress: address,
       blockHeight: blockHeight,
+      atSingleBlock: true,
     });
     if (dbTxsQuery.total == 0) {
       return;

--- a/src/api/routes/ws/ws-rpc.ts
+++ b/src/api/routes/ws/ws-rpc.ts
@@ -382,6 +382,7 @@ export function createWsRpcRouter(db: DataStore, server: http.Server): WebSocket
         const dbTxsQuery = await db.getAddressTxsWithAssetTransfers({
           stxAddress: address,
           blockHeight: blockHeight,
+          atSingleBlock: true,
         });
         if (dbTxsQuery.total == 0) {
           return;

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -701,11 +701,11 @@ export interface DataStore extends DataStoreEventEmitter {
   getStxBalanceAtBlock(stxAddress: string, blockHeight: number): Promise<DbStxBalance>;
   getFungibleTokenBalances(args: {
     stxAddress: string;
-    atBlock: number;
+    untilBlock: number;
   }): Promise<Map<string, DbFtBalance>>;
   getNonFungibleTokenCounts(args: {
     stxAddress: string;
-    atBlock: number;
+    untilBlock: number;
   }): Promise<Map<string, { count: bigint; totalSent: bigint; totalReceived: bigint }>>;
 
   getUnlockedStxSupply(

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -701,11 +701,11 @@ export interface DataStore extends DataStoreEventEmitter {
   getStxBalanceAtBlock(stxAddress: string, blockHeight: number): Promise<DbStxBalance>;
   getFungibleTokenBalances(args: {
     stxAddress: string;
-    includeUnanchored: boolean;
+    atBlock: number;
   }): Promise<Map<string, DbFtBalance>>;
   getNonFungibleTokenCounts(args: {
     stxAddress: string;
-    includeUnanchored: boolean;
+    atBlock: number;
   }): Promise<Map<string, { count: bigint; totalSent: bigint; totalReceived: bigint }>>;
 
   getUnlockedStxSupply(
@@ -720,21 +720,21 @@ export interface DataStore extends DataStoreEventEmitter {
 
   getSTXFaucetRequests(address: string): Promise<{ results: DbFaucetRequest[] }>;
 
-  getAddressTxs(
-    args: {
-      stxAddress: string;
-      limit: number;
-      offset: number;
-    } & ({ blockHeight: number } | { includeUnanchored: boolean })
-  ): Promise<{ results: DbTx[]; total: number }>;
+  getAddressTxs(args: {
+    stxAddress: string;
+    blockHeight: number;
+    atSingleBlock: boolean;
+    limit: number;
+    offset: number;
+  }): Promise<{ results: DbTx[]; total: number }>;
 
-  getAddressTxsWithAssetTransfers(
-    args: {
-      stxAddress: string;
-      limit?: number;
-      offset?: number;
-    } & ({ blockHeight: number } | { includeUnanchored: boolean })
-  ): Promise<{ results: DbTxWithAssetTransfers[]; total: number }>;
+  getAddressTxsWithAssetTransfers(args: {
+    stxAddress: string;
+    blockHeight: number;
+    atSingleBlock: boolean;
+    limit?: number;
+    offset?: number;
+  }): Promise<{ results: DbTxWithAssetTransfers[]; total: number }>;
 
   getInformationTxsWithStxTransfers(args: {
     stxAddress: string;
@@ -743,9 +743,9 @@ export interface DataStore extends DataStoreEventEmitter {
 
   getAddressAssetEvents(args: {
     stxAddress: string;
+    blockHeight: number;
     limit: number;
     offset: number;
-    includeUnanchored: boolean;
   }): Promise<{ results: DbEvent[]; total: number }>;
 
   getAddressNonces(args: {
@@ -757,14 +757,14 @@ export interface DataStore extends DataStoreEventEmitter {
     detectedMissingNonces: number[];
   }>;
 
-  getInboundTransfers(
-    args: {
-      stxAddress: string;
-      limit: number;
-      offset: number;
-      sendManyContractId: string;
-    } & ({ blockHeight: number } | { includeUnanchored: boolean })
-  ): Promise<{ results: DbInboundStxTransfer[]; total: number }>;
+  getInboundTransfers(args: {
+    stxAddress: string;
+    blockHeight: number;
+    atSingleBlock: boolean;
+    limit: number;
+    offset: number;
+    sendManyContractId: string;
+  }): Promise<{ results: DbInboundStxTransfer[]; total: number }>;
 
   searchHash(args: { hash: string }): Promise<FoundOrNot<DbSearchResult>>;
 
@@ -776,9 +776,9 @@ export interface DataStore extends DataStoreEventEmitter {
 
   getAddressNFTEvent(args: {
     stxAddress: string;
+    blockHeight: number;
     limit: number;
     offset: number;
-    includeUnanchored: boolean;
   }): Promise<{ results: AddressNftEventIdentifier[]; total: number }>;
 
   getConfigState(): Promise<DbConfigState>;

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -779,6 +779,7 @@ export interface DataStore extends DataStoreEventEmitter {
     blockHeight: number;
     limit: number;
     offset: number;
+    includeUnanchored: boolean;
   }): Promise<{ results: AddressNftEventIdentifier[]; total: number }>;
 
   getConfigState(): Promise<DbConfigState>;

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -516,14 +516,14 @@ export class MemoryDataStore
 
   getFungibleTokenBalances(args: {
     stxAddress: string;
-    atBlock: number;
+    untilBlock: number;
   }): Promise<Map<string, DbStxBalance>> {
     throw new Error('not yet implemented');
   }
 
   getNonFungibleTokenCounts(args: {
     stxAddress: string;
-    atBlock: number;
+    untilBlock: number;
   }): Promise<Map<string, { count: bigint; totalSent: bigint; totalReceived: bigint }>> {
     throw new Error('not yet implemented');
   }

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -516,24 +516,22 @@ export class MemoryDataStore
 
   getFungibleTokenBalances(args: {
     stxAddress: string;
-    includeUnanchored: boolean;
+    atBlock: number;
   }): Promise<Map<string, DbStxBalance>> {
     throw new Error('not yet implemented');
   }
 
   getNonFungibleTokenCounts(args: {
     stxAddress: string;
-    includeUnanchored: boolean;
+    atBlock: number;
   }): Promise<Map<string, { count: bigint; totalSent: bigint; totalReceived: bigint }>> {
     throw new Error('not yet implemented');
   }
 
-  getAddressTxs({
-    stxAddress,
-    limit,
-    offset,
-  }: {
+  getAddressTxs(args: {
     stxAddress: string;
+    blockHeight: number;
+    atSingleBlock: boolean;
     limit: number;
     offset: number;
   }): Promise<{ results: DbTx[]; total: number }> {
@@ -549,19 +547,17 @@ export class MemoryDataStore
 
   getAddressTxsWithAssetTransfers(args: {
     stxAddress: string;
+    blockHeight: number;
+    atSingleBlock: boolean;
     limit?: number;
     offset?: number;
-    blockHeight?: number;
   }): Promise<{ results: DbTxWithAssetTransfers[]; total: number }> {
     throw new Error('not yet implemented');
   }
 
-  getAddressAssetEvents({
-    stxAddress,
-    limit,
-    offset,
-  }: {
+  getAddressAssetEvents(args: {
     stxAddress: string;
+    blockHeight: number;
     limit: number;
     offset: number;
   }): Promise<{ results: DbEvent[]; total: number }> {
@@ -579,12 +575,13 @@ export class MemoryDataStore
     throw new Error('not yet implemented');
   }
 
-  getInboundTransfers({
-    stxAddress,
-  }: {
+  getInboundTransfers(args: {
     stxAddress: string;
+    blockHeight: number;
+    atSingleBlock: boolean;
     limit: number;
     offset: number;
+    sendManyContractId: string;
   }): Promise<{ results: DbInboundStxTransfer[]; total: number }> {
     throw new Error('not yet implemented');
   }
@@ -636,6 +633,7 @@ export class MemoryDataStore
 
   getAddressNFTEvent(args: {
     stxAddress: string;
+    blockHeight: number;
     limit: number;
     offset: number;
   }): Promise<{ results: AddressNftEventIdentifier[]; total: number }> {

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -636,6 +636,7 @@ export class MemoryDataStore
     blockHeight: number;
     limit: number;
     offset: number;
+    includeUnanchored: boolean;
   }): Promise<{ results: AddressNftEventIdentifier[]; total: number }> {
     throw new Error('Method not implemented.');
   }

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -5494,7 +5494,7 @@ export class PgDataStore
               AND type_id = 0
               AND token_transfer_recipient_address = $1
           ) transfers
-        WHERE block_height <= $5
+        ${whereClause}
         ORDER BY
           block_height DESC,
           microblock_sequence DESC,

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -5778,6 +5778,7 @@ export class PgDataStore
     limit: number;
     offset: number;
     blockHeight: number;
+    includeUnanchored: boolean;
   }): Promise<{ results: AddressNftEventIdentifier[]; total: number }> {
     return this.queryTx(async client => {
       const result = await client.query<AddressNftEventIdentifier & { count: string }>(

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -4870,15 +4870,14 @@ export class PgDataStore
     stxAddress,
     limit,
     offset,
-    includeUnanchored,
+    blockHeight,
   }: {
     stxAddress: string;
     limit: number;
     offset: number;
-    includeUnanchored: boolean;
+    blockHeight: number;
   }): Promise<{ results: DbEvent[]; total: number }> {
     return this.queryTx(async client => {
-      const maxBlockHeight = await this.getMaxBlockHeight(client, { includeUnanchored });
       const results = await client.query<
         {
           asset_type: 'stx_lock' | 'stx' | 'ft' | 'nft';
@@ -4929,7 +4928,7 @@ export class PgDataStore
         LIMIT $2
         OFFSET $3
         `,
-        [stxAddress, limit, offset, maxBlockHeight]
+        [stxAddress, limit, offset, blockHeight]
       );
 
       const events: DbEvent[] = results.rows.map(row => {
@@ -5002,15 +5001,11 @@ export class PgDataStore
     });
   }
 
-  async getFungibleTokenBalances({
-    stxAddress,
-    includeUnanchored,
-  }: {
+  async getFungibleTokenBalances(args: {
     stxAddress: string;
-    includeUnanchored: boolean;
+    atBlock: number;
   }): Promise<Map<string, DbFtBalance>> {
     return this.queryTx(async client => {
-      const blockHeight = await this.getMaxBlockHeight(client, { includeUnanchored });
       const result = await client.query<{
         asset_identifier: string;
         credit_total: string | null;
@@ -5037,7 +5032,7 @@ export class PgDataStore
         SELECT coalesce(credit.asset_identifier, debit.asset_identifier) as asset_identifier, credit_total, debit_total
         FROM credit FULL JOIN debit USING (asset_identifier)
         `,
-        [stxAddress, blockHeight]
+        [args.stxAddress, args.atBlock]
       );
       // sort by asset name (case-insensitive)
       const rows = result.rows.sort((r1, r2) =>
@@ -5055,15 +5050,11 @@ export class PgDataStore
     });
   }
 
-  async getNonFungibleTokenCounts({
-    stxAddress,
-    includeUnanchored,
-  }: {
+  async getNonFungibleTokenCounts(args: {
     stxAddress: string;
-    includeUnanchored: boolean;
+    atBlock: number;
   }): Promise<Map<string, { count: bigint; totalSent: bigint; totalReceived: bigint }>> {
     return this.queryTx(async client => {
-      const blockHeight = await this.getMaxBlockHeight(client, { includeUnanchored });
       const result = await client.query<{
         asset_identifier: string;
         received_total: string | null;
@@ -5090,7 +5081,7 @@ export class PgDataStore
         SELECT coalesce(credit.asset_identifier, debit.asset_identifier) as asset_identifier, received_total, sent_total
         FROM credit FULL JOIN debit USING (asset_identifier)
         `,
-        [stxAddress, blockHeight]
+        [args.stxAddress, args.atBlock]
       );
       // sort by asset name (case-insensitive)
       const rows = result.rows.sort((r1, r2) =>
@@ -5108,26 +5099,14 @@ export class PgDataStore
     });
   }
 
-  async getAddressTxs(
-    args: {
-      stxAddress: string;
-      limit: number;
-      offset: number;
-    } & ({ blockHeight: number } | { includeUnanchored: boolean })
-  ): Promise<{ results: DbTx[]; total: number }> {
+  async getAddressTxs(args: {
+    stxAddress: string;
+    blockHeight: number;
+    atSingleBlock: boolean;
+    limit: number;
+    offset: number;
+  }): Promise<{ results: DbTx[]; total: number }> {
     return this.queryTx(async client => {
-      let atSingleBlock: boolean;
-      const queryParams: (string | number)[] = [args.stxAddress, args.limit, args.offset];
-      if ('blockHeight' in args) {
-        queryParams.push(args.blockHeight);
-        atSingleBlock = true;
-      } else {
-        const blockHeight = await this.getMaxBlockHeight(client, {
-          includeUnanchored: args.includeUnanchored,
-        });
-        atSingleBlock = false;
-        queryParams.push(blockHeight);
-      }
       const principal = isValidPrincipal(args.stxAddress);
       if (!principal) {
         return { results: [], total: 0 };
@@ -5135,7 +5114,9 @@ export class PgDataStore
       // Smart contracts with a very high tx volume get frequent requests for the last N tx, where N
       // is commonly <= 50. We'll query a materialized view if this is the case.
       const useMaterializedView =
-        principal.type == 'contractAddress' && !atSingleBlock && args.limit + args.offset <= 50;
+        principal.type == 'contractAddress' &&
+        !args.atSingleBlock &&
+        args.limit + args.offset <= 50;
       const resultQuery = useMaterializedView
         ? await client.query<TxQueryResult & { count: number }>(
             `
@@ -5146,7 +5127,7 @@ export class PgDataStore
             LIMIT $2
             OFFSET $3
             `,
-            queryParams
+            [args.stxAddress, args.limit, args.offset, args.blockHeight]
           )
         : await client.query<TxQueryResult & { count: number }>(
             `
@@ -5170,12 +5151,12 @@ export class PgDataStore
             )
             SELECT ${TX_COLUMNS}, (COUNT(*) OVER())::integer as count
             FROM principal_txs
-            ${atSingleBlock ? 'WHERE block_height = $4' : 'WHERE block_height <= $4'}
+            ${args.atSingleBlock ? 'WHERE block_height = $4' : 'WHERE block_height <= $4'}
             ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC
             LIMIT $2
             OFFSET $3
             `,
-            queryParams
+            [args.stxAddress, args.limit, args.offset, args.blockHeight]
           );
       const count = resultQuery.rowCount > 0 ? resultQuery.rows[0].count : 0;
       const parsed = resultQuery.rows.map(r => this.parseTxQueryResult(r));
@@ -5249,29 +5230,22 @@ export class PgDataStore
     });
   }
 
-  async getAddressTxsWithAssetTransfers(
-    args: {
-      stxAddress: string;
-      limit?: number;
-      offset?: number;
-    } & ({ blockHeight: number } | { includeUnanchored: boolean })
-  ): Promise<{ results: DbTxWithAssetTransfers[]; total: number }> {
+  async getAddressTxsWithAssetTransfers(args: {
+    stxAddress: string;
+    blockHeight: number;
+    atSingleBlock: boolean;
+    limit?: number;
+    offset?: number;
+  }): Promise<{ results: DbTxWithAssetTransfers[]; total: number }> {
     return this.queryTx(async client => {
-      let atSingleBlock: boolean;
       const queryParams: (string | number)[] = [args.stxAddress];
-      if ('blockHeight' in args) {
-        // Single block mode ignores `limit` and `offset` arguments so we can retrieve all
-        // address events for that address in that block.
-        atSingleBlock = true;
+
+      if (args.atSingleBlock) {
         queryParams.push(args.blockHeight);
       } else {
-        const blockHeight = await this.getMaxBlockHeight(client, {
-          includeUnanchored: args.includeUnanchored,
-        });
-        atSingleBlock = false;
         queryParams.push(args.limit ?? 20);
         queryParams.push(args.offset ?? 0);
-        queryParams.push(blockHeight);
+        queryParams.push(args.blockHeight);
       }
       // Use a JOIN to include stx_events associated with the address's txs
       const resultQuery = await client.query<
@@ -5310,9 +5284,9 @@ export class PgDataStore
           )
           SELECT ${TX_COLUMNS}, (COUNT(*) OVER())::integer as count
           FROM principal_txs
-          ${atSingleBlock ? 'WHERE block_height = $2' : 'WHERE block_height <= $4'}
+          ${args.atSingleBlock ? 'WHERE block_height = $2' : 'WHERE block_height <= $4'}
           ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC
-          ${!atSingleBlock ? 'LIMIT $2 OFFSET $3' : ''}
+          ${!args.atSingleBlock ? 'LIMIT $2 OFFSET $3' : ''}
         ), events AS (
           SELECT
             tx_id, sender, recipient, event_index, amount,
@@ -5460,30 +5434,19 @@ export class PgDataStore
     return txs;
   }
 
-  async getInboundTransfers(
-    args: {
-      stxAddress: string;
-      limit: number;
-      offset: number;
-      sendManyContractId: string;
-    } & ({ blockHeight: number } | { includeUnanchored: boolean })
-  ): Promise<{ results: DbInboundStxTransfer[]; total: number }> {
+  async getInboundTransfers(args: {
+    stxAddress: string;
+    blockHeight: number;
+    atSingleBlock: boolean;
+    limit: number;
+    offset: number;
+    sendManyContractId: string;
+  }): Promise<{ results: DbInboundStxTransfer[]; total: number }> {
     return this.queryTx(async client => {
-      const queryParams: (string | number)[] = [
-        args.stxAddress,
-        args.sendManyContractId,
-        args.limit,
-        args.offset,
-      ];
       let whereClause: string;
-      if ('blockHeight' in args) {
-        queryParams.push(args.blockHeight);
+      if (args.atSingleBlock) {
         whereClause = 'WHERE block_height = $5';
       } else {
-        const blockHeight = await this.getMaxBlockHeight(client, {
-          includeUnanchored: args.includeUnanchored,
-        });
-        queryParams.push(blockHeight);
         whereClause = 'WHERE block_height <= $5';
       }
       const resultQuery = await client.query<TransferQueryResult & { count: number }>(
@@ -5531,7 +5494,7 @@ export class PgDataStore
               AND type_id = 0
               AND token_transfer_recipient_address = $1
           ) transfers
-        ${whereClause}
+        WHERE block_height <= $5
         ORDER BY
           block_height DESC,
           microblock_sequence DESC,
@@ -5539,7 +5502,7 @@ export class PgDataStore
         LIMIT $3
         OFFSET $4
         `,
-        queryParams
+        [args.stxAddress, args.sendManyContractId, args.limit, args.offset, args.blockHeight]
       );
       const count = resultQuery.rowCount > 0 ? resultQuery.rows[0].count : 0;
       const parsed: DbInboundStxTransfer[] = resultQuery.rows.map(r => {
@@ -5814,12 +5777,9 @@ export class PgDataStore
     stxAddress: string;
     limit: number;
     offset: number;
-    includeUnanchored: boolean;
+    blockHeight: number;
   }): Promise<{ results: AddressNftEventIdentifier[]; total: number }> {
     return this.queryTx(async client => {
-      const maxBlockHeight = await this.getMaxBlockHeight(client, {
-        includeUnanchored: args.includeUnanchored,
-      });
       const result = await client.query<AddressNftEventIdentifier & { count: string }>(
         // Join against `nft_custody` materialized view only if we're looking for canonical results.
         `
@@ -5843,7 +5803,7 @@ export class PgDataStore
         ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
         LIMIT $2 OFFSET $3
         `,
-        [args.stxAddress, args.limit, args.offset, maxBlockHeight]
+        [args.stxAddress, args.limit, args.offset, args.blockHeight]
       );
 
       const count = result.rows.length > 0 ? parseInt(result.rows[0].count) : 0;

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -5003,7 +5003,7 @@ export class PgDataStore
 
   async getFungibleTokenBalances(args: {
     stxAddress: string;
-    atBlock: number;
+    untilBlock: number;
   }): Promise<Map<string, DbFtBalance>> {
     return this.queryTx(async client => {
       const result = await client.query<{
@@ -5032,7 +5032,7 @@ export class PgDataStore
         SELECT coalesce(credit.asset_identifier, debit.asset_identifier) as asset_identifier, credit_total, debit_total
         FROM credit FULL JOIN debit USING (asset_identifier)
         `,
-        [args.stxAddress, args.atBlock]
+        [args.stxAddress, args.untilBlock]
       );
       // sort by asset name (case-insensitive)
       const rows = result.rows.sort((r1, r2) =>
@@ -5052,7 +5052,7 @@ export class PgDataStore
 
   async getNonFungibleTokenCounts(args: {
     stxAddress: string;
-    atBlock: number;
+    untilBlock: number;
   }): Promise<Map<string, { count: bigint; totalSent: bigint; totalReceived: bigint }>> {
     return this.queryTx(async client => {
       const result = await client.query<{
@@ -5081,7 +5081,7 @@ export class PgDataStore
         SELECT coalesce(credit.asset_identifier, debit.asset_identifier) as asset_identifier, received_total, sent_total
         FROM credit FULL JOIN debit USING (asset_identifier)
         `,
-        [args.stxAddress, args.atBlock]
+        [args.stxAddress, args.untilBlock]
       );
       // sort by asset name (case-insensitive)
       const rows = result.rows.sort((r1, r2) =>

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -4614,6 +4614,36 @@ describe('api tests', () => {
     expect(searchResult.status).toBe(404);
   });
 
+  test('exclusive address endpoints params', async () => {
+    const addressEndpoints = [
+      '/stx',
+      '/balances',
+      '/transactions',
+      '/transactions_with_transfers',
+      '/assets',
+      '/stx_inbound',
+      '/nft_events',
+    ];
+
+    //check for mutually exclusive unachored and and at_block
+    for (const path of addressEndpoints) {
+      const response = await supertest(api.server).get(
+        `/extended/v1/address/STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6${path}?at_block=5&unanchored=true`
+      );
+      expect(response.status).toBe(400);
+    }
+
+    const addressEndpoints1 = ['/transactions', '/transactions_with_transfers', '/stx_inbound'];
+
+    /// check for mutually exclusive at_block adn height params
+    for (const path of addressEndpoints1) {
+      const response1 = await supertest(api.server).get(
+        `/extended/v1/address/STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6${path}?at_block=5&height=0`
+      );
+      expect(response1.status).toBe(400);
+    }
+  });
+
   test('Success: nft events for address', async () => {
     const addr1 = 'ST3J8EVYHVKH6XXPD61EE8XEHW4Y2K83861225AB1';
     const addr2 = 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4';

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -4625,20 +4625,20 @@ describe('api tests', () => {
       '/nft_events',
     ];
 
-    //check for mutually exclusive unachored and and at_block
+    //check for mutually exclusive unachored and and until_block
     for (const path of addressEndpoints) {
       const response = await supertest(api.server).get(
-        `/extended/v1/address/STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6${path}?at_block=5&unanchored=true`
+        `/extended/v1/address/STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6${path}?until_block=5&unanchored=true`
       );
       expect(response.status).toBe(400);
     }
 
     const addressEndpoints1 = ['/transactions', '/transactions_with_transfers', '/stx_inbound'];
 
-    /// check for mutually exclusive at_block adn height params
+    /// check for mutually exclusive until_block adn height params
     for (const path of addressEndpoints1) {
       const response1 = await supertest(api.server).get(
-        `/extended/v1/address/STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6${path}?at_block=5&height=0`
+        `/extended/v1/address/STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6${path}?until_block=5&height=0`
       );
       expect(response1.status).toBe(400);
     }

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -514,21 +514,22 @@ describe('postgres datastore', () => {
       await db.updateFtEvent(client, tx, event);
     }
 
+    const blockHeight = await db.getMaxBlockHeight(client, { includeUnanchored: false });
     const addrAResult = await db.getFungibleTokenBalances({
       stxAddress: 'addrA',
-      includeUnanchored: false,
+      atBlock: blockHeight,
     });
     const addrBResult = await db.getFungibleTokenBalances({
       stxAddress: 'addrB',
-      includeUnanchored: false,
+      atBlock: blockHeight,
     });
     const addrCResult = await db.getFungibleTokenBalances({
       stxAddress: 'addrC',
-      includeUnanchored: false,
+      atBlock: blockHeight,
     });
     const addrDResult = await db.getFungibleTokenBalances({
       stxAddress: 'addrD',
-      includeUnanchored: false,
+      atBlock: blockHeight,
     });
 
     expect([...addrAResult]).toEqual([
@@ -665,21 +666,23 @@ describe('postgres datastore', () => {
       await db.updateNftEvent(client, tx, event);
     }
 
+    const blockHeight = await db.getMaxBlockHeight(client, { includeUnanchored: false });
+
     const addrAResult = await db.getNonFungibleTokenCounts({
       stxAddress: 'addrA',
-      includeUnanchored: false,
+      atBlock: blockHeight,
     });
     const addrBResult = await db.getNonFungibleTokenCounts({
       stxAddress: 'addrB',
-      includeUnanchored: false,
+      atBlock: blockHeight,
     });
     const addrCResult = await db.getNonFungibleTokenCounts({
       stxAddress: 'addrC',
-      includeUnanchored: false,
+      atBlock: blockHeight,
     });
     const addrDResult = await db.getNonFungibleTokenCounts({
       stxAddress: 'addrD',
-      includeUnanchored: false,
+      atBlock: blockHeight,
     });
 
     expect([...addrAResult]).toEqual([
@@ -847,41 +850,49 @@ describe('postgres datastore', () => {
       await db.updateTx(client, tx);
     }
 
+    const blockHeight = await db.getMaxBlockHeight(client, { includeUnanchored: false });
+
     const addrAResult = await db.getAddressTxs({
       stxAddress: 'addrA',
       limit: 3,
       offset: 0,
-      includeUnanchored: false,
+      blockHeight: blockHeight,
+      atSingleBlock: false,
     });
     const addrBResult = await db.getAddressTxs({
       stxAddress: 'addrB',
       limit: 3,
       offset: 0,
-      includeUnanchored: false,
+      blockHeight: blockHeight,
+      atSingleBlock: false,
     });
     const addrCResult = await db.getAddressTxs({
       stxAddress: 'addrC',
       limit: 3,
       offset: 0,
-      includeUnanchored: false,
+      blockHeight: blockHeight,
+      atSingleBlock: false,
     });
     const addrDResult = await db.getAddressTxs({
       stxAddress: 'addrD',
       limit: 3,
       offset: 0,
-      includeUnanchored: false,
+      blockHeight: blockHeight,
+      atSingleBlock: false,
     });
     const addrEResult = await db.getAddressTxs({
       stxAddress: 'addrE',
       limit: 3,
       offset: 0,
-      includeUnanchored: false,
+      blockHeight: blockHeight,
+      atSingleBlock: false,
     });
     const addrEResultP2 = await db.getAddressTxs({
       stxAddress: 'addrE',
       limit: 3,
       offset: 3,
-      includeUnanchored: false,
+      blockHeight: blockHeight,
+      atSingleBlock: false,
     });
 
     expect(addrEResult.total).toBe(5);
@@ -1230,11 +1241,13 @@ describe('postgres datastore', () => {
       await db.updateNftEvent(client, tx3, event);
     }
 
+    const blockHeight = await db.getMaxBlockHeight(client, { includeUnanchored: false });
+
     const assetDbEvents = await db.getAddressAssetEvents({
       stxAddress: 'addrA',
       limit: 10000,
       offset: 0,
-      includeUnanchored: false,
+      blockHeight: blockHeight,
     });
     const assetEvents = assetDbEvents.results.map(event => parseDbEvent(event));
     expect(assetEvents).toEqual([

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -517,19 +517,19 @@ describe('postgres datastore', () => {
     const blockHeight = await db.getMaxBlockHeight(client, { includeUnanchored: false });
     const addrAResult = await db.getFungibleTokenBalances({
       stxAddress: 'addrA',
-      atBlock: blockHeight,
+      untilBlock: blockHeight,
     });
     const addrBResult = await db.getFungibleTokenBalances({
       stxAddress: 'addrB',
-      atBlock: blockHeight,
+      untilBlock: blockHeight,
     });
     const addrCResult = await db.getFungibleTokenBalances({
       stxAddress: 'addrC',
-      atBlock: blockHeight,
+      untilBlock: blockHeight,
     });
     const addrDResult = await db.getFungibleTokenBalances({
       stxAddress: 'addrD',
-      atBlock: blockHeight,
+      untilBlock: blockHeight,
     });
 
     expect([...addrAResult]).toEqual([
@@ -670,19 +670,19 @@ describe('postgres datastore', () => {
 
     const addrAResult = await db.getNonFungibleTokenCounts({
       stxAddress: 'addrA',
-      atBlock: blockHeight,
+      untilBlock: blockHeight,
     });
     const addrBResult = await db.getNonFungibleTokenCounts({
       stxAddress: 'addrB',
-      atBlock: blockHeight,
+      untilBlock: blockHeight,
     });
     const addrCResult = await db.getNonFungibleTokenCounts({
       stxAddress: 'addrC',
-      atBlock: blockHeight,
+      untilBlock: blockHeight,
     });
     const addrDResult = await db.getNonFungibleTokenCounts({
       stxAddress: 'addrD',
-      atBlock: blockHeight,
+      untilBlock: blockHeight,
     });
 
     expect([...addrAResult]).toEqual([

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -793,6 +793,7 @@ describe('postgres datastore', () => {
       sender: string,
       recipient: string,
       amount: number,
+      dbBlock: DbBlock,
       canonical: boolean = true
     ): DbTx => {
       const tx: DbTx = {
@@ -834,17 +835,17 @@ describe('postgres datastore', () => {
       return tx;
     };
     const txs = [
-      createStxTx('none', 'addrA', 100_000),
-      createStxTx('addrA', 'addrB', 100),
-      createStxTx('addrA', 'addrB', 250),
-      createStxTx('addrA', 'addrB', 40, false),
-      createStxTx('addrB', 'addrC', 15),
-      createStxTx('addrA', 'addrC', 35),
-      createStxTx('addrE', 'addrF', 2),
-      createStxTx('addrE', 'addrF', 2),
-      createStxTx('addrE', 'addrF', 2),
-      createStxTx('addrE', 'addrF', 2),
-      createStxTx('addrE', 'addrF', 2),
+      createStxTx('none', 'addrA', 100_000, dbBlock),
+      createStxTx('addrA', 'addrB', 100, dbBlock),
+      createStxTx('addrA', 'addrB', 250, dbBlock),
+      createStxTx('addrA', 'addrB', 40, dbBlock, false),
+      createStxTx('addrB', 'addrC', 15, dbBlock),
+      createStxTx('addrA', 'addrC', 35, dbBlock),
+      createStxTx('addrE', 'addrF', 2, dbBlock),
+      createStxTx('addrE', 'addrF', 2, dbBlock),
+      createStxTx('addrE', 'addrF', 2, dbBlock),
+      createStxTx('addrE', 'addrF', 2, dbBlock),
+      createStxTx('addrE', 'addrF', 2, dbBlock),
     ];
     for (const tx of txs) {
       await db.updateTx(client, tx);
@@ -995,6 +996,62 @@ describe('postgres datastore', () => {
       },
     ]);
     expect(mapAddrTxResults(addrDResult.results)).toEqual([]);
+
+    //test for atBlock query
+    const dbBlock1: DbBlock = {
+      block_hash: '0xffff',
+      index_block_hash: '0x1235',
+      parent_index_block_hash: '0x5679',
+      parent_block_hash: '0x5670',
+      parent_microblock_hash: '',
+      parent_microblock_sequence: 0,
+      block_height: 2,
+      burn_block_time: 1594647996,
+      burn_block_hash: '0x1235',
+      burn_block_height: 124,
+      miner_txid: '0x4322',
+      canonical: true,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
+    };
+    await db.updateBlock(client, dbBlock1);
+    const txs1 = [
+      createStxTx('addrA', 'addrB', 100, dbBlock1),
+      createStxTx('addrA', 'addrB', 250, dbBlock1),
+      createStxTx('addrA', 'addrB', 40, dbBlock1, false),
+      createStxTx('addrB', 'addrC', 15, dbBlock1),
+      createStxTx('addrA', 'addrC', 35, dbBlock1),
+      createStxTx('addrE', 'addrF', 2, dbBlock1),
+      createStxTx('addrE', 'addrF', 2, dbBlock1),
+      createStxTx('addrE', 'addrF', 2, dbBlock1),
+      createStxTx('addrE', 'addrF', 2, dbBlock1),
+      createStxTx('addrE', 'addrF', 2, dbBlock1),
+    ];
+    for (const tx of txs) {
+      await db.updateTx(client, tx);
+    }
+
+    const addrAAtBlockResult = await db.getAddressTxs({
+      stxAddress: 'addrA',
+      limit: 3,
+      offset: 0,
+      blockHeight: 2,
+      atSingleBlock: true,
+    });
+
+    const addrAAllBlockResult = await db.getAddressTxs({
+      stxAddress: 'addrA',
+      limit: 3,
+      offset: 0,
+      blockHeight: 2,
+      atSingleBlock: false,
+    });
+
+    expect(addrAAtBlockResult.total).toBe(4);
+    expect(addrAAllBlockResult.total).toBe(8);
   });
 
   test('pg get address asset events', async () => {


### PR DESCRIPTION
## Description
This PR adds `at_block` query param for all `/address` endpoints to get data till that block height.  It also checks for exclusive params `height`  and `unanchored`.  It changes a little bit of the structure of involving methods. 

For details refer to issue #803 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other



## Checklist
- [x] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x]@zone117x for review
