### PR TITLE
fix: transaction broadcast log

### DIFF
--- a/src/api/routes/core-node-rpc-proxy.ts
+++ b/src/api/routes/core-node-rpc-proxy.ts
@@ -220,6 +220,12 @@ export function createCoreNodeRpcProxyRouter(db: DataStore): express.Router {
       proxyResp.headers.forEach((value, name) => {
         res.setHeader(name, value);
       });
+      if (proxyResp.status === 200) {
+        // Log the transaction id broadcast, but clone the `Response` first before parsing its body
+        // so we don't mess up the original response's `ReadableStream` pointers.
+        const parsedTxId: string = await proxyResp.clone().json();
+        await logTxBroadcast(parsedTxId);
+      }
       await pipelineAsync(proxyResp.body, res);
     }
   });

--- a/src/tests/v2-proxy-tests.ts
+++ b/src/tests/v2-proxy-tests.ts
@@ -50,7 +50,8 @@ describe('v2-proxy tests', () => {
         return [apiServer, apiServer.terminate] as const;
       },
       async (_, __, api) => {
-        const primaryStubbedResponse = 'success stubbed response';
+        const primaryStubbedResponse =
+          '"1659fcdc9167576eb1f2a05d0aaba5ca1aa1943892e7e6e5d3ccb3e537f1c870"';
         const extraStubbedResponse = 'extra success stubbed response';
         const testRequest = 'fake-tx-data';
         let mockedRequestBody = 'none';


### PR DESCRIPTION
## Description

This patch fixes the transaction broadcast logs when an API pod is set to multicast.

Closes #838 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
Local tests

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @kyranjamie or @zone117x for review
