### PR TITLE
Add nft_custody pg materialized view to speed up nft event lookup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -285,7 +285,7 @@ async function handleProgramArgs() {
     // or the `--force` option can be used.
     await cycleMigrations({ dangerousAllowDataLoss: true });
 
-    const db = await PgDataStore.connect(true, false);
+    const db = await PgDataStore.connect(true, false, true);
     const eventServer = await startEventServer({
       datastore: db,
       chainId: getConfiguredChainID(),
@@ -315,6 +315,7 @@ async function handleProgramArgs() {
         });
       }
     }
+    await db.finishEventReplay();
     console.log(`Event import and playback successful.`);
     await eventServer.closeAsync();
     await db.close();

--- a/src/migrations/1636130197558_nft_custody.ts
+++ b/src/migrations/1636130197558_nft_custody.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createMaterializedView('nft_custody', {}, `
+    SELECT
+      DISTINCT ON(asset_identifier, value) asset_identifier, value, recipient
+    FROM
+      nft_events
+    WHERE
+      canonical = true AND microblock_canonical = true
+    ORDER BY
+      asset_identifier DESC,
+      value DESC,
+      block_height DESC,
+      microblock_sequence DESC,
+      tx_index DESC,
+      event_index DESC
+  `);
+
+  pgm.createIndex('nft_custody', ['asset_identifier', 'value']);
+  pgm.createIndex('nft_custody', 'recipient');
+}


### PR DESCRIPTION
## Description

This PR adds a Postgres materialized view `nft_custody` that stores the current owner address of an NFT (a combination of `asset_identifier` and `value`) at the **current canonical chain tip**. It also adds indexes so lookups by NFT or owner address is very quick.

After using this view, the current NFT lookup query sees a huge increase in performance. Local tests showed an improvement from ~400ms before to ~35ms after.

Related to #828 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
Local performance tests

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @kyranjamie or @zone117x for review
