### PR TITLE
fix: tx broadcast logging error

### DIFF
--- a/src/tests/v2-proxy-tests.ts
+++ b/src/tests/v2-proxy-tests.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as nock from 'nock';
+import { DbBlock } from 'src/datastore/common';
 
 describe('v2-proxy tests', () => {
   let db: PgDataStore;
@@ -50,6 +51,34 @@ describe('v2-proxy tests', () => {
         return [apiServer, apiServer.terminate] as const;
       },
       async (_, __, api) => {
+        const block1: DbBlock = {
+          block_hash: '0x11',
+          index_block_hash: '0xaa',
+          parent_index_block_hash: '0x00',
+          parent_block_hash: '0x00',
+          parent_microblock_hash: '',
+          block_height: 1,
+          burn_block_time: 1234,
+          burn_block_hash: '0x1234',
+          burn_block_height: 123,
+          miner_txid: '0x4321',
+          canonical: true,
+          parent_microblock_sequence: 0,
+          execution_cost_read_count: 0,
+          execution_cost_read_length: 0,
+          execution_cost_runtime: 0,
+          execution_cost_write_count: 0,
+          execution_cost_write_length: 0,
+        };
+
+        // Ensure db has a block so that current block height queries return a found result
+        await db.update({
+          block: block1,
+          microblocks: [],
+          minerRewards: [],
+          txs: [],
+        });
+
         const primaryStubbedResponse =
           '"1659fcdc9167576eb1f2a05d0aaba5ca1aa1943892e7e6e5d3ccb3e537f1c870"';
         const extraStubbedResponse = 'extra success stubbed response';


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/852

Implemented the fix at a few layers for robustness:
A. Use `<fetch result>.text()` rather than `<fetch resuilt>.json()` to get the unaltered response (similar to the non-tx-multicasting behavior).
B. Use a regex to strip the double quotes, rather than `JSON.parse()`, which allows for them to be optional `"123"` -> `123`, or `123` -> `123` (unaltered, no error).
C. Wrap the logging function in a try/catch/log-error so that any potential future errors in this function (e.g. resolving the current block height) won't result in an error response to the client.

Updated the unit test so that this code path is covered. This logging path is skipped when there are no blocks in the db, which was the case for the tx multicast unit tests.