### PR TITLE
chore: rename github org references from blockstack to hirosystems

### DIFF
--- a/.github/ISSUE_TEMPLATE/testnet-bug.md
+++ b/.github/ISSUE_TEMPLATE/testnet-bug.md
@@ -34,8 +34,6 @@ that demonstrates the issue.
 
 ----
 
-If you think this is eligible for a [bug bounty](https://testnet.blockstack.org/bounties), please check the relevant boxes below:
-
 ### Critical, Launch Blocking Bugs
 **Consensus critical bugs**
 - [ ] Can cause a chain split

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ Describe the changes that where made in this pull request. When possible start w
 5. Provide examples of use cases with code samples and applicable acceptance criteria
 
 Example:
-As a Blockstack developer, I would like to encrypt files using the app private key. This is needed because storing unencrypted files is unacceptable. This pull request adds the `encryptContent` function which will take a string and encrypt it using the app private key.
+As a Hiro Systems developer, I would like to encrypt files using the app private key. This is needed because storing unencrypted files is unacceptable. This pull request adds the `encryptContent` function which will take a string and encrypt it using the app private key.
 
 ```
 encryptContent('my data')
@@ -41,7 +41,7 @@ Workarounds for or expected timeline for deprecation
     - Change in instructions inside tutorials/guides
     - etc...
 
-   The best way to find these is by searching inside the docs at https://github.com/blockstack/docs
+   The best way to find these is by searching inside the docs at https://github.com/hirosystems/docs
 -->
 - [ ] Link to documentation updates: 
 

--- a/README-rosetta.md
+++ b/README-rosetta.md
@@ -28,4 +28,4 @@ requires token transfer transactions while `rosetta-cli` is running.
 
 Documentation for the Rosetta APIs can be found at
 
-https://blockstack.github.io/stacks-blockchain-api/
+https://hirosystems.github.io/stacks-blockchain-api/

--- a/client/README.md
+++ b/client/README.md
@@ -1,6 +1,6 @@
 # @stacks/blockchain-api-client
 [![NPM Package](https://img.shields.io/npm/v/@stacks/blockchain-api-client.svg?style=flat-square)](https://www.npmjs.org/package/@stacks/blockchain-api-client)
-[![Build Status](https://github.com/blockstack/stacks-blockchain-api/workflows/stacks-blockchain-api/badge.svg)](https://github.com/blockstack/stacks-blockchain-api/actions)
+[![Build Status](https://github.com/hirosystems/stacks-blockchain-api/workflows/stacks-blockchain-api/badge.svg)](https://github.com/hirosystems/stacks-blockchain-api/actions)
 
 A JS Client for the Stacks Blockchain API
 
@@ -47,7 +47,7 @@ await sub.unsubscribe();
 
 ## Documentation
 
-You can find full references [here](https://blockstack.github.io/stacks-blockchain-api/client/index.html).
+You can find full references [here](https://hirosystems.github.io/stacks-blockchain-api/client/index.html).
 
 ## Known Issues
 

--- a/client/package.json
+++ b/client/package.json
@@ -3,16 +3,16 @@
   "version": "0.1.2",
   "access": "public",
   "description": "Client for the Stacks Blockchain API",
-  "homepage": "https://github.com/blockstack/stacks-blockchain-api/tree/master/client#readme",
-  "author": "Blockstack PBC <engineering@blockstack.com> (https://blockstack.org)",
+  "homepage": "https://github.com/hirosystems/stacks-blockchain-api/tree/master/client#readme",
+  "author": "Hiro Systems PBC <engineering@hiro.so> (https://hiro.so)",
   "license": "GPL-3.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/blockstack/stacks-blockchain-api.git",
+    "url": "https://github.com/hirosystems/stacks-blockchain-api.git",
     "directory": "client"
   },
   "bugs": {
-    "url": "https://github.com/blockstack/stacks-blockchain-api/issues"
+    "url": "https://github.com/hirosystems/stacks-blockchain-api/issues"
   },
   "main": "lib/index.js",
   "unpkg": "lib/index.umd.js",

--- a/client/src/generated/apis/TransactionsApi.ts
+++ b/client/src/generated/apis/TransactionsApi.ts
@@ -78,7 +78,7 @@ export interface TransactionsApiInterface {
     getMempoolTransactionList(requestParameters: GetMempoolTransactionListRequest): Promise<MempoolTransactionListResponse>;
 
     /**
-     * Get a specific transaction by ID  `import type { Transaction } from \'@blockstack/stacks-blockchain-api-types\';` 
+     * Get a specific transaction by ID  `import type { Transaction } from \'@stacks/stacks-blockchain-api-types\';` 
      * @summary Get transaction
      * @param {string} txId Hash of transaction
      * @param {number} [eventOffset] The number of events to skip
@@ -90,13 +90,13 @@ export interface TransactionsApiInterface {
     getTransactionByIdRaw(requestParameters: GetTransactionByIdRequest): Promise<runtime.ApiResponse<object>>;
 
     /**
-     * Get a specific transaction by ID  `import type { Transaction } from \'@blockstack/stacks-blockchain-api-types\';` 
+     * Get a specific transaction by ID  `import type { Transaction } from \'@stacks/stacks-blockchain-api-types\';` 
      * Get transaction
      */
     getTransactionById(requestParameters: GetTransactionByIdRequest): Promise<object>;
 
     /**
-     * Get all recently mined transactions  If using TypeScript, import typings for this response from our types package:  `import type { TransactionResults } from \'@blockstack/stacks-blockchain-api-types\';` 
+     * Get all recently mined transactions  If using TypeScript, import typings for this response from our types package:  `import type { TransactionResults } from \'@stacks/stacks-blockchain-api-types\';` 
      * @summary Get recent transactions
      * @param {number} [limit] max number of transactions to fetch
      * @param {number} [offset] index of first transaction to fetch
@@ -108,13 +108,13 @@ export interface TransactionsApiInterface {
     getTransactionListRaw(requestParameters: GetTransactionListRequest): Promise<runtime.ApiResponse<TransactionResults>>;
 
     /**
-     * Get all recently mined transactions  If using TypeScript, import typings for this response from our types package:  `import type { TransactionResults } from \'@blockstack/stacks-blockchain-api-types\';` 
+     * Get all recently mined transactions  If using TypeScript, import typings for this response from our types package:  `import type { TransactionResults } from \'@stacks/stacks-blockchain-api-types\';` 
      * Get recent transactions
      */
     getTransactionList(requestParameters: GetTransactionListRequest): Promise<TransactionResults>;
 
     /**
-     * Broadcast raw transactions on the network. You can use the [@stacks/transactions](https://github.com/blockstack/stacks.js) project to generate a raw transaction payload.
+     * Broadcast raw transactions on the network. You can use the [@stacks/transactions](https://github.com/hirosystems/stacks.js) project to generate a raw transaction payload.
      * @summary Broadcast raw transaction
      * @param {Blob} [body] 
      * @param {*} [options] Override http request option.
@@ -124,7 +124,7 @@ export interface TransactionsApiInterface {
     postCoreNodeTransactionsRaw(requestParameters: PostCoreNodeTransactionsRequest): Promise<runtime.ApiResponse<string>>;
 
     /**
-     * Broadcast raw transactions on the network. You can use the [@stacks/transactions](https://github.com/blockstack/stacks.js) project to generate a raw transaction payload.
+     * Broadcast raw transactions on the network. You can use the [@stacks/transactions](https://github.com/hirosystems/stacks.js) project to generate a raw transaction payload.
      * Broadcast raw transaction
      */
     postCoreNodeTransactions(requestParameters: PostCoreNodeTransactionsRequest): Promise<string>;
@@ -185,7 +185,7 @@ export class TransactionsApi extends runtime.BaseAPI implements TransactionsApiI
     }
 
     /**
-     * Get a specific transaction by ID  `import type { Transaction } from \'@blockstack/stacks-blockchain-api-types\';` 
+     * Get a specific transaction by ID  `import type { Transaction } from \'@stacks/stacks-blockchain-api-types\';` 
      * Get transaction
      */
     async getTransactionByIdRaw(requestParameters: GetTransactionByIdRequest): Promise<runtime.ApiResponse<object>> {
@@ -216,7 +216,7 @@ export class TransactionsApi extends runtime.BaseAPI implements TransactionsApiI
     }
 
     /**
-     * Get a specific transaction by ID  `import type { Transaction } from \'@blockstack/stacks-blockchain-api-types\';` 
+     * Get a specific transaction by ID  `import type { Transaction } from \'@stacks/stacks-blockchain-api-types\';` 
      * Get transaction
      */
     async getTransactionById(requestParameters: GetTransactionByIdRequest): Promise<object> {
@@ -225,7 +225,7 @@ export class TransactionsApi extends runtime.BaseAPI implements TransactionsApiI
     }
 
     /**
-     * Get all recently mined transactions  If using TypeScript, import typings for this response from our types package:  `import type { TransactionResults } from \'@blockstack/stacks-blockchain-api-types\';` 
+     * Get all recently mined transactions  If using TypeScript, import typings for this response from our types package:  `import type { TransactionResults } from \'@stacks/stacks-blockchain-api-types\';` 
      * Get recent transactions
      */
     async getTransactionListRaw(requestParameters: GetTransactionListRequest): Promise<runtime.ApiResponse<TransactionResults>> {
@@ -256,7 +256,7 @@ export class TransactionsApi extends runtime.BaseAPI implements TransactionsApiI
     }
 
     /**
-     * Get all recently mined transactions  If using TypeScript, import typings for this response from our types package:  `import type { TransactionResults } from \'@blockstack/stacks-blockchain-api-types\';` 
+     * Get all recently mined transactions  If using TypeScript, import typings for this response from our types package:  `import type { TransactionResults } from \'@stacks/stacks-blockchain-api-types\';` 
      * Get recent transactions
      */
     async getTransactionList(requestParameters: GetTransactionListRequest): Promise<TransactionResults> {
@@ -265,7 +265,7 @@ export class TransactionsApi extends runtime.BaseAPI implements TransactionsApiI
     }
 
     /**
-     * Broadcast raw transactions on the network. You can use the [@stacks/transactions](https://github.com/blockstack/stacks.js) project to generate a raw transaction payload.
+     * Broadcast raw transactions on the network. You can use the [@stacks/transactions](https://github.com/hirosystems/stacks.js) project to generate a raw transaction payload.
      * Broadcast raw transaction
      */
     async postCoreNodeTransactionsRaw(requestParameters: PostCoreNodeTransactionsRequest): Promise<runtime.ApiResponse<string>> {
@@ -287,7 +287,7 @@ export class TransactionsApi extends runtime.BaseAPI implements TransactionsApiI
     }
 
     /**
-     * Broadcast raw transactions on the network. You can use the [@stacks/transactions](https://github.com/blockstack/stacks.js) project to generate a raw transaction payload.
+     * Broadcast raw transactions on the network. You can use the [@stacks/transactions](https://github.com/hirosystems/stacks.js) project to generate a raw transaction payload.
      * Broadcast raw transaction
      */
     async postCoreNodeTransactions(requestParameters: PostCoreNodeTransactionsRequest): Promise<string> {

--- a/docs/api/bns/name-querying/bns-get-subdomain-at-tx-response.schema.json
+++ b/docs/api/bns/name-querying/bns-get-subdomain-at-tx-response.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "bns-get-subdomain-at-tx",
   "title": "BnsGetSubdomainAtTx",
-  "description": "Fetches the list of subdomain operations processed by a given transaction. The returned array includes subdomain operations that have not yet been accepted as part of any subdomain’s history (checkable via the accepted field). If the given transaction ID does not correspond to a Blockstack transaction that introduced new subdomain operations, and empty array will be returned.",
+  "description": "Fetches the list of subdomain operations processed by a given transaction. The returned array includes subdomain operations that have not yet been accepted as part of any subdomain’s history (checkable via the accepted field). If the given transaction ID does not correspond to a Stacks transaction that introduced new subdomain operations, and empty array will be returned.",
   "required": [
     "accepted",
     "block_height",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -344,7 +344,7 @@ paths:
       summary: Broadcast raw transaction
       tags:
         - Transactions
-      description: Broadcast raw transactions on the network. You can use the [@stacks/transactions](https://github.com/blockstack/stacks.js) project to generate a raw transaction payload.
+      description: Broadcast raw transactions on the network. You can use the [@stacks/transactions](https://github.com/hirosystems/stacks.js) project to generate a raw transaction payload.
       operationId: post_core_node_transactions
       requestBody:
         content:
@@ -2450,7 +2450,7 @@ paths:
   /v1/subdomains/{txid}:
     get:
       summary: Get Subdomain at Transaction
-      description: Fetches the list of subdomain operations processed by a given transaction. The returned array includes subdomain operations that have not yet been accepted as part of any subdomain’s history (checkable via the accepted field). If the given transaction ID does not correspond to a Blockstack transaction that introduced new subdomain operations, and empty array will be returned.
+      description: Fetches the list of subdomain operations processed by a given transaction. The returned array includes subdomain operations that have not yet been accepted as part of any subdomain’s history (checkable via the accepted field). If the given transaction ID does not correspond to a Stacks transaction that introduced new subdomain operations, and empty array will be returned.
       tags:
         - BNS
       operationId: get_subdomain_at_transaction

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,11 +19,11 @@
     "validate:schemas": "rimraf .tmp && gulp flattenSchemas --silent && ts-node ./scripts/validate-schemas.ts",
     "deploy:docs": "npm run generate:types && npm run generate:docs && gulp deployDocs"
   },
-  "author": "@blockstack",
+  "author": "@hirosystems",
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/blockstack/stacks-blockchain-api.git",
+    "url": "https://github.com/hirosystems/stacks-blockchain-api.git",
     "directory": "docs"
   },
   "files": [

--- a/overview.md
+++ b/overview.md
@@ -28,7 +28,7 @@
 
 * All http endpoints and responses are defined in OpenAPI and JSON Schema.
   * See `/docs/openapi.yaml`
-  * These are used to auto generate the docs at https://blockstack.github.io/stacks-blockchain-api/
+  * These are used to auto generate the docs at https://hirosystems.github.io/stacks-blockchain-api/
   * The JSON Schemas are converted into Typescript interfaces, which are used internally by the db controller module to transform SQL query results into the correct object shapes.
   * ALSO the OpenAPI + JSONSchemas are used to generate a standalone `@stacks/blockchain-api-client`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@blockstack/stacks-blockchain-api",
+  "name": "@hirosystems/stacks-blockchain-api",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@blockstack/stacks-blockchain-api",
+  "name": "@hirosystems/stacks-blockchain-api",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
@@ -38,14 +38,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/blockstack/stacks-blockchain-api.git"
+    "url": "git+https://github.com/hirosystems/stacks-blockchain-api.git"
   },
-  "author": "Blockstack PBC <engineering@blockstack.com> (https://blockstack.org)",
+  "author": "Hiro Systems PBC <engineering@hiro.so> (https://hiro.so)",
   "license": "GPL-3.0",
   "bugs": {
-    "url": "https://github.com/blockstack/stacks-blockchain-api/issues"
+    "url": "https://github.com/hirosystems/stacks-blockchain-api/issues"
   },
-  "homepage": "https://github.com/blockstack/stacks-blockchain-api#readme",
+  "homepage": "https://github.com/hirosystems/stacks-blockchain-api#readme",
   "prettier": "@stacks/prettier-config",
   "engines": {
     "node": ">=14"

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
-# @blockstack/stacks-blockchain-api
+# @hirosystems/stacks-blockchain-api
 
-[![stacks-blockchain-api](https://github.com/blockstack/stacks-blockchain-api/actions/workflows/stacks-blockchain-api.yml/badge.svg?branch=master)](https://github.com/blockstack/stacks-blockchain-api/actions/workflows/stacks-blockchain-api.yml)
+[![stacks-blockchain-api](https://github.com/hirosystems/stacks-blockchain-api/actions/workflows/stacks-blockchain-api.yml/badge.svg?branch=master)](https://github.com/hirosystems/stacks-blockchain-api/actions/workflows/stacks-blockchain-api.yml)
 
-[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/blockstack/stacks-blockchain-api)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/hirosystems/stacks-blockchain-api)
 
 ## Quick start
 

--- a/running_an_api.md
+++ b/running_an_api.md
@@ -1,6 +1,6 @@
 # Running a stacks-blockchain API instance with Docker
 
-In this document, we'll go over how to run a [stacks-blockchain-api](https://github.com/blockstack/stacks-blockchain-api) instance.  
+In this document, we'll go over how to run a [stacks-blockchain-api](https://github.com/hirosystems/stacks-blockchain-api) instance.  
 There are several components involved here to have a working setup, and we'll go over each.  
 We'll focus on the **easy** path to get the services running, which today is using Docker.  
 Please note that the following guide is meant for a Unix-like OS (Linux/MacOS) - the commands *may* work on Windows but will likely need some adjustments (PR's welcome!).

--- a/running_api_from_source.md
+++ b/running_api_from_source.md
@@ -1,6 +1,6 @@
 # Running a stacks-blockchain API instance from source
 
-In this document, we'll go over how to run a [stacks-blockchain-api](https://github.com/blockstack/stacks-blockchain-api) instance.  
+In this document, we'll go over how to run a [stacks-blockchain-api](https://github.com/hirosystems/stacks-blockchain-api) instance.  
 There are several components involved here to have a working setup, and we'll go over each.  
 Please note that the following guide is targetted for Debian based systems - that in mind, most of the commands will work on other Unix systems with some small adjustments.
 
@@ -114,7 +114,7 @@ $ sudo systemctl stop postgresql
 ### building stacks-blockchain-api
 
 ```bash
-$ git clone https://github.com/blockstack/stacks-blockchain-api /stacks-node/stacks-blockchain-api && cd /stacks-node/stacks-blockchain-api \
+$ git clone https://github.com/hirosystems/stacks-blockchain-api /stacks-node/stacks-blockchain-api && cd /stacks-node/stacks-blockchain-api \
   && echo "GIT_TAG=$(git tag --points-at HEAD)" >> .env \
   && npm config set unsafe-perm true \
   && npm install \

--- a/src/api/routes/core-node-rpc-proxy.ts
+++ b/src/api/routes/core-node-rpc-proxy.ts
@@ -30,7 +30,7 @@ export function createCoreNodeRpcProxyRouter(db: DataStore): express.Router {
 
   // Note: while keep-alive may result in some performance improvements with the stacks-node http server,
   // it can also cause request distribution issues when proxying to a pool of stacks-nodes. See:
-  // https://github.com/blockstack/stacks-blockchain-api/issues/756
+  // https://github.com/hirosystems/stacks-blockchain-api/issues/756
   const httpAgent = new Agent({
     // keepAlive: true,
     keepAlive: false, // `false` is the default -- set it explicitly for readability anyway.

--- a/src/api/routes/info.ts
+++ b/src/api/routes/info.ts
@@ -12,7 +12,7 @@ const enum TargetBlockTime {
   /**
    * This is currently the Stacks 2.0 testnet, which uses a regtest bitcoin node with a
    * controller service that controls the block mining. The configured time can be found at
-   * https://github.com/blockstackpbc/k8s/blob/5a3ae6abe74b736a0f21566a187838b00425e045/blockstack-core/v2/argon/bitcoin/staging/configmap.yaml#L7
+   * https://github.com/hirosystems/k8s/blob/5a3ae6abe74b736a0f21566a187838b00425e045/blockstack-core/v2/argon/bitcoin/staging/configmap.yaml#L7
    */
   Testnet = 2 * 60, // 2 minutes
   /**

--- a/src/tests/parse-db-tx.ts
+++ b/src/tests/parse-db-tx.ts
@@ -10,5 +10,5 @@ test('buggy parsing of contract-call args', () => {
   expect(() => {
     clarityVals.map(c => getCVTypeString(c));
   }).not.toThrow(); //the issue is fixed in updated stacks.js so it should not throw
-  //context: https://github.com/blockstack/stacks-blockchain-api/pull/709
+  //context: https://github.com/hirosystems/stacks-blockchain-api/pull/709
 });

--- a/stx-rosetta.Dockerfile
+++ b/stx-rosetta.Dockerfile
@@ -1,6 +1,6 @@
 ARG STACKS_API_VERSION=v0.63.0
 ARG STACKS_NODE_VERSION=2.0.11.2.0
-ARG STACKS_API_REPO=blockstack/stacks-blockchain-api
+ARG STACKS_API_REPO=hirosystems/stacks-blockchain-api
 ARG STACKS_NODE_REPO=blockstack/stacks-blockchain
 ARG PG_VERSION=12
 ARG STACKS_NETWORK=testnet


### PR DESCRIPTION
## Description

This PR renames all references from blockstack to hirosystems. It also removes some other broken URLs and obsolete refs from our code comments.

See https://github.com/hirosystems/devops/issues/830

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
N/A

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @kyranjamie or @zone117x for review
