### PR TITLE
feat: add prometheus metrics for websockets

### DIFF
--- a/src/api/routes/ws/metrics.ts
+++ b/src/api/routes/ws/metrics.ts
@@ -66,7 +66,9 @@ export class WebSocketPrometheus {
 
   public connect(remoteAddress: string) {
     this.metrics.connectTotal.inc();
-    this.metrics.connectRemoteAddressTotal.inc({ remoteAddress: remoteAddress });
+    this.metrics.connectRemoteAddressTotal.inc({
+      remoteAddress: remoteAddress.split(',')[0].trim(),
+    });
   }
 
   public disconnect(subscriber: WebSocketSubscriber) {

--- a/src/api/routes/ws/metrics.ts
+++ b/src/api/routes/ws/metrics.ts
@@ -42,6 +42,7 @@ export class WebSocketPrometheus {
         name: `${metricsNamePrefix}_subscription_timers`,
         help: 'Subscription timers',
         labelNames: ['topic'],
+        buckets: [1, 5, 10, 30, 60, 180, 300, 600, 1200, 1800, 3600],
       }),
       connectTotal: new prom.Counter({
         name: `${metricsNamePrefix}_connect_total`,

--- a/src/api/routes/ws/metrics.ts
+++ b/src/api/routes/ws/metrics.ts
@@ -4,12 +4,19 @@ import { Topic } from '@stacks/stacks-blockchain-api-types';
 export type WebSocketMetricsPrefix = 'socket_io' | 'websocket';
 
 interface WebSocketMetrics {
+  // Current number of active subscriptions (labeled by topic).
   subscriptions: prom.Gauge<string>;
+  // Total connections.
   connectTotal: prom.Counter<string>;
+  // Total disconnections.
   disconnectTotal: prom.Counter<string>;
+  // Total events sent (labeled by event type).
   eventsSent: prom.Counter<string>;
 }
 
+/**
+ * Wrapper for `prom-client` that allows us to gather metrics for Socket.io and WebSocket usage.
+ */
 export class WebSocketPrometheus {
   private metrics: WebSocketMetrics;
 

--- a/src/api/routes/ws/metrics.ts
+++ b/src/api/routes/ws/metrics.ts
@@ -1,11 +1,17 @@
 import * as prom from 'prom-client';
+import * as WebSocket from 'ws';
 import { Topic } from '@stacks/stacks-blockchain-api-types';
+import { Socket } from 'socket.io';
 
 export type WebSocketMetricsPrefix = 'socket_io' | 'websocket';
+
+export type WebSocketSubscriber = WebSocket | Socket;
 
 interface WebSocketMetrics {
   // Current number of active subscriptions (labeled by topic).
   subscriptions: prom.Gauge<string>;
+  // Time spent subscribed to a particular topic.
+  subscriptionTimers: prom.Histogram<string>;
   // Total connections.
   connectTotal: prom.Counter<string>;
   // Total disconnections.
@@ -19,12 +25,20 @@ interface WebSocketMetrics {
  */
 export class WebSocketPrometheus {
   private metrics: WebSocketMetrics;
+  // Record of all dates when a particular socket started observing an event. Useful for measuring
+  // total subscription time.
+  private subscriptions = new Map<WebSocketSubscriber, Map<string, Date>>();
 
   constructor(metricsNamePrefix: WebSocketMetricsPrefix) {
     this.metrics = {
       subscriptions: new prom.Gauge({
         name: `${metricsNamePrefix}_subscriptions`,
         help: 'Current subscriptions',
+        labelNames: ['topic'],
+      }),
+      subscriptionTimers: new prom.Histogram({
+        name: `${metricsNamePrefix}_subscription_timers`,
+        help: 'Subscription timers',
         labelNames: ['topic'],
       }),
       connectTotal: new prom.Counter({
@@ -47,23 +61,67 @@ export class WebSocketPrometheus {
     this.metrics.connectTotal.inc();
   }
 
-  public disconnect() {
-    this.metrics.disconnectTotal.inc();
+  public disconnect(subscriber: WebSocketSubscriber) {
+    this.doDisconnect(subscriber);
   }
 
-  public subscribe(topic: Topic | Topic[] | string) {
+  public subscribe(subscriber: WebSocketSubscriber, topic: Topic | Topic[] | string) {
     if (Array.isArray(topic)) {
-      topic.forEach(t => this.metrics.subscriptions.inc({ topic: t.toString() }));
+      topic.forEach(t => this.doSubscribe(subscriber, t));
     } else {
-      this.metrics.subscriptions.inc({ topic: topic.toString() });
+      this.doSubscribe(subscriber, topic);
     }
   }
 
-  public unsubscribe(topic: Topic | string) {
-    this.metrics.subscriptions.dec({ topic: topic.toString() });
+  public unsubscribe(subscriber: WebSocketSubscriber, topic: Topic | string) {
+    this.doUnsubscribe(subscriber, topic);
   }
 
   public sendEvent(event: string) {
     this.metrics.eventsSent.inc({ event: event });
+  }
+
+  private doSubscribe(subscriber: WebSocketSubscriber, topic: Topic | Topic[] | string) {
+    const topicStr = topic.toString();
+    // Increase subscription count.
+    this.metrics.subscriptions.inc({ topic: topicStr });
+    // Record the subscription date.
+    let map = this.subscriptions.get(subscriber);
+    if (!map) {
+      map = new Map();
+      this.subscriptions.set(subscriber, map);
+    }
+    map.set(topicStr, new Date());
+  }
+
+  private doUnsubscribe(subscriber: WebSocketSubscriber, topic: Topic | string) {
+    const topicStr = topic.toString();
+    // Decrease subscription count.
+    this.metrics.subscriptions.dec({ topic: topicStr });
+    // Report total subscription duration.
+    const map = this.subscriptions.get(subscriber);
+    if (map) {
+      const startDate = map.get(topicStr);
+      if (startDate) {
+        const elapsedSeconds = (new Date().getTime() - startDate.getTime()) / 1000;
+        this.metrics.subscriptionTimers.observe({ topic: topicStr }, elapsedSeconds);
+        map.delete(topicStr);
+        if (map.size === 0) {
+          this.subscriptions.delete(subscriber);
+        }
+      }
+    }
+  }
+
+  private doDisconnect(subscriber: WebSocketSubscriber) {
+    this.metrics.disconnectTotal.inc();
+    // Also unsubscribe from every topic.
+    const map = this.subscriptions.get(subscriber);
+    if (map) {
+      const topics = Array.from(map.keys());
+      topics.forEach(topic => {
+        this.doUnsubscribe(subscriber, topic);
+      });
+    }
   }
 }

--- a/src/api/routes/ws/metrics.ts
+++ b/src/api/routes/ws/metrics.ts
@@ -14,6 +14,8 @@ interface WebSocketMetrics {
   subscriptionTimers: prom.Histogram<string>;
   // Total connections.
   connectTotal: prom.Counter<string>;
+  // Total connections by remote address.
+  connectRemoteAddressTotal: prom.Counter<string>;
   // Total disconnections.
   disconnectTotal: prom.Counter<string>;
   // Total events sent (labeled by event type).
@@ -45,6 +47,11 @@ export class WebSocketPrometheus {
         name: `${metricsNamePrefix}_connect_total`,
         help: 'Total count of connection requests',
       }),
+      connectRemoteAddressTotal: new prom.Counter({
+        name: `${metricsNamePrefix}_connect_remote_address_total`,
+        help: 'Total count of connection requests by remote address',
+        labelNames: ['remoteAddress'],
+      }),
       disconnectTotal: new prom.Counter({
         name: `${metricsNamePrefix}_disconnect_total`,
         help: 'Total count of disconnections',
@@ -57,8 +64,9 @@ export class WebSocketPrometheus {
     };
   }
 
-  public connect() {
+  public connect(remoteAddress: string) {
     this.metrics.connectTotal.inc();
+    this.metrics.connectRemoteAddressTotal.inc({ remoteAddress: remoteAddress });
   }
 
   public disconnect(subscriber: WebSocketSubscriber) {

--- a/src/api/routes/ws/metrics.ts
+++ b/src/api/routes/ws/metrics.ts
@@ -1,0 +1,62 @@
+import * as prom from 'prom-client';
+import { Topic } from '@stacks/stacks-blockchain-api-types';
+
+export type WebSocketMetricsPrefix = 'socket_io' | 'websocket';
+
+interface WebSocketMetrics {
+  subscriptions: prom.Gauge<string>;
+  connectTotal: prom.Counter<string>;
+  disconnectTotal: prom.Counter<string>;
+  eventsSent: prom.Counter<string>;
+}
+
+export class WebSocketPrometheus {
+  private metrics: WebSocketMetrics;
+
+  constructor(metricsNamePrefix: WebSocketMetricsPrefix) {
+    this.metrics = {
+      subscriptions: new prom.Gauge({
+        name: `${metricsNamePrefix}_subscriptions`,
+        help: 'Current subscriptions',
+        labelNames: ['topic'],
+      }),
+      connectTotal: new prom.Counter({
+        name: `${metricsNamePrefix}_connect_total`,
+        help: 'Total count of connection requests',
+      }),
+      disconnectTotal: new prom.Counter({
+        name: `${metricsNamePrefix}_disconnect_total`,
+        help: 'Total count of disconnections',
+      }),
+      eventsSent: new prom.Counter({
+        name: `${metricsNamePrefix}_events_sent`,
+        help: 'Total count of sent events',
+        labelNames: ['event'],
+      }),
+    };
+  }
+
+  public connect() {
+    this.metrics.connectTotal.inc();
+  }
+
+  public disconnect() {
+    this.metrics.disconnectTotal.inc();
+  }
+
+  public subscribe(topic: Topic | Topic[] | string) {
+    if (Array.isArray(topic)) {
+      topic.forEach(t => this.metrics.subscriptions.inc({ topic: t.toString() }));
+    } else {
+      this.metrics.subscriptions.inc({ topic: topic.toString() });
+    }
+  }
+
+  public unsubscribe(topic: Topic | string) {
+    this.metrics.subscriptions.dec({ topic: topic.toString() });
+  }
+
+  public sendEvent(event: string) {
+    this.metrics.eventsSent.inc({ event: event });
+  }
+}

--- a/src/api/routes/ws/socket-io.ts
+++ b/src/api/routes/ws/socket-io.ts
@@ -34,26 +34,26 @@ export function createSocketIORouter(db: DataStore, server: http.Server) {
     prometheus?.connect();
     socket.on('disconnect', reason => {
       logger.info(`[socket.io] disconnected: ${reason}`);
-      prometheus?.disconnect();
+      prometheus?.disconnect(socket);
     });
     const subscriptions = socket.handshake.query['subscriptions'];
     if (subscriptions) {
       // TODO: check if init topics are valid, reject connection with error if not
       const topics = [...[subscriptions]].flat().flatMap(r => r.split(','));
       topics.forEach(topic => {
-        prometheus?.subscribe(topic);
+        prometheus?.subscribe(socket, topic);
         void socket.join(topic);
       });
     }
     socket.on('subscribe', (topic, callback) => {
-      prometheus?.subscribe(topic);
+      prometheus?.subscribe(socket, topic);
       void socket.join(topic);
       // TODO: check if topic is valid, and return error message if not
       callback?.(null);
     });
     socket.on('unsubscribe', (...topics) => {
       topics.forEach(topic => {
-        prometheus?.unsubscribe(topic);
+        prometheus?.unsubscribe(socket, topic);
         void socket.leave(topic);
       });
     });

--- a/src/api/routes/ws/socket-io.ts
+++ b/src/api/routes/ws/socket-io.ts
@@ -31,7 +31,11 @@ export function createSocketIORouter(db: DataStore, server: http.Server) {
 
   io.on('connection', socket => {
     logger.info('[socket.io] new connection');
-    prometheus?.connect(socket.handshake.address);
+    if (socket.handshake.headers['x-forwarded-for']) {
+      prometheus?.connect(socket.handshake.headers['x-forwarded-for'] as string);
+    } else {
+      prometheus?.connect(socket.handshake.address);
+    }
     socket.on('disconnect', reason => {
       logger.info(`[socket.io] disconnected: ${reason}`);
       prometheus?.disconnect(socket);

--- a/src/api/routes/ws/socket-io.ts
+++ b/src/api/routes/ws/socket-io.ts
@@ -31,7 +31,7 @@ export function createSocketIORouter(db: DataStore, server: http.Server) {
 
   io.on('connection', socket => {
     logger.info('[socket.io] new connection');
-    prometheus?.connect();
+    prometheus?.connect(socket.handshake.address);
     socket.on('disconnect', reason => {
       logger.info(`[socket.io] disconnected: ${reason}`);
       prometheus?.disconnect(socket);

--- a/src/api/routes/ws/ws-rpc.ts
+++ b/src/api/routes/ws/ws-rpc.ts
@@ -263,10 +263,10 @@ export function createWsRpcRouter(db: DataStore, server: http.Server): WebSocket
     }
     if (subscribe) {
       txUpdateSubscriptions.addSubscription(client, txId);
-      prometheus?.subscribe(`transaction:${txId}`);
+      prometheus?.subscribe(client, `transaction:${txId}`);
     } else {
       txUpdateSubscriptions.removeSubscription(client, txId);
-      prometheus?.unsubscribe(`transaction:${txId}`);
+      prometheus?.unsubscribe(client, `transaction:${txId}`);
     }
     return jsonRpcSuccess(req.payload.id, { tx_id: txId });
   }
@@ -284,10 +284,10 @@ export function createWsRpcRouter(db: DataStore, server: http.Server): WebSocket
     }
     if (subscribe) {
       addressTxUpdateSubscriptions.addSubscription(client, address);
-      prometheus?.subscribe(`address-transaction:${address}`);
+      prometheus?.subscribe(client, `address-transaction:${address}`);
     } else {
       addressTxUpdateSubscriptions.removeSubscription(client, address);
-      prometheus?.unsubscribe(`address-transaction:${address}`);
+      prometheus?.unsubscribe(client, `address-transaction:${address}`);
     }
     return jsonRpcSuccess(req.payload.id, { address: address });
   }
@@ -304,10 +304,10 @@ export function createWsRpcRouter(db: DataStore, server: http.Server): WebSocket
     }
     if (subscribe) {
       addressBalanceUpdateSubscriptions.addSubscription(client, address);
-      prometheus?.subscribe(`address-stx-balance:${address}`);
+      prometheus?.subscribe(client, `address-stx-balance:${address}`);
     } else {
       addressBalanceUpdateSubscriptions.removeSubscription(client, address);
-      prometheus?.unsubscribe(`address-stx-balance:${address}`);
+      prometheus?.unsubscribe(client, `address-stx-balance:${address}`);
     }
     return jsonRpcSuccess(req.payload.id, { address: address });
   }
@@ -320,10 +320,10 @@ export function createWsRpcRouter(db: DataStore, server: http.Server): WebSocket
   ) {
     if (subscribe) {
       blockSubscriptions.addSubscription(client, params.event);
-      prometheus?.subscribe('block');
+      prometheus?.subscribe(client, 'block');
     } else {
       blockSubscriptions.removeSubscription(client, params.event);
-      prometheus?.unsubscribe('block');
+      prometheus?.unsubscribe(client, 'block');
     }
     return jsonRpcSuccess(req.payload.id, {});
   }
@@ -336,10 +336,10 @@ export function createWsRpcRouter(db: DataStore, server: http.Server): WebSocket
   ) {
     if (subscribe) {
       microblockSubscriptions.addSubscription(client, params.event);
-      prometheus?.subscribe('microblock');
+      prometheus?.subscribe(client, 'microblock');
     } else {
       microblockSubscriptions.removeSubscription(client, params.event);
-      prometheus?.unsubscribe('microblock');
+      prometheus?.unsubscribe(client, 'microblock');
     }
     return jsonRpcSuccess(req.payload.id, {});
   }
@@ -352,10 +352,10 @@ export function createWsRpcRouter(db: DataStore, server: http.Server): WebSocket
   ) {
     if (subscribe) {
       mempoolSubscriptions.addSubscription(client, params.event);
-      prometheus?.subscribe('mempool');
+      prometheus?.subscribe(client, 'mempool');
     } else {
       mempoolSubscriptions.removeSubscription(client, params.event);
-      prometheus?.unsubscribe('mempool');
+      prometheus?.unsubscribe(client, 'mempool');
     }
     return jsonRpcSuccess(req.payload.id, {});
   }
@@ -538,7 +538,7 @@ export function createWsRpcRouter(db: DataStore, server: http.Server): WebSocket
       void handleClientMessage(clientSocket, data);
     });
     clientSocket.on('close', (_: WebSocket) => {
-      prometheus?.disconnect();
+      prometheus?.disconnect(clientSocket);
     });
   });
 

--- a/src/api/routes/ws/ws-rpc.ts
+++ b/src/api/routes/ws/ws-rpc.ts
@@ -226,9 +226,6 @@ export function createWsRpcRouter(db: DataStore, server: http.Server): WebSocket
         JsonRpcError.invalidParams('subscription requests must include an event name')
       );
     }
-    if (subscribe) {
-      prometheus?.connect();
-    }
     switch (params.event) {
       case 'tx_update':
         return handleTxUpdateSubscription(client, req, params, subscribe);
@@ -534,6 +531,9 @@ export function createWsRpcRouter(db: DataStore, server: http.Server): WebSocket
   });
 
   wsServer.on('connection', (clientSocket, req) => {
+    if (req.socket.remoteAddress) {
+      prometheus?.connect(req.socket.remoteAddress);
+    }
     clientSocket.on('message', data => {
       void handleClientMessage(clientSocket, data);
     });

--- a/src/api/routes/ws/ws-rpc.ts
+++ b/src/api/routes/ws/ws-rpc.ts
@@ -531,7 +531,9 @@ export function createWsRpcRouter(db: DataStore, server: http.Server): WebSocket
   });
 
   wsServer.on('connection', (clientSocket, req) => {
-    if (req.socket.remoteAddress) {
+    if (req.headers['x-forwarded-for']) {
+      prometheus?.connect(req.headers['x-forwarded-for'] as string);
+    } else if (req.socket.remoteAddress) {
       prometheus?.connect(req.socket.remoteAddress);
     }
     clientSocket.on('message', data => {


### PR DESCRIPTION
## Description

This patch adds Prometheus metrics for WebSocket usage. Example:
```
# HELP websocket_subscriptions Current subscriptions
# TYPE websocket_subscriptions gauge
websocket_subscriptions{topic="block"} 0

# HELP websocket_subscription_timers Subscription timers
# TYPE websocket_subscription_timers histogram
websocket_subscription_timers_bucket{le="1",topic="block"} 0
websocket_subscription_timers_bucket{le="5",topic="block"} 0
websocket_subscription_timers_bucket{le="10",topic="block"} 0
websocket_subscription_timers_bucket{le="30",topic="block"} 1
websocket_subscription_timers_bucket{le="60",topic="block"} 1
websocket_subscription_timers_bucket{le="180",topic="block"} 1
websocket_subscription_timers_bucket{le="300",topic="block"} 1
websocket_subscription_timers_bucket{le="600",topic="block"} 1
websocket_subscription_timers_bucket{le="1200",topic="block"} 1
websocket_subscription_timers_bucket{le="1800",topic="block"} 1
websocket_subscription_timers_bucket{le="3600",topic="block"} 1
websocket_subscription_timers_bucket{le="+Inf",topic="block"} 1
websocket_subscription_timers_sum{topic="block"} 10.78
websocket_subscription_timers_count{topic="block"} 1

# HELP websocket_connect_total Total count of connection requests
# TYPE websocket_connect_total counter
websocket_connect_total 1

# HELP websocket_connect_remote_address_total Total count of connection requests by remote address
# TYPE websocket_connect_remote_address_total counter
websocket_connect_remote_address_total{remoteAddress="127.0.0.1"} 1

# HELP websocket_disconnect_total Total count of disconnections
# TYPE websocket_disconnect_total counter
websocket_disconnect_total 1

# HELP websocket_events_sent Total count of sent events
# TYPE websocket_events_sent counter
websocket_events_sent{event="block"} 10
```

Closes #840 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
Local testing

## Checklist
- [x] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @kyranjamie or @zone117x for review
