### PR TITLE
Move build-publish Github actions to docker/build-push-action@v2

### DIFF
--- a/.github/workflows/stacks-blockchain-api.yml
+++ b/.github/workflows/stacks-blockchain-api.yml
@@ -440,6 +440,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2.5.0
@@ -458,7 +459,7 @@ jobs:
             semantic-release-slack-bot
             @semantic-release/exec
 
-      - name: Docker meta
+      - name: Docker Meta
         id: meta
         uses: docker/metadata-action@v3
         with:
@@ -466,10 +467,17 @@ jobs:
             blockstack/${{ github.workflow }}
             hirosystems/${{ github.workflow }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern=${{ steps.semantic.outputs.new_release_version }}
-            type=sha
+
+      - name: Docker Standalone Meta
+        id: meta_standalone
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            blockstack/${{ github.workflow }}-standalone
+            hirosystems/${{ github.workflow }}-standalone
+          tags: |
+            type=semver,pattern=${{ steps.semantic.outputs.new_release_version }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -489,18 +497,15 @@ jobs:
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
           push: ${{ (github.ref != 'refs/heads/master' || steps.semantic.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
 
-      # - name: Build/Tag/Push standalone Image
-      #   uses: docker/build-push-action@v2
-      #   with:
-      #     dockerfile: docker/stx-rosetta.Dockerfile
-      #     repository: blockstack/${{ github.workflow }}-standalone
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      #     tags: ${{ steps.semantic.outputs.new_release_version }}
-      #     tag_with_ref: true
-      #     add_git_labels: true
-      #     # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
-      #     push: ${{ (github.ref != 'refs/heads/master' || steps.semantic.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+      - name: Build/Tag/Push Standalone Image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/stx-rosetta.Dockerfile
+          tags: ${{ steps.semantic.outputs.new_release_version }}
+          labels: ${{ steps.meta_standalone.outputs.labels }}
+          # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
+          push: ${{ (github.ref != 'refs/heads/master' || steps.semantic.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
 
   notify-end:
     runs-on: ubuntu-latest

--- a/.github/workflows/stacks-blockchain-api.yml
+++ b/.github/workflows/stacks-blockchain-api.yml
@@ -468,8 +468,9 @@ jobs:
             hirosystems/${{ github.workflow }}
           tags: |
             type=ref,event=branch
-            type=semver,pattern=${{ steps.semantic.outputs.new_release_version }}
-            type=sha
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Docker Standalone Meta
         id: meta_standalone
@@ -480,11 +481,9 @@ jobs:
             hirosystems/${{ github.workflow }}-standalone
           tags: |
             type=ref,event=branch
-            type=semver,pattern=${{ steps.semantic.outputs.new_release_version }}
-            type=sha
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -495,7 +494,6 @@ jobs:
       - name: Build/Tag/Push Image
         uses: docker/build-push-action@v2
         with:
-          context: .
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
@@ -504,7 +502,6 @@ jobs:
       - name: Build/Tag/Push Standalone Image
         uses: docker/build-push-action@v2
         with:
-          context: .
           file: docker/stx-rosetta.Dockerfile
           tags: ${{ steps.meta_standalone.outputs.tags }}
           labels: ${{ steps.meta_standalone.outputs.labels }}

--- a/.github/workflows/stacks-blockchain-api.yml
+++ b/.github/workflows/stacks-blockchain-api.yml
@@ -10,6 +10,8 @@ on:
       - '**/CHANGELOG.md'
       - '**/package.json'
   pull_request:
+    types:
+      - opened
   workflow_dispatch:
 
 jobs:
@@ -451,31 +453,49 @@ jobs:
             @semantic-release/git
             semantic-release-slack-bot
             @semantic-release/exec
+      
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            blockstack/${{ github.workflow }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern=${{ steps.semantic.outputs.new_release_version }}
+            type=sha
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build/Tag/Push Image
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v2
         with:
-          repository: blockstack/${{ github.workflow }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          tags: ${{ steps.semantic.outputs.new_release_version }}
-          tag_with_ref: true
-          add_git_labels: true
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
           push: ${{ (github.ref != 'refs/heads/master' || steps.semantic.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
 
-      - name: Build/Tag/Push standalone Image
-        uses: docker/build-push-action@v1
-        with:
-          dockerfile: docker/stx-rosetta.Dockerfile
-          repository: blockstack/${{ github.workflow }}-standalone
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          tags: ${{ steps.semantic.outputs.new_release_version }}
-          tag_with_ref: true
-          add_git_labels: true
-          # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
-          push: ${{ (github.ref != 'refs/heads/master' || steps.semantic.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+      # - name: Build/Tag/Push standalone Image
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     dockerfile: docker/stx-rosetta.Dockerfile
+      #     repository: blockstack/${{ github.workflow }}-standalone
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      #     tags: ${{ steps.semantic.outputs.new_release_version }}
+      #     tag_with_ref: true
+      #     add_git_labels: true
+      #     # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
+      #     push: ${{ (github.ref != 'refs/heads/master' || steps.semantic.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
 
   notify-end:
     runs-on: ubuntu-latest

--- a/.github/workflows/stacks-blockchain-api.yml
+++ b/.github/workflows/stacks-blockchain-api.yml
@@ -430,6 +430,10 @@ jobs:
     needs:
       - test
       - test-rosetta
+      - test-bns
+      - test-rosetta-cli-data
+      - test-rosetta-cli-construction
+      - test-tokens
       - lint
       - lint-docs
     steps:
@@ -453,7 +457,7 @@ jobs:
             @semantic-release/git
             semantic-release-slack-bot
             @semantic-release/exec
-      
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -472,8 +476,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build/Tag/Push Image
         uses: docker/build-push-action@v2

--- a/.github/workflows/stacks-blockchain-api.yml
+++ b/.github/workflows/stacks-blockchain-api.yml
@@ -502,7 +502,7 @@ jobs:
         with:
           context: .
           file: docker/stx-rosetta.Dockerfile
-          tags: ${{ steps.semantic.outputs.new_release_version }}
+          tags: ${{ steps.meta_standalone.outputs.tags }}
           labels: ${{ steps.meta_standalone.outputs.labels }}
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
           push: ${{ (github.ref != 'refs/heads/master' || steps.semantic.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/.github/workflows/stacks-blockchain-api.yml
+++ b/.github/workflows/stacks-blockchain-api.yml
@@ -464,6 +464,7 @@ jobs:
         with:
           images: |
             blockstack/${{ github.workflow }}
+            hirosystems/${{ github.workflow }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -472,7 +473,7 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/stacks-blockchain-api.yml
+++ b/.github/workflows/stacks-blockchain-api.yml
@@ -428,14 +428,14 @@ jobs:
   build-publish:
     runs-on: ubuntu-latest
     needs:
-      - test
-      - test-rosetta
-      - test-bns
-      - test-rosetta-cli-data
-      - test-rosetta-cli-construction
-      - test-tokens
       - lint
       - lint-docs
+      - test
+      - test-bns
+      - test-rosetta
+      - test-rosetta-cli-construction
+      - test-rosetta-cli-data
+      - test-tokens
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/stacks-blockchain-api.yml
+++ b/.github/workflows/stacks-blockchain-api.yml
@@ -3,15 +3,14 @@ name: stacks-blockchain-api
 on:
   push:
     branches:
-      - '**'
+      - master
+      - develop
     tags-ignore:
       - '**'
     paths-ignore:
       - '**/CHANGELOG.md'
       - '**/package.json'
   pull_request:
-    types:
-      - opened
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/stacks-blockchain-api.yml
+++ b/.github/workflows/stacks-blockchain-api.yml
@@ -467,7 +467,9 @@ jobs:
             blockstack/${{ github.workflow }}
             hirosystems/${{ github.workflow }}
           tags: |
+            type=ref,event=branch
             type=semver,pattern=${{ steps.semantic.outputs.new_release_version }}
+            type=sha
 
       - name: Docker Standalone Meta
         id: meta_standalone
@@ -477,7 +479,9 @@ jobs:
             blockstack/${{ github.workflow }}-standalone
             hirosystems/${{ github.workflow }}-standalone
           tags: |
+            type=ref,event=branch
             type=semver,pattern=${{ steps.semantic.outputs.new_release_version }}
+            type=sha
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:14-alpine
 WORKDIR /app
 COPY . .
 
-RUN apk add --no-cache --virtual .build-deps alpine-sdk python2 git openjdk8-jre
+RUN apk add --no-cache --virtual .build-deps alpine-sdk python2 git openjdk8-jre cmake
 RUN echo "GIT_TAG=$(git tag --points-at HEAD)" >> .env
 RUN npm config set unsafe-perm true && npm install && npm run build && npm prune --production
 RUN apk del .build-deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:14-alpine
 WORKDIR /app
 COPY . .
 
-RUN apk add --no-cache --virtual .build-deps alpine-sdk python2 git openjdk8-jre cmake
+RUN apk add --no-cache --virtual .build-deps alpine-sdk python3 git openjdk8-jre cmake
 RUN echo "GIT_TAG=$(git tag --points-at HEAD)" >> .env
 RUN npm config set unsafe-perm true && npm install && npm run build && npm prune --production
 RUN apk del .build-deps

--- a/docker/stx-rosetta.Dockerfile
+++ b/docker/stx-rosetta.Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update -y \
         curl \
         jq \
         openjdk-11-jre-headless \
+        cmake \
     && git clone -b ${STACKS_API_VERSION} --depth 1 https://github.com/${STACKS_API_REPO} . \
     && echo "GIT_TAG=$(git tag --points-at HEAD)" >> .env \
     && npm config set unsafe-perm true \


### PR DESCRIPTION
## Description

This patch upgrades our `build-publish` Github actions step to use `docker/build-push-action@v2`. It also makes a few improvements:
- Push images to `blockstack/` and `hirosystems/` on Docker hub
- Limit `branch` event hook to only run actions on `master` and `develop` to avoid duplicating work with every PR push
- Adds `cmake` dependency to Dockerfiles so CPU profiling tools work correctly
- Checks out the repo with full depth so git tags work correctly

Closes #832 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @kyranjamie or @zone117x for review
