### PR TITLE
refactor: remove `@await/express` usage

### DIFF
--- a/jest.config.bns.js
+++ b/jest.config.bns.js
@@ -5,7 +5,7 @@ module.exports = {
     testMatch: ['<rootDir>/tests-bns/*.ts'],
     testPathIgnorePatterns: ['<rootDir>/tests-bns/setup.ts', '<rootDir>/tests-bns/teardown.ts'],
     collectCoverageFrom: ['<rootDir>/**/*.ts'],
-    coveragePathIgnorePatterns: ['<rootDir>/tests'],
+    coveragePathIgnorePatterns: ['<rootDir>/tests*'],
     coverageDirectory: '../coverage',
     globalSetup: '<rootDir>/tests-bns/setup.ts',
     globalTeardown: '<rootDir>/tests-bns/teardown.ts',

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   testMatch: ['<rootDir>/tests/**/*.ts'],
   testPathIgnorePatterns: ['<rootDir>/tests/setup.ts', '<rootDir>/tests/teardown.ts'],
   collectCoverageFrom: ['<rootDir>/**/*.ts'],
-  coveragePathIgnorePatterns: ['<rootDir>/tests-rosetta'],
+  coveragePathIgnorePatterns: ['<rootDir>/tests*'],
   coverageDirectory: '../coverage',
   globalSetup: '<rootDir>/tests/setup.ts',
   globalTeardown: '<rootDir>/tests/teardown.ts',

--- a/jest.config.microblocks.js
+++ b/jest.config.microblocks.js
@@ -5,7 +5,7 @@ module.exports = {
     testMatch: ['<rootDir>/tests-microblocks/*.ts'],
     testPathIgnorePatterns: ['<rootDir>/tests-microblocks/setup.ts', '<rootDir>/tests-microblocks/teardown.ts'],
     collectCoverageFrom: ['<rootDir>/**/*.ts'],
-    coveragePathIgnorePatterns: ['<rootDir>/tests'],
+    coveragePathIgnorePatterns: ['<rootDir>/tests*'],
     coverageDirectory: '../coverage',
     globalSetup: '<rootDir>/tests-microblocks/setup.ts',
     globalTeardown: '<rootDir>/tests-microblocks/teardown.ts',

--- a/jest.config.rosetta-cli-construction.js
+++ b/jest.config.rosetta-cli-construction.js
@@ -5,7 +5,7 @@ module.exports = {
   testMatch: ['<rootDir>/tests-rosetta-cli-construction/**/*.ts'],
   testPathIgnorePatterns: ['<rootDir>/tests-rosetta-cli-construction/setup.ts', '<rootDir>/tests-rosetta-cli-construction/teardown.ts'],
   collectCoverageFrom: ['<rootDir>/**/*.ts'],
-  coveragePathIgnorePatterns: ['<rootDir>/tests'],
+  coveragePathIgnorePatterns: ['<rootDir>/tests*'],
   coverageDirectory: '../coverage',
   globalSetup: '<rootDir>/tests-rosetta-cli-construction/setup.ts',
   globalTeardown: '<rootDir>/tests-rosetta-cli-construction/teardown.ts',

--- a/jest.config.rosetta-cli-data.js
+++ b/jest.config.rosetta-cli-data.js
@@ -5,7 +5,7 @@ module.exports = {
   testMatch: ['<rootDir>/tests-rosetta-cli-data/**/*.ts'],
   testPathIgnorePatterns: ['<rootDir>/tests-rosetta-cli-data/setup.ts', '<rootDir>/tests-rosetta-cli-data/teardown.ts'],
   collectCoverageFrom: ['<rootDir>/**/*.ts'],
-  coveragePathIgnorePatterns: ['<rootDir>/tests'],
+  coveragePathIgnorePatterns: ['<rootDir>/tests*'],
   coverageDirectory: '../coverage',
   globalSetup: '<rootDir>/tests-rosetta-cli-data/setup.ts',
   globalTeardown: '<rootDir>/tests-rosetta-cli-data/teardown.ts',

--- a/jest.config.rosetta.js
+++ b/jest.config.rosetta.js
@@ -5,7 +5,7 @@ module.exports = {
    testMatch: ['<rootDir>/tests-rosetta/**/*.ts'],
    testPathIgnorePatterns: ['<rootDir>/tests-rosetta/setup.ts', '<rootDir>/tests-rosetta/teardown.ts'],
    collectCoverageFrom: ['<rootDir>/**/*.ts'],
-   coveragePathIgnorePatterns: ['<rootDir>/tests'],
+   coveragePathIgnorePatterns: ['<rootDir>/tests*'],
    coverageDirectory: '../coverage',
    globalSetup: '<rootDir>/tests-rosetta/setup.ts',
    globalTeardown: '<rootDir>/tests-rosetta/teardown.ts',

--- a/jest.config.tokens.js
+++ b/jest.config.tokens.js
@@ -5,7 +5,7 @@ module.exports = {
     testMatch: ['<rootDir>/tests-tokens/*.ts'],
     testPathIgnorePatterns: ['<rootDir>/tests-tokens/setup.ts', '<rootDir>/tests-tokens/teardown.ts'],
     collectCoverageFrom: ['<rootDir>/**/*.ts'],
-    coveragePathIgnorePatterns: ['<rootDir>/tests'],
+    coveragePathIgnorePatterns: ['<rootDir>/tests*'],
     coverageDirectory: '../coverage',
     globalSetup: '<rootDir>/tests-tokens/setup.ts',
     globalTeardown: '<rootDir>/tests-tokens/teardown.ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,11 +55,6 @@
         "js-yaml": "^3.13.1"
       }
     },
-    "@awaitjs/express": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@awaitjs/express/-/express-0.7.2.tgz",
-      "integrity": "sha512-eX7+/nKq1HePLz7sxVHH1HFl/2xvyt7mItVTIi1xktq+4LQImVieAdH+xSXHOE7TcZ7TMJQOJF+3icJzIZ+Dkw=="
-    },
     "@babel/code-frame": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.7",
-    "@awaitjs/express": "^0.7.2",
     "@promster/express": "^4.1.12",
     "@promster/server": "^4.2.13",
     "@promster/types": "^1.0.6",

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -5,7 +5,6 @@ import * as expressWinston from 'express-winston';
 import * as winston from 'winston';
 import { v4 as uuid } from 'uuid';
 import * as cors from 'cors';
-import { addAsync, ExpressWithAsync } from '@awaitjs/express';
 import * as WebSocket from 'ws';
 import * as SocketIO from 'socket.io';
 
@@ -46,7 +45,7 @@ import { createFeeRateRouter } from './routes/fee-rate';
 import { setResponseNonCacheable } from './controllers/cache-controller';
 
 export interface ApiServer {
-  expressApp: ExpressWithAsync;
+  expressApp: express.Express;
   server: Server;
   wss: WebSocket.Server;
   io: SocketIO.Server;
@@ -67,7 +66,7 @@ export async function startApiServer(opts: {
 }): Promise<ApiServer> {
   const { datastore, chainId, serverHost, serverPort, httpLogLevel } = opts;
 
-  const app = addAsync(express());
+  const app = express();
   const apiHost = serverHost ?? process.env['STACKS_BLOCKCHAIN_API_HOST'];
   const apiPort = serverPort ?? parseInt(process.env['STACKS_BLOCKCHAIN_API_PORT'] ?? '');
 
@@ -154,7 +153,7 @@ export async function startApiServer(opts: {
   app.use(
     '/extended/v1',
     (() => {
-      const router = addAsync(express.Router());
+      const router = express.Router();
       router.use(cors());
       router.use('/tx', createTxRouter(datastore));
       router.use('/block', createBlockRouter(datastore));
@@ -180,7 +179,7 @@ export async function startApiServer(opts: {
   app.use(
     '/v2',
     (() => {
-      const router = addAsync(express.Router());
+      const router = express.Router();
       router.use(cors());
       router.use('/prices', createBnsPriceRouter(datastore, chainId));
       router.use('/', createCoreNodeRpcProxyRouter(datastore));
@@ -193,7 +192,7 @@ export async function startApiServer(opts: {
   app.use(
     '/rosetta/v1',
     (() => {
-      const router = addAsync(express.Router());
+      const router = express.Router();
       router.use(cors());
       router.use('/network', createRosettaNetworkRouter(datastore, chainId));
       router.use('/mempool', createRosettaMempoolRouter(datastore, chainId));
@@ -208,7 +207,7 @@ export async function startApiServer(opts: {
   app.use(
     '/v1',
     (() => {
-      const router = addAsync(express.Router());
+      const router = express.Router();
       router.use(cors());
       router.use('/namespaces', createBnsNamespacesRouter(datastore));
       router.use('/names', createBnsNamesRouter(datastore));

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -1,5 +1,5 @@
 import * as express from 'express';
-import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { asyncHandler } from '../async-handler';
 import * as Bluebird from 'bluebird';
 import { DataStore } from '../../datastore/common';
 import { parseLimitQuery, parsePagingQueryInput } from '../pagination';
@@ -93,82 +93,25 @@ interface AddressAssetEvents {
   total: number;
 }
 
-export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createAddressRouter(db: DataStore, chainId: ChainID): express.Router {
+  const router = express.Router();
 
-  router.getAsync('/:stx_address/stx', async (req, res, next) => {
-    const stxAddress = req.params['stx_address'];
-    if (!isValidPrincipal(stxAddress)) {
-      return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
-    }
-    const untilBlock = parseUntilBlockQuery(req, res, next);
+  router.get(
+    '/:stx_address/stx',
+    asyncHandler(async (req, res, next) => {
+      const stxAddress = req.params['stx_address'];
+      if (!isValidPrincipal(stxAddress)) {
+        res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
+        return;
+      }
+      const untilBlock = parseUntilBlockQuery(req, res, next);
 
-    const blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
+      const blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
 
-    // Get balance info for STX token
-    const stxBalanceResult = await db.getStxBalanceAtBlock(stxAddress, blockHeight);
-    const tokenOfferingLocked = await db.getTokenOfferingLocked(stxAddress, blockHeight);
-    const result: AddressStxBalanceResponse = {
-      balance: stxBalanceResult.balance.toString(),
-      total_sent: stxBalanceResult.totalSent.toString(),
-      total_received: stxBalanceResult.totalReceived.toString(),
-      total_fees_sent: stxBalanceResult.totalFeesSent.toString(),
-      total_miner_rewards_received: stxBalanceResult.totalMinerRewardsReceived.toString(),
-      lock_tx_id: stxBalanceResult.lockTxId,
-      locked: stxBalanceResult.locked.toString(),
-      lock_height: stxBalanceResult.lockHeight,
-      burnchain_lock_height: stxBalanceResult.burnchainLockHeight,
-      burnchain_unlock_height: stxBalanceResult.burnchainUnlockHeight,
-    };
-
-    if (tokenOfferingLocked.found) {
-      result.token_offering_locked = tokenOfferingLocked.result;
-    }
-    res.json(result);
-  });
-
-  // get balances for STX, FTs, and counts for NFTs
-  router.getAsync('/:stx_address/balances', async (req, res, next) => {
-    const stxAddress = req.params['stx_address'];
-    if (!isValidPrincipal(stxAddress)) {
-      return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
-    }
-
-    const untilBlock = parseUntilBlockQuery(req, res, next);
-    const blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
-
-    // Get balance info for STX token
-    const stxBalanceResult = await db.getStxBalanceAtBlock(stxAddress, blockHeight);
-    const tokenOfferingLocked = await db.getTokenOfferingLocked(stxAddress, blockHeight);
-
-    // Get balances for fungible tokens
-    const ftBalancesResult = await db.getFungibleTokenBalances({
-      stxAddress,
-      untilBlock: blockHeight,
-    });
-    const ftBalances = formatMapToObject(ftBalancesResult, val => {
-      return {
-        balance: val.balance.toString(),
-        total_sent: val.totalSent.toString(),
-        total_received: val.totalReceived.toString(),
-      };
-    });
-
-    // Get counts for non-fungible tokens
-    const nftBalancesResult = await db.getNonFungibleTokenCounts({
-      stxAddress,
-      untilBlock: blockHeight,
-    });
-    const nftBalances = formatMapToObject(nftBalancesResult, val => {
-      return {
-        count: val.count.toString(),
-        total_sent: val.totalSent.toString(),
-        total_received: val.totalReceived.toString(),
-      };
-    });
-
-    const result: AddressBalanceResponse = {
-      stx: {
+      // Get balance info for STX token
+      const stxBalanceResult = await db.getStxBalanceAtBlock(stxAddress, blockHeight);
+      const tokenOfferingLocked = await db.getTokenOfferingLocked(stxAddress, blockHeight);
+      const result: AddressStxBalanceResponse = {
         balance: stxBalanceResult.balance.toString(),
         total_sent: stxBalanceResult.totalSent.toString(),
         total_received: stxBalanceResult.totalReceived.toString(),
@@ -179,348 +122,448 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
         lock_height: stxBalanceResult.lockHeight,
         burnchain_lock_height: stxBalanceResult.burnchainLockHeight,
         burnchain_unlock_height: stxBalanceResult.burnchainUnlockHeight,
-      },
-      fungible_tokens: ftBalances,
-      non_fungible_tokens: nftBalances,
-    };
-
-    if (tokenOfferingLocked.found) {
-      result.token_offering_locked = tokenOfferingLocked.result;
-    }
-
-    res.json(result);
-  });
-
-  router.getAsync('/:stx_address/transactions', async (req, res, next) => {
-    // get recent txs associated (sender or receiver) with address
-    const stxAddress = req.params['stx_address'];
-    if (!isValidPrincipal(stxAddress)) {
-      return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
-    }
-
-    const untilBlock = parseUntilBlockQuery(req, res, next);
-    const blockParams = getBlockParams(req, res, next);
-    let atSingleBlock = false;
-    let blockHeight = 0;
-    if (blockParams.blockHeight) {
-      if (untilBlock) {
-        return res
-          .status(400)
-          .json({ error: `can't handle until_block and block_height in the same request` });
-      }
-      atSingleBlock = true;
-      blockHeight = blockParams.blockHeight;
-    } else {
-      blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
-    }
-    const limit = parseTxQueryLimit(req.query.limit ?? 20);
-    const offset = parsePagingQueryInput(req.query.offset ?? 0);
-    const { results: txResults, total } = await db.getAddressTxs({
-      stxAddress: stxAddress,
-      limit,
-      offset,
-      blockHeight,
-      atSingleBlock,
-    });
-    // TODO: use getBlockWithMetadata or similar to avoid transaction integrity issues from lazy resolving block tx data (primarily the contract-call ABI data)
-    const results = await Bluebird.mapSeries(txResults, async tx => {
-      const txQuery = await getTxFromDataStore(db, {
-        txId: tx.tx_id,
-        dbTx: tx,
-        includeUnanchored: true,
-      });
-      if (!txQuery.found) {
-        throw new Error('unexpected tx not found -- fix tx enumeration query');
-      }
-      return txQuery.result;
-    });
-    const response: TransactionResults = { limit, offset, total, results };
-    res.json(response);
-  });
-
-  router.getAsync('/:stx_address/:tx_id/with_transfers', async (req, res) => {
-    const stxAddress = req.params['stx_address'];
-    let tx_id = req.params['tx_id'];
-    if (!isValidPrincipal(stxAddress)) {
-      return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
-    }
-    if (!has0xPrefix(tx_id)) {
-      tx_id = '0x' + tx_id;
-    }
-    const results = await db.getInformationTxsWithStxTransfers({ stxAddress, tx_id });
-    if (results && results.tx) {
-      const txQuery = await getTxFromDataStore(db, {
-        txId: results.tx.tx_id,
-        dbTx: results.tx,
-        includeUnanchored: false,
-      });
-      if (!txQuery.found) {
-        throw new Error('unexpected tx not found -- fix tx enumeration query');
-      }
-      const result: AddressTransactionWithTransfers = {
-        tx: txQuery.result,
-        stx_sent: results.stx_sent.toString(),
-        stx_received: results.stx_received.toString(),
-        stx_transfers: results.stx_transfers.map(transfer => ({
-          amount: transfer.amount.toString(),
-          sender: transfer.sender,
-          recipient: transfer.recipient,
-        })),
       };
+
+      if (tokenOfferingLocked.found) {
+        result.token_offering_locked = tokenOfferingLocked.result;
+      }
       res.json(result);
-    } else res.status(404).json({ error: 'No matching transaction found' });
-  });
+    })
+  );
 
-  router.getAsync('/:stx_address/transactions_with_transfers', async (req, res, next) => {
-    const stxAddress = req.params['stx_address'];
-    if (!isValidPrincipal(stxAddress)) {
-      return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
-    }
-
-    const untilBlock = parseUntilBlockQuery(req, res, next);
-    const blockParams = getBlockParams(req, res, next);
-    let atSingleBlock = false;
-    let blockHeight = 0;
-    if (blockParams.blockHeight) {
-      if (untilBlock) {
-        return res
-          .status(400)
-          .json({ error: `can't handle until_block and block_height in the same request` });
-      }
-      atSingleBlock = true;
-      blockHeight = blockParams.blockHeight;
-    } else {
-      blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
-    }
-    const limit = parseTxQueryLimit(req.query.limit ?? 20);
-    const offset = parsePagingQueryInput(req.query.offset ?? 0);
-    const { results: txResults, total } = await db.getAddressTxsWithAssetTransfers({
-      stxAddress: stxAddress,
-      limit,
-      offset,
-      blockHeight,
-      atSingleBlock,
-    });
-
-    // TODO: use getBlockWithMetadata or similar to avoid transaction integrity issues from lazy resolving block tx data (primarily the contract-call ABI data)
-    const results = await Bluebird.mapSeries(txResults, async entry => {
-      const txQuery = await getTxFromDataStore(db, {
-        txId: entry.tx.tx_id,
-        dbTx: entry.tx,
-        includeUnanchored: blockParams.includeUnanchored ?? false,
-      });
-      if (!txQuery.found) {
-        throw new Error('unexpected tx not found -- fix tx enumeration query');
-      }
-      const result: AddressTransactionWithTransfers = {
-        tx: txQuery.result,
-        stx_sent: entry.stx_sent.toString(),
-        stx_received: entry.stx_received.toString(),
-        stx_transfers: entry.stx_transfers.map(transfer => ({
-          amount: transfer.amount.toString(),
-          sender: transfer.sender,
-          recipient: transfer.recipient,
-        })),
-        ft_transfers: entry.ft_transfers.map(transfer => ({
-          asset_identifier: transfer.asset_identifier,
-          amount: transfer.amount.toString(),
-          sender: transfer.sender,
-          recipient: transfer.recipient,
-        })),
-        nft_transfers: entry.nft_transfers.map(transfer => {
-          const valueHex = bufferToHexPrefixString(transfer.value);
-          const valueRepr = cvToString(deserializeCV(transfer.value));
-          const nftTransfer = {
-            asset_identifier: transfer.asset_identifier,
-            value: {
-              hex: valueHex,
-              repr: valueRepr,
-            },
-            sender: transfer.sender,
-            recipient: transfer.recipient,
-          };
-          return nftTransfer;
-        }),
-      };
-      return result;
-    });
-
-    const response: AddressTransactionsWithTransfersListResponse = {
-      limit,
-      offset,
-      total,
-      results,
-    };
-    res.json(response);
-  });
-
-  router.getAsync('/:stx_address/assets', async (req, res, next) => {
-    // get recent asset event associated with address
-    const stxAddress = req.params['stx_address'];
-    if (!isValidPrincipal(stxAddress)) {
-      return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
-    }
-    const untilBlock = parseUntilBlockQuery(req, res, next);
-    const blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
-
-    const limit = parseAssetsQueryLimit(req.query.limit ?? 20);
-    const offset = parsePagingQueryInput(req.query.offset ?? 0);
-    const { results: assetEvents, total } = await db.getAddressAssetEvents({
-      stxAddress,
-      limit,
-      offset,
-      blockHeight,
-    });
-    const results = assetEvents.map(event => parseDbEvent(event));
-    const response: AddressAssetEvents = { limit, offset, total, results };
-    res.json(response);
-  });
-
-  router.getAsync('/:stx_address/stx_inbound', async (req, res, next) => {
-    // get recent inbound STX transfers with memos
-    const stxAddress = req.params['stx_address'];
-    try {
-      const sendManyContractId = getSendManyContract(chainId);
-      if (!sendManyContractId || !isValidPrincipal(sendManyContractId)) {
-        logger.error('Send many contract ID not properly configured');
-        return res.status(500).json({ error: 'Send many contract ID not properly configured' });
-      }
+  // get balances for STX, FTs, and counts for NFTs
+  router.get(
+    '/:stx_address/balances',
+    asyncHandler(async (req, res, next) => {
+      const stxAddress = req.params['stx_address'];
       if (!isValidPrincipal(stxAddress)) {
-        return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
+        res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
+        return;
       }
 
-      let atSingleBlock = false;
+      const untilBlock = parseUntilBlockQuery(req, res, next);
+      const blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
+
+      // Get balance info for STX token
+      const stxBalanceResult = await db.getStxBalanceAtBlock(stxAddress, blockHeight);
+      const tokenOfferingLocked = await db.getTokenOfferingLocked(stxAddress, blockHeight);
+
+      // Get balances for fungible tokens
+      const ftBalancesResult = await db.getFungibleTokenBalances({
+        stxAddress,
+        untilBlock: blockHeight,
+      });
+      const ftBalances = formatMapToObject(ftBalancesResult, val => {
+        return {
+          balance: val.balance.toString(),
+          total_sent: val.totalSent.toString(),
+          total_received: val.totalReceived.toString(),
+        };
+      });
+
+      // Get counts for non-fungible tokens
+      const nftBalancesResult = await db.getNonFungibleTokenCounts({
+        stxAddress,
+        untilBlock: blockHeight,
+      });
+      const nftBalances = formatMapToObject(nftBalancesResult, val => {
+        return {
+          count: val.count.toString(),
+          total_sent: val.totalSent.toString(),
+          total_received: val.totalReceived.toString(),
+        };
+      });
+
+      const result: AddressBalanceResponse = {
+        stx: {
+          balance: stxBalanceResult.balance.toString(),
+          total_sent: stxBalanceResult.totalSent.toString(),
+          total_received: stxBalanceResult.totalReceived.toString(),
+          total_fees_sent: stxBalanceResult.totalFeesSent.toString(),
+          total_miner_rewards_received: stxBalanceResult.totalMinerRewardsReceived.toString(),
+          lock_tx_id: stxBalanceResult.lockTxId,
+          locked: stxBalanceResult.locked.toString(),
+          lock_height: stxBalanceResult.lockHeight,
+          burnchain_lock_height: stxBalanceResult.burnchainLockHeight,
+          burnchain_unlock_height: stxBalanceResult.burnchainUnlockHeight,
+        },
+        fungible_tokens: ftBalances,
+        non_fungible_tokens: nftBalances,
+      };
+
+      if (tokenOfferingLocked.found) {
+        result.token_offering_locked = tokenOfferingLocked.result;
+      }
+
+      res.json(result);
+    })
+  );
+
+  router.get(
+    '/:stx_address/transactions',
+    asyncHandler(async (req, res, next) => {
+      // get recent txs associated (sender or receiver) with address
+      const stxAddress = req.params['stx_address'];
+      if (!isValidPrincipal(stxAddress)) {
+        res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
+        return;
+      }
+
       const untilBlock = parseUntilBlockQuery(req, res, next);
       const blockParams = getBlockParams(req, res, next);
+      let atSingleBlock = false;
       let blockHeight = 0;
       if (blockParams.blockHeight) {
         if (untilBlock) {
-          return res
+          res
             .status(400)
             .json({ error: `can't handle until_block and block_height in the same request` });
+          return;
         }
         atSingleBlock = true;
         blockHeight = blockParams.blockHeight;
       } else {
         blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
       }
-
-      const limit = parseStxInboundLimit(req.query.limit ?? 20);
+      const limit = parseTxQueryLimit(req.query.limit ?? 20);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
-      const { results, total } = await db.getInboundTransfers({
-        stxAddress,
+      const { results: txResults, total } = await db.getAddressTxs({
+        stxAddress: stxAddress,
         limit,
         offset,
-        sendManyContractId,
         blockHeight,
         atSingleBlock,
       });
-      const transfers: InboundStxTransfer[] = results.map(r => ({
-        sender: r.sender,
-        amount: r.amount.toString(),
-        memo: r.memo,
-        block_height: r.block_height,
-        tx_id: r.tx_id,
-        transfer_type: r.transfer_type as InboundStxTransfer['transfer_type'],
-        tx_index: r.tx_index,
-      }));
-      const response: AddressStxInboundListResponse = {
-        results: transfers,
-        total: total,
+      // TODO: use getBlockWithMetadata or similar to avoid transaction integrity issues from lazy resolving block tx data (primarily the contract-call ABI data)
+      const results = await Bluebird.mapSeries(txResults, async tx => {
+        const txQuery = await getTxFromDataStore(db, {
+          txId: tx.tx_id,
+          dbTx: tx,
+          includeUnanchored: true,
+        });
+        if (!txQuery.found) {
+          throw new Error('unexpected tx not found -- fix tx enumeration query');
+        }
+        return txQuery.result;
+      });
+      const response: TransactionResults = { limit, offset, total, results };
+      res.json(response);
+    })
+  );
+
+  router.get(
+    '/:stx_address/:tx_id/with_transfers',
+    asyncHandler(async (req, res) => {
+      const stxAddress = req.params['stx_address'];
+      let tx_id = req.params['tx_id'];
+      if (!isValidPrincipal(stxAddress)) {
+        res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
+        return;
+      }
+      if (!has0xPrefix(tx_id)) {
+        tx_id = '0x' + tx_id;
+      }
+      const results = await db.getInformationTxsWithStxTransfers({ stxAddress, tx_id });
+      if (results && results.tx) {
+        const txQuery = await getTxFromDataStore(db, {
+          txId: results.tx.tx_id,
+          dbTx: results.tx,
+          includeUnanchored: false,
+        });
+        if (!txQuery.found) {
+          throw new Error('unexpected tx not found -- fix tx enumeration query');
+        }
+        const result: AddressTransactionWithTransfers = {
+          tx: txQuery.result,
+          stx_sent: results.stx_sent.toString(),
+          stx_received: results.stx_received.toString(),
+          stx_transfers: results.stx_transfers.map(transfer => ({
+            amount: transfer.amount.toString(),
+            sender: transfer.sender,
+            recipient: transfer.recipient,
+          })),
+        };
+        res.json(result);
+      } else res.status(404).json({ error: 'No matching transaction found' });
+    })
+  );
+
+  router.get(
+    '/:stx_address/transactions_with_transfers',
+    asyncHandler(async (req, res, next) => {
+      const stxAddress = req.params['stx_address'];
+      if (!isValidPrincipal(stxAddress)) {
+        res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
+        return;
+      }
+
+      const untilBlock = parseUntilBlockQuery(req, res, next);
+      const blockParams = getBlockParams(req, res, next);
+      let atSingleBlock = false;
+      let blockHeight = 0;
+      if (blockParams.blockHeight) {
+        if (untilBlock) {
+          res
+            .status(400)
+            .json({ error: `can't handle until_block and block_height in the same request` });
+          return;
+        }
+        atSingleBlock = true;
+        blockHeight = blockParams.blockHeight;
+      } else {
+        blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
+      }
+      const limit = parseTxQueryLimit(req.query.limit ?? 20);
+      const offset = parsePagingQueryInput(req.query.offset ?? 0);
+      const { results: txResults, total } = await db.getAddressTxsWithAssetTransfers({
+        stxAddress: stxAddress,
         limit,
         offset,
+        blockHeight,
+        atSingleBlock,
+      });
+
+      // TODO: use getBlockWithMetadata or similar to avoid transaction integrity issues from lazy resolving block tx data (primarily the contract-call ABI data)
+      const results = await Bluebird.mapSeries(txResults, async entry => {
+        const txQuery = await getTxFromDataStore(db, {
+          txId: entry.tx.tx_id,
+          dbTx: entry.tx,
+          includeUnanchored: blockParams.includeUnanchored ?? false,
+        });
+        if (!txQuery.found) {
+          throw new Error('unexpected tx not found -- fix tx enumeration query');
+        }
+        const result: AddressTransactionWithTransfers = {
+          tx: txQuery.result,
+          stx_sent: entry.stx_sent.toString(),
+          stx_received: entry.stx_received.toString(),
+          stx_transfers: entry.stx_transfers.map(transfer => ({
+            amount: transfer.amount.toString(),
+            sender: transfer.sender,
+            recipient: transfer.recipient,
+          })),
+          ft_transfers: entry.ft_transfers.map(transfer => ({
+            asset_identifier: transfer.asset_identifier,
+            amount: transfer.amount.toString(),
+            sender: transfer.sender,
+            recipient: transfer.recipient,
+          })),
+          nft_transfers: entry.nft_transfers.map(transfer => {
+            const valueHex = bufferToHexPrefixString(transfer.value);
+            const valueRepr = cvToString(deserializeCV(transfer.value));
+            const nftTransfer = {
+              asset_identifier: transfer.asset_identifier,
+              value: {
+                hex: valueHex,
+                repr: valueRepr,
+              },
+              sender: transfer.sender,
+              recipient: transfer.recipient,
+            };
+            return nftTransfer;
+          }),
+        };
+        return result;
+      });
+
+      const response: AddressTransactionsWithTransfersListResponse = {
+        limit,
+        offset,
+        total,
+        results,
       };
       res.json(response);
-    } catch (error) {
-      logger.error(`Unable to get inbound transfers for ${stxAddress}`, error);
-      throw error;
-    }
-  });
+    })
+  );
 
-  router.getAsync('/:stx_address/nft_events', async (req, res, next) => {
-    // get recent asset event associated with address
-    const stxAddress = req.params['stx_address'];
-    if (!isValidPrincipal(stxAddress)) {
-      return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
-    }
+  router.get(
+    '/:stx_address/assets',
+    asyncHandler(async (req, res, next) => {
+      // get recent asset event associated with address
+      const stxAddress = req.params['stx_address'];
+      if (!isValidPrincipal(stxAddress)) {
+        res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
+        return;
+      }
+      const untilBlock = parseUntilBlockQuery(req, res, next);
+      const blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
 
-    const untilBlock = parseUntilBlockQuery(req, res, next);
-    const blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
-    const limit = parseAssetsQueryLimit(req.query.limit ?? 20);
-    const offset = parsePagingQueryInput(req.query.offset ?? 0);
-    const includeUnanchored = isUnanchoredRequest(req, res, next);
+      const limit = parseAssetsQueryLimit(req.query.limit ?? 20);
+      const offset = parsePagingQueryInput(req.query.offset ?? 0);
+      const { results: assetEvents, total } = await db.getAddressAssetEvents({
+        stxAddress,
+        limit,
+        offset,
+        blockHeight,
+      });
+      const results = assetEvents.map(event => parseDbEvent(event));
+      const response: AddressAssetEvents = { limit, offset, total, results };
+      res.json(response);
+    })
+  );
 
-    const response = await db.getAddressNFTEvent({
-      stxAddress,
-      limit,
-      offset,
-      blockHeight,
-      includeUnanchored,
-    });
-    const nft_events = response.results.map(row => ({
-      sender: row.sender,
-      recipient: row.recipient,
-      asset_identifier: row.asset_identifier,
-      value: {
-        hex: bufferToHexPrefixString(row.value),
-        repr: cvToString(deserializeCV(row.value)),
-      },
-      tx_id: bufferToHexPrefixString(row.tx_id),
-      block_height: row.block_height,
-    }));
-    const nftListResponse: AddressNftListResponse = {
-      nft_events: nft_events,
-      total: response.total,
-      limit: limit,
-      offset: offset,
-    };
-    res.json(nftListResponse);
-  });
+  router.get(
+    '/:stx_address/stx_inbound',
+    asyncHandler(async (req, res, next) => {
+      // get recent inbound STX transfers with memos
+      const stxAddress = req.params['stx_address'];
+      try {
+        const sendManyContractId = getSendManyContract(chainId);
+        if (!sendManyContractId || !isValidPrincipal(sendManyContractId)) {
+          logger.error('Send many contract ID not properly configured');
+          res.status(500).json({ error: 'Send many contract ID not properly configured' });
+          return;
+        }
+        if (!isValidPrincipal(stxAddress)) {
+          res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
+          return;
+        }
 
-  router.getAsync('/:address/mempool', async (req, res, next) => {
-    const limit = parseTxQueryLimit(req.query.limit ?? MAX_TX_PER_REQUEST);
-    const offset = parsePagingQueryInput(req.query.offset ?? 0);
+        let atSingleBlock = false;
+        const untilBlock = parseUntilBlockQuery(req, res, next);
+        const blockParams = getBlockParams(req, res, next);
+        let blockHeight = 0;
+        if (blockParams.blockHeight) {
+          if (untilBlock) {
+            res
+              .status(400)
+              .json({ error: `can't handle until_block and block_height in the same request` });
+            return;
+          }
+          atSingleBlock = true;
+          blockHeight = blockParams.blockHeight;
+        } else {
+          blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
+        }
 
-    const address = req.params['address'];
-    if (!isValidC32Address(address)) {
-      res.status(400).json({ error: `Invalid query parameter for "${address}"` });
-    }
+        const limit = parseStxInboundLimit(req.query.limit ?? 20);
+        const offset = parsePagingQueryInput(req.query.offset ?? 0);
+        const { results, total } = await db.getInboundTransfers({
+          stxAddress,
+          limit,
+          offset,
+          sendManyContractId,
+          blockHeight,
+          atSingleBlock,
+        });
+        const transfers: InboundStxTransfer[] = results.map(r => ({
+          sender: r.sender,
+          amount: r.amount.toString(),
+          memo: r.memo,
+          block_height: r.block_height,
+          tx_id: r.tx_id,
+          transfer_type: r.transfer_type as InboundStxTransfer['transfer_type'],
+          tx_index: r.tx_index,
+        }));
+        const response: AddressStxInboundListResponse = {
+          results: transfers,
+          total: total,
+          limit,
+          offset,
+        };
+        res.json(response);
+      } catch (error) {
+        logger.error(`Unable to get inbound transfers for ${stxAddress}`, error);
+        throw error;
+      }
+    })
+  );
 
-    const includeUnanchored = isUnanchoredRequest(req, res, next);
-    const { results: txResults, total } = await db.getMempoolTxList({
-      offset,
-      limit,
-      address,
-      includeUnanchored,
-    });
+  router.get(
+    '/:stx_address/nft_events',
+    asyncHandler(async (req, res, next) => {
+      // get recent asset event associated with address
+      const stxAddress = req.params['stx_address'];
+      if (!isValidPrincipal(stxAddress)) {
+        res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
+        return;
+      }
 
-    const results = txResults.map(tx => parseDbMempoolTx(tx));
-    const response: MempoolTransactionListResponse = { limit, offset, total, results };
-    if (!isProdEnv) {
-      const schemaPath =
-        '@stacks/stacks-blockchain-api-types/api/transaction/get-mempool-transactions.schema.json';
-      await validate(schemaPath, response);
-    }
-    res.json(response);
-  });
+      const untilBlock = parseUntilBlockQuery(req, res, next);
+      const blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
+      const limit = parseAssetsQueryLimit(req.query.limit ?? 20);
+      const offset = parsePagingQueryInput(req.query.offset ?? 0);
+      const includeUnanchored = isUnanchoredRequest(req, res, next);
 
-  router.getAsync('/:stx_address/nonces', async (req, res) => {
-    // get recent asset event associated with address
-    const stxAddress = req.params['stx_address'];
-    if (!isValidPrincipal(stxAddress)) {
-      return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
-    }
-    const nonces = await db.getAddressNonces({
-      stxAddress,
-    });
-    const results: AddressNonces = {
-      last_executed_tx_nonce: nonces.lastExecutedTxNonce as number,
-      last_mempool_tx_nonce: nonces.lastMempoolTxNonce as number,
-      possible_next_nonce: nonces.possibleNextNonce,
-      detected_missing_nonces: nonces.detectedMissingNonces,
-    };
-    res.json(results);
-  });
+      const response = await db.getAddressNFTEvent({
+        stxAddress,
+        limit,
+        offset,
+        blockHeight,
+        includeUnanchored,
+      });
+      const nft_events = response.results.map(row => ({
+        sender: row.sender,
+        recipient: row.recipient,
+        asset_identifier: row.asset_identifier,
+        value: {
+          hex: bufferToHexPrefixString(row.value),
+          repr: cvToString(deserializeCV(row.value)),
+        },
+        tx_id: bufferToHexPrefixString(row.tx_id),
+        block_height: row.block_height,
+      }));
+      const nftListResponse: AddressNftListResponse = {
+        nft_events: nft_events,
+        total: response.total,
+        limit: limit,
+        offset: offset,
+      };
+      res.json(nftListResponse);
+    })
+  );
+
+  router.get(
+    '/:address/mempool',
+    asyncHandler(async (req, res, next) => {
+      const limit = parseTxQueryLimit(req.query.limit ?? MAX_TX_PER_REQUEST);
+      const offset = parsePagingQueryInput(req.query.offset ?? 0);
+
+      const address = req.params['address'];
+      if (!isValidC32Address(address)) {
+        res.status(400).json({ error: `Invalid query parameter for "${address}"` });
+      }
+
+      const includeUnanchored = isUnanchoredRequest(req, res, next);
+      const { results: txResults, total } = await db.getMempoolTxList({
+        offset,
+        limit,
+        address,
+        includeUnanchored,
+      });
+
+      const results = txResults.map(tx => parseDbMempoolTx(tx));
+      const response: MempoolTransactionListResponse = { limit, offset, total, results };
+      if (!isProdEnv) {
+        const schemaPath =
+          '@stacks/stacks-blockchain-api-types/api/transaction/get-mempool-transactions.schema.json';
+        await validate(schemaPath, response);
+      }
+      res.json(response);
+    })
+  );
+
+  router.get(
+    '/:stx_address/nonces',
+    asyncHandler(async (req, res) => {
+      // get recent asset event associated with address
+      const stxAddress = req.params['stx_address'];
+      if (!isValidPrincipal(stxAddress)) {
+        res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
+        return;
+      }
+      const nonces = await db.getAddressNonces({
+        stxAddress,
+      });
+      const results: AddressNonces = {
+        last_executed_tx_nonce: nonces.lastExecutedTxNonce as number,
+        last_mempool_tx_nonce: nonces.lastMempoolTxNonce as number,
+        possible_next_nonce: nonces.possibleNextNonce,
+        detected_missing_nonces: nonces.detectedMissingNonces,
+      };
+      res.json(results);
+    })
+  );
 
   return router;
 }

--- a/src/api/routes/block.ts
+++ b/src/api/routes/block.ts
@@ -1,5 +1,4 @@
 import * as express from 'express';
-import { addAsync, RouterWithAsync } from '@awaitjs/express';
 import * as Bluebird from 'bluebird';
 import { BlockListResponse } from '@stacks/stacks-blockchain-api-types';
 
@@ -18,8 +17,8 @@ const parseBlockQueryLimit = parseLimitQuery({
   errorMsg: '`limit` must be equal to or less than ' + MAX_BLOCKS_PER_REQUEST,
 });
 
-export function createBlockRouter(db: DataStore): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createBlockRouter(db: DataStore): express.Router {
+  const router = express.Router();
   const cacheHandler = getChainTipCacheHandler(db);
   router.get(
     '/',

--- a/src/api/routes/bns/addresses.ts
+++ b/src/api/routes/bns/addresses.ts
@@ -1,31 +1,33 @@
 import * as express from 'express';
-import { RouterWithAsync, addAsync } from '@awaitjs/express';
+import { asyncHandler } from '../../async-handler';
 import { DataStore } from '../../../datastore/common';
 import { isUnanchoredRequest } from '../../query-helpers';
 
 const SUPPORTED_BLOCKCHAINS = ['stacks'];
 
-export function createBnsAddressesRouter(db: DataStore): RouterWithAsync {
-  const router = addAsync(express.Router());
-
-  router.getAsync('/:blockchain/:address', async (req, res, next) => {
-    // Retrieves a list of names owned by the address provided.
-    const { blockchain, address } = req.params;
-    if (!SUPPORTED_BLOCKCHAINS.includes(blockchain)) {
-      res.status(404).json({ error: 'Unsupported blockchain' });
-      return;
-    }
-    const includeUnanchored = isUnanchoredRequest(req, res, next);
-    const namesByAddress = await db.getNamesByAddressList({
-      address: address,
-      includeUnanchored,
-    });
-    if (namesByAddress.found) {
-      res.json({ names: namesByAddress.result });
-    } else {
-      res.json({ names: [] });
-    }
-  });
+export function createBnsAddressesRouter(db: DataStore): express.Router {
+  const router = express.Router();
+  router.get(
+    '/:blockchain/:address',
+    asyncHandler(async (req, res, next) => {
+      // Retrieves a list of names owned by the address provided.
+      const { blockchain, address } = req.params;
+      if (!SUPPORTED_BLOCKCHAINS.includes(blockchain)) {
+        res.status(404).json({ error: 'Unsupported blockchain' });
+        return;
+      }
+      const includeUnanchored = isUnanchoredRequest(req, res, next);
+      const namesByAddress = await db.getNamesByAddressList({
+        address: address,
+        includeUnanchored,
+      });
+      if (namesByAddress.found) {
+        res.json({ names: namesByAddress.result });
+      } else {
+        res.json({ names: [] });
+      }
+    })
+  );
 
   return router;
 }

--- a/src/api/routes/bns/names.ts
+++ b/src/api/routes/bns/names.ts
@@ -1,127 +1,142 @@
 import * as express from 'express';
-import { RouterWithAsync, addAsync } from '@awaitjs/express';
+import { asyncHandler } from '../../async-handler';
 import { DataStore } from '../../../datastore/common';
 import { parsePagingQueryInput } from '../../../api/pagination';
 import { isUnanchoredRequest } from '../../query-helpers';
 import { bnsBlockchain, BnsErrors } from '../../../bns-constants';
 import { BnsGetNameInfoResponse } from '@stacks/stacks-blockchain-api-types';
 
-export function createBnsNamesRouter(db: DataStore): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createBnsNamesRouter(db: DataStore): express.Router {
+  const router = express.Router();
 
-  router.getAsync('/:name/zonefile/:zoneFileHash', async (req, res, next) => {
-    // Fetches the historical zonefile specified by the username and zone hash.
-    const { name, zoneFileHash } = req.params;
-    const includeUnanchored = isUnanchoredRequest(req, res, next);
-    let nameFound = false;
-    const nameQuery = await db.getName({ name: name, includeUnanchored });
-    nameFound = nameQuery.found;
-    if (!nameFound) {
-      const subdomainQuery = await db.getSubdomain({ subdomain: name, includeUnanchored });
-      nameFound = subdomainQuery.found;
-    }
-
-    if (nameFound) {
-      const zonefile = await db.getHistoricalZoneFile({ name: name, zoneFileHash: zoneFileHash });
-      if (zonefile.found) {
-        res.json(zonefile.result);
-      } else {
-        res.status(404).json({ error: 'No such zonefile' });
+  router.get(
+    '/:name/zonefile/:zoneFileHash',
+    asyncHandler(async (req, res, next) => {
+      // Fetches the historical zonefile specified by the username and zone hash.
+      const { name, zoneFileHash } = req.params;
+      const includeUnanchored = isUnanchoredRequest(req, res, next);
+      let nameFound = false;
+      const nameQuery = await db.getName({ name: name, includeUnanchored });
+      nameFound = nameQuery.found;
+      if (!nameFound) {
+        const subdomainQuery = await db.getSubdomain({ subdomain: name, includeUnanchored });
+        nameFound = subdomainQuery.found;
       }
-    } else {
-      res.status(400).json({ error: 'Invalid name or subdomain' });
-    }
-  });
 
-  router.getAsync('/:name/zonefile', async (req, res, next) => {
-    // Fetch a user’s raw zone file. This only works for RFC-compliant zone files. This method returns an error for names that have non-standard zone files.
-    const { name } = req.params;
-    const includeUnanchored = isUnanchoredRequest(req, res, next);
-    let nameFound = false;
-    const nameQuery = await db.getName({ name: name, includeUnanchored });
-    nameFound = nameQuery.found;
-    if (!nameFound) {
-      const subdomainQuery = await db.getSubdomain({ subdomain: name, includeUnanchored });
-      nameFound = subdomainQuery.found;
-    }
-
-    if (nameFound) {
-      const zonefile = await db.getLatestZoneFile({ name: name, includeUnanchored });
-      if (zonefile.found) {
-        res.json(zonefile.result);
+      if (nameFound) {
+        const zonefile = await db.getHistoricalZoneFile({ name: name, zoneFileHash: zoneFileHash });
+        if (zonefile.found) {
+          res.json(zonefile.result);
+        } else {
+          res.status(404).json({ error: 'No such zonefile' });
+        }
       } else {
-        res.status(404).json({ error: 'No zone file for name' });
+        res.status(400).json({ error: 'Invalid name or subdomain' });
       }
-    } else {
-      res.status(400).json({ error: 'Invalid name or subdomain' });
-    }
-  });
+    })
+  );
 
-  router.getAsync('/', async (req, res, next) => {
-    const page = parsePagingQueryInput(req.query.page ?? 0);
-    const includeUnanchored = isUnanchoredRequest(req, res, next);
-    const { results } = await db.getNamesList({ page, includeUnanchored });
-    if (results.length === 0 && req.query.page) {
-      res.status(400).json(BnsErrors.InvalidPageNumber);
-    }
-    res.json(results);
-  });
+  router.get(
+    '/:name/zonefile',
+    asyncHandler(async (req, res, next) => {
+      // Fetch a user’s raw zone file. This only works for RFC-compliant zone files. This method returns an error for names that have non-standard zone files.
+      const { name } = req.params;
+      const includeUnanchored = isUnanchoredRequest(req, res, next);
+      let nameFound = false;
+      const nameQuery = await db.getName({ name: name, includeUnanchored });
+      nameFound = nameQuery.found;
+      if (!nameFound) {
+        const subdomainQuery = await db.getSubdomain({ subdomain: name, includeUnanchored });
+        nameFound = subdomainQuery.found;
+      }
 
-  router.getAsync('/:name', async (req, res, next) => {
-    const { name } = req.params;
-    const includeUnanchored = isUnanchoredRequest(req, res, next);
-    let nameInfoResponse: BnsGetNameInfoResponse;
-    // Subdomain case
-    if (name.split('.').length == 3) {
-      const subdomainQuery = await db.getSubdomain({ subdomain: name, includeUnanchored });
-      if (!subdomainQuery.found) {
-        const namePart = name.split('.').slice(1).join('.');
-        const resolverResult = await db.getSubdomainResolver({ name: namePart });
-        if (resolverResult.found) {
-          if (resolverResult.result === '') {
-            return res.status(404).json({ error: `missing resolver from a malformed zonefile` });
+      if (nameFound) {
+        const zonefile = await db.getLatestZoneFile({ name: name, includeUnanchored });
+        if (zonefile.found) {
+          res.json(zonefile.result);
+        } else {
+          res.status(404).json({ error: 'No zone file for name' });
+        }
+      } else {
+        res.status(400).json({ error: 'Invalid name or subdomain' });
+      }
+    })
+  );
+
+  router.get(
+    '/',
+    asyncHandler(async (req, res, next) => {
+      const page = parsePagingQueryInput(req.query.page ?? 0);
+      const includeUnanchored = isUnanchoredRequest(req, res, next);
+      const { results } = await db.getNamesList({ page, includeUnanchored });
+      if (results.length === 0 && req.query.page) {
+        res.status(400).json(BnsErrors.InvalidPageNumber);
+      }
+      res.json(results);
+    })
+  );
+
+  router.get(
+    '/:name',
+    asyncHandler(async (req, res, next) => {
+      const { name } = req.params;
+      const includeUnanchored = isUnanchoredRequest(req, res, next);
+      let nameInfoResponse: BnsGetNameInfoResponse;
+      // Subdomain case
+      if (name.split('.').length == 3) {
+        const subdomainQuery = await db.getSubdomain({ subdomain: name, includeUnanchored });
+        if (!subdomainQuery.found) {
+          const namePart = name.split('.').slice(1).join('.');
+          const resolverResult = await db.getSubdomainResolver({ name: namePart });
+          if (resolverResult.found) {
+            if (resolverResult.result === '') {
+              res.status(404).json({ error: `missing resolver from a malformed zonefile` });
+              return;
+            }
+            res.redirect(`${resolverResult.result}/v1/names${req.url}`);
+            next();
+            return;
           }
-          res.redirect(`${resolverResult.result}/v1/names${req.url}`);
-          next();
+          res.status(404).json({ error: `cannot find subdomain ${name}` });
           return;
         }
-        return res.status(404).json({ error: `cannot find subdomain ${name}` });
-      }
-      const { result } = subdomainQuery;
+        const { result } = subdomainQuery;
 
-      nameInfoResponse = {
-        address: result.owner,
-        blockchain: bnsBlockchain,
-        last_txid: result.tx_id,
-        resolver: result.resolver,
-        status: 'registered_subdomain',
-        zonefile: result.zonefile,
-        zonefile_hash: result.zonefile_hash,
-      };
-    } else {
-      const nameQuery = await db.getName({ name, includeUnanchored: includeUnanchored });
-      if (!nameQuery.found) {
-        return res.status(404).json({ error: `cannot find name ${name}` });
+        nameInfoResponse = {
+          address: result.owner,
+          blockchain: bnsBlockchain,
+          last_txid: result.tx_id,
+          resolver: result.resolver,
+          status: 'registered_subdomain',
+          zonefile: result.zonefile,
+          zonefile_hash: result.zonefile_hash,
+        };
+      } else {
+        const nameQuery = await db.getName({ name, includeUnanchored: includeUnanchored });
+        if (!nameQuery.found) {
+          res.status(404).json({ error: `cannot find name ${name}` });
+          return;
+        }
+        const { result } = nameQuery;
+        nameInfoResponse = {
+          address: result.address,
+          blockchain: bnsBlockchain,
+          expire_block: result.expire_block,
+          grace_period: result.grace_period,
+          last_txid: result.tx_id ? result.tx_id : '',
+          resolver: result.resolver,
+          status: result.status ? result.status : '',
+          zonefile: result.zonefile,
+          zonefile_hash: result.zonefile_hash,
+        };
       }
-      const { result } = nameQuery;
-      nameInfoResponse = {
-        address: result.address,
-        blockchain: bnsBlockchain,
-        expire_block: result.expire_block,
-        grace_period: result.grace_period,
-        last_txid: result.tx_id ? result.tx_id : '',
-        resolver: result.resolver,
-        status: result.status ? result.status : '',
-        zonefile: result.zonefile,
-        zonefile_hash: result.zonefile_hash,
-      };
-    }
 
-    const response = Object.fromEntries(
-      Object.entries(nameInfoResponse).filter(([_, v]) => v != null)
-    );
-    res.json(response);
-  });
+      const response = Object.fromEntries(
+        Object.entries(nameInfoResponse).filter(([_, v]) => v != null)
+      );
+      res.json(response);
+    })
+  );
 
   return router;
 }

--- a/src/api/routes/bns/namespaces.ts
+++ b/src/api/routes/bns/namespaces.ts
@@ -1,42 +1,49 @@
 import * as express from 'express';
-import { RouterWithAsync, addAsync } from '@awaitjs/express';
+import { asyncHandler } from '../../async-handler';
 import { DataStore } from '../../../datastore/common';
 import { parsePagingQueryInput } from '../../../api/pagination';
 import { isUnanchoredRequest } from '../../query-helpers';
 import { BnsErrors } from '../../../bns-constants';
 import { BnsGetAllNamespacesResponse } from '@stacks/stacks-blockchain-api-types';
 
-export function createBnsNamespacesRouter(db: DataStore): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createBnsNamespacesRouter(db: DataStore): express.Router {
+  const router = express.Router();
 
-  router.getAsync('/', async (req, res, next) => {
-    const includeUnanchored = isUnanchoredRequest(req, res, next);
-    const { results } = await db.getNamespaceList({ includeUnanchored });
-    const response: BnsGetAllNamespacesResponse = {
-      namespaces: results,
-    };
-    return res.json(response);
-  });
+  router.get(
+    '/',
+    asyncHandler(async (req, res, next) => {
+      const includeUnanchored = isUnanchoredRequest(req, res, next);
+      const { results } = await db.getNamespaceList({ includeUnanchored });
+      const response: BnsGetAllNamespacesResponse = {
+        namespaces: results,
+      };
+      res.json(response);
+      return;
+    })
+  );
 
-  router.getAsync('/:tld/names', async (req, res, next) => {
-    const { tld } = req.params;
-    const page = parsePagingQueryInput(req.query.page ?? 0);
-    const includeUnanchored = isUnanchoredRequest(req, res, next);
-    const response = await db.getNamespace({ namespace: tld, includeUnanchored });
-    if (!response.found) {
-      res.status(404).json(BnsErrors.NoSuchNamespace);
-    } else {
-      const { results } = await db.getNamespaceNamesList({
-        namespace: tld,
-        page,
-        includeUnanchored,
-      });
-      if (results.length === 0 && req.query.page) {
-        res.status(400).json(BnsErrors.InvalidPageNumber);
+  router.get(
+    '/:tld/names',
+    asyncHandler(async (req, res, next) => {
+      const { tld } = req.params;
+      const page = parsePagingQueryInput(req.query.page ?? 0);
+      const includeUnanchored = isUnanchoredRequest(req, res, next);
+      const response = await db.getNamespace({ namespace: tld, includeUnanchored });
+      if (!response.found) {
+        res.status(404).json(BnsErrors.NoSuchNamespace);
+      } else {
+        const { results } = await db.getNamespaceNamesList({
+          namespace: tld,
+          page,
+          includeUnanchored,
+        });
+        if (results.length === 0 && req.query.page) {
+          res.status(400).json(BnsErrors.InvalidPageNumber);
+        }
+        res.json(results);
       }
-      res.json(results);
-    }
-  });
+    })
+  );
 
   return router;
 }

--- a/src/api/routes/bns/pricing.ts
+++ b/src/api/routes/bns/pricing.ts
@@ -1,5 +1,5 @@
 import * as express from 'express';
-import { RouterWithAsync, addAsync } from '@awaitjs/express';
+import { asyncHandler } from '../../async-handler';
 import { DataStore, DbBnsNamespace } from '../../../datastore/common';
 import {
   makeRandomPrivKey,
@@ -21,101 +21,109 @@ import {
 } from '@stacks/stacks-blockchain-api-types';
 import { isValidPrincipal, logger } from './../../../helpers';
 
-export function createBnsPriceRouter(db: DataStore, chainId: ChainID): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createBnsPriceRouter(db: DataStore, chainId: ChainID): express.Router {
+  const router = express.Router();
   const stacksNetwork = GetStacksNetwork(chainId);
 
-  router.getAsync('/namespaces/:namespace', async (req, res) => {
-    const { namespace } = req.params;
-    if (namespace.length > 20) {
-      res.status(400).json({ error: 'Invalid namespace' });
-      return;
-    }
-    const randomPrivKey = makeRandomPrivKey();
-    const address = getAddressFromPrivateKey(
-      randomPrivKey.data,
-      chainId === ChainID.Mainnet ? TransactionVersion.Mainnet : TransactionVersion.Testnet
-    );
-    const bnsContractIdentifier = getBnsContractID(chainId);
-    if (!bnsContractIdentifier || !isValidPrincipal(bnsContractIdentifier)) {
-      logger.error('BNS contract ID not properly configured');
-      return res.status(500).json({ error: 'BNS contract ID not properly configured' });
-    }
+  router.get(
+    '/namespaces/:namespace',
+    asyncHandler(async (req, res) => {
+      const { namespace } = req.params;
+      if (namespace.length > 20) {
+        res.status(400).json({ error: 'Invalid namespace' });
+        return;
+      }
+      const randomPrivKey = makeRandomPrivKey();
+      const address = getAddressFromPrivateKey(
+        randomPrivKey.data,
+        chainId === ChainID.Mainnet ? TransactionVersion.Mainnet : TransactionVersion.Testnet
+      );
+      const bnsContractIdentifier = getBnsContractID(chainId);
+      if (!bnsContractIdentifier || !isValidPrincipal(bnsContractIdentifier)) {
+        logger.error('BNS contract ID not properly configured');
+        res.status(500).json({ error: 'BNS contract ID not properly configured' });
+        return;
+      }
 
-    const [bnsContractAddress, bnsContractName] = bnsContractIdentifier.split('.');
+      const [bnsContractAddress, bnsContractName] = bnsContractIdentifier.split('.');
 
-    const txOptions: ReadOnlyFunctionOptions = {
-      senderAddress: address,
-      contractAddress: bnsContractAddress,
-      contractName: bnsContractName,
-      functionName: 'get-namespace-price',
-      functionArgs: [bufferCVFromString(namespace)],
-      network: stacksNetwork,
-    };
-    const contractCallTx = await callReadOnlyFunction(txOptions);
-    if (
-      contractCallTx.type == ClarityType.ResponseOk &&
-      contractCallTx.value.type == ClarityType.UInt
-    ) {
-      const response: BnsGetNamespacePriceResponse = {
-        units: 'STX',
-        amount: contractCallTx.value.value.toString(10),
+      const txOptions: ReadOnlyFunctionOptions = {
+        senderAddress: address,
+        contractAddress: bnsContractAddress,
+        contractName: bnsContractName,
+        functionName: 'get-namespace-price',
+        functionArgs: [bufferCVFromString(namespace)],
+        network: stacksNetwork,
       };
-      res.json(response);
-    } else {
-      res.status(400).json({ error: 'Invalid namespace' });
-    }
-  });
+      const contractCallTx = await callReadOnlyFunction(txOptions);
+      if (
+        contractCallTx.type == ClarityType.ResponseOk &&
+        contractCallTx.value.type == ClarityType.UInt
+      ) {
+        const response: BnsGetNamespacePriceResponse = {
+          units: 'STX',
+          amount: contractCallTx.value.value.toString(10),
+        };
+        res.json(response);
+      } else {
+        res.status(400).json({ error: 'Invalid namespace' });
+      }
+    })
+  );
 
-  router.getAsync('/names/:name', async (req, res) => {
-    const input = req.params.name;
-    if (!input.includes('.')) {
-      res.status(400).json({ error: 'Invalid name' });
-      return;
-    }
-    const split = input.split('.');
-    if (split.length != 2) {
-      res.status(400).json({ error: 'Invalid name' });
-      return;
-    }
-    const name = split[0];
-    const namespace = split[1];
-    const randomPrivKey = makeRandomPrivKey();
-    const address = getAddressFromPrivateKey(
-      randomPrivKey.data,
-      chainId === ChainID.Mainnet ? TransactionVersion.Mainnet : TransactionVersion.Testnet
-    );
+  router.get(
+    '/names/:name',
+    asyncHandler(async (req, res) => {
+      const input = req.params.name;
+      if (!input.includes('.')) {
+        res.status(400).json({ error: 'Invalid name' });
+        return;
+      }
+      const split = input.split('.');
+      if (split.length != 2) {
+        res.status(400).json({ error: 'Invalid name' });
+        return;
+      }
+      const name = split[0];
+      const namespace = split[1];
+      const randomPrivKey = makeRandomPrivKey();
+      const address = getAddressFromPrivateKey(
+        randomPrivKey.data,
+        chainId === ChainID.Mainnet ? TransactionVersion.Mainnet : TransactionVersion.Testnet
+      );
 
-    const bnsContractIdentifier = getBnsContractID(chainId);
-    if (!bnsContractIdentifier || !isValidPrincipal(bnsContractIdentifier)) {
-      logger.error('BNS contract ID not properly configured');
-      return res.status(500).json({ error: 'BNS contract ID not properly configured' });
-    }
+      const bnsContractIdentifier = getBnsContractID(chainId);
+      if (!bnsContractIdentifier || !isValidPrincipal(bnsContractIdentifier)) {
+        logger.error('BNS contract ID not properly configured');
+        res.status(500).json({ error: 'BNS contract ID not properly configured' });
+        return;
+      }
 
-    const [bnsContractAddress, bnsContractName] = bnsContractIdentifier.split('.');
-    const txOptions: ReadOnlyFunctionOptions = {
-      senderAddress: address,
-      contractAddress: bnsContractAddress,
-      contractName: bnsContractName,
-      functionName: 'get-name-price',
-      functionArgs: [bufferCVFromString(namespace), bufferCVFromString(name)],
-      network: stacksNetwork,
-    };
-
-    const contractCall = await callReadOnlyFunction(txOptions);
-    if (
-      contractCall.type == ClarityType.ResponseOk &&
-      contractCall.value.type == ClarityType.UInt
-    ) {
-      const response: BnsGetNamePriceResponse = {
-        units: 'STX',
-        amount: contractCall.value.value.toString(10),
+      const [bnsContractAddress, bnsContractName] = bnsContractIdentifier.split('.');
+      const txOptions: ReadOnlyFunctionOptions = {
+        senderAddress: address,
+        contractAddress: bnsContractAddress,
+        contractName: bnsContractName,
+        functionName: 'get-name-price',
+        functionArgs: [bufferCVFromString(namespace), bufferCVFromString(name)],
+        network: stacksNetwork,
       };
-      res.json(response);
-    } else {
-      res.status(400).json({ error: 'Invalid name' });
-    }
-  });
+
+      const contractCall = await callReadOnlyFunction(txOptions);
+      if (
+        contractCall.type == ClarityType.ResponseOk &&
+        contractCall.value.type == ClarityType.UInt
+      ) {
+        const response: BnsGetNamePriceResponse = {
+          units: 'STX',
+          amount: contractCall.value.value.toString(10),
+        };
+        res.json(response);
+      } else {
+        res.status(400).json({ error: 'Invalid name' });
+      }
+    })
+  );
 
   return router;
 }

--- a/src/api/routes/burnchain.ts
+++ b/src/api/routes/burnchain.ts
@@ -1,5 +1,5 @@
 import * as express from 'express';
-import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { asyncHandler } from '../async-handler';
 import {
   BurnchainReward,
   BurnchainRewardListResponse,
@@ -19,173 +19,188 @@ const parseQueryLimit = parseLimitQuery({
   errorMsg: '`limit` must be equal to or less than ' + MAX_BLOCKS_PER_REQUEST,
 });
 
-export function createBurnchainRouter(db: DataStore): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createBurnchainRouter(db: DataStore): express.Router {
+  const router = express.Router();
 
-  router.getAsync('/reward_slot_holders', async (req, res) => {
-    const limit = parseQueryLimit(req.query.limit ?? 96);
-    const offset = parsePagingQueryInput(req.query.offset ?? 0);
+  router.get(
+    '/reward_slot_holders',
+    asyncHandler(async (req, res) => {
+      const limit = parseQueryLimit(req.query.limit ?? 96);
+      const offset = parsePagingQueryInput(req.query.offset ?? 0);
 
-    const queryResults = await db.getBurnchainRewardSlotHolders({ offset, limit });
-    const results = queryResults.slotHolders.map(r => {
-      const slotHolder: BurnchainRewardSlotHolder = {
-        canonical: r.canonical,
-        burn_block_hash: r.burn_block_hash,
-        burn_block_height: r.burn_block_height,
-        address: r.address,
-        slot_index: r.slot_index,
+      const queryResults = await db.getBurnchainRewardSlotHolders({ offset, limit });
+      const results = queryResults.slotHolders.map(r => {
+        const slotHolder: BurnchainRewardSlotHolder = {
+          canonical: r.canonical,
+          burn_block_hash: r.burn_block_hash,
+          burn_block_height: r.burn_block_height,
+          address: r.address,
+          slot_index: r.slot_index,
+        };
+        return slotHolder;
+      });
+      const response: BurnchainRewardSlotHolderListResponse = {
+        limit,
+        offset,
+        total: queryResults.total,
+        results: results,
       };
-      return slotHolder;
-    });
-    const response: BurnchainRewardSlotHolderListResponse = {
-      limit,
-      offset,
-      total: queryResults.total,
-      results: results,
-    };
-    res.json(response);
-  });
+      res.json(response);
+    })
+  );
 
-  router.getAsync('/reward_slot_holders/:address', async (req, res) => {
-    const limit = parseQueryLimit(req.query.limit ?? 96);
-    const offset = parsePagingQueryInput(req.query.offset ?? 0);
-    const { address } = req.params;
+  router.get(
+    '/reward_slot_holders/:address',
+    asyncHandler(async (req, res) => {
+      const limit = parseQueryLimit(req.query.limit ?? 96);
+      const offset = parsePagingQueryInput(req.query.offset ?? 0);
+      const { address } = req.params;
 
-    let burnchainAddress: string | undefined = undefined;
-    const queryAddr = address.trim();
-    if (isValidBitcoinAddress(queryAddr)) {
-      burnchainAddress = queryAddr;
-    } else {
-      const convertedAddr = tryConvertC32ToBtc(queryAddr);
-      if (convertedAddr) {
-        burnchainAddress = convertedAddr;
+      let burnchainAddress: string | undefined = undefined;
+      const queryAddr = address.trim();
+      if (isValidBitcoinAddress(queryAddr)) {
+        burnchainAddress = queryAddr;
+      } else {
+        const convertedAddr = tryConvertC32ToBtc(queryAddr);
+        if (convertedAddr) {
+          burnchainAddress = convertedAddr;
+        }
       }
-    }
-    if (!burnchainAddress) {
-      res
-        .status(400)
-        .json({ error: `Address ${queryAddr} is not a valid Bitcoin or STX address.` });
-      return;
-    }
-
-    const queryResults = await db.getBurnchainRewardSlotHolders({
-      offset,
-      limit,
-      burnchainAddress,
-    });
-    const results = queryResults.slotHolders.map(r => {
-      const slotHolder: BurnchainRewardSlotHolder = {
-        canonical: r.canonical,
-        burn_block_hash: r.burn_block_hash,
-        burn_block_height: r.burn_block_height,
-        address: r.address,
-        slot_index: r.slot_index,
-      };
-      return slotHolder;
-    });
-    const response: BurnchainRewardSlotHolderListResponse = {
-      limit,
-      offset,
-      total: queryResults.total,
-      results: results,
-    };
-    res.json(response);
-  });
-
-  router.getAsync('/rewards', async (req, res) => {
-    const limit = parseQueryLimit(req.query.limit ?? 96);
-    const offset = parsePagingQueryInput(req.query.offset ?? 0);
-
-    const queryResults = await db.getBurnchainRewards({ offset, limit });
-    const results = queryResults.map(r => {
-      const reward: BurnchainReward = {
-        canonical: r.canonical,
-        burn_block_hash: r.burn_block_hash,
-        burn_block_height: r.burn_block_height,
-        burn_amount: r.burn_amount.toString(),
-        reward_recipient: r.reward_recipient,
-        reward_amount: r.reward_amount.toString(),
-        reward_index: r.reward_index,
-      };
-      return reward;
-    });
-    const response: BurnchainRewardListResponse = { limit, offset, results };
-    // TODO: schema validation
-    res.json(response);
-  });
-
-  router.getAsync('/rewards/:address', async (req, res) => {
-    const limit = parseQueryLimit(req.query.limit ?? 96);
-    const offset = parsePagingQueryInput(req.query.offset ?? 0);
-    const { address } = req.params;
-
-    let burnchainAddress: string | undefined = undefined;
-    const queryAddr = address.trim();
-    if (isValidBitcoinAddress(queryAddr)) {
-      burnchainAddress = queryAddr;
-    } else {
-      const convertedAddr = tryConvertC32ToBtc(queryAddr);
-      if (convertedAddr) {
-        burnchainAddress = convertedAddr;
+      if (!burnchainAddress) {
+        res
+          .status(400)
+          .json({ error: `Address ${queryAddr} is not a valid Bitcoin or STX address.` });
+        return;
       }
-    }
-    if (!burnchainAddress) {
-      res
-        .status(400)
-        .json({ error: `Address ${queryAddr} is not a valid Bitcoin or STX address.` });
-      return;
-    }
 
-    const queryResults = await db.getBurnchainRewards({
-      burnchainRecipient: burnchainAddress,
-      offset,
-      limit,
-    });
-    const results = queryResults.map(r => {
-      const reward: BurnchainReward = {
-        canonical: r.canonical,
-        burn_block_hash: r.burn_block_hash,
-        burn_block_height: r.burn_block_height,
-        burn_amount: r.burn_amount.toString(),
-        reward_recipient: r.reward_recipient,
-        reward_amount: r.reward_amount.toString(),
-        reward_index: r.reward_index,
+      const queryResults = await db.getBurnchainRewardSlotHolders({
+        offset,
+        limit,
+        burnchainAddress,
+      });
+      const results = queryResults.slotHolders.map(r => {
+        const slotHolder: BurnchainRewardSlotHolder = {
+          canonical: r.canonical,
+          burn_block_hash: r.burn_block_hash,
+          burn_block_height: r.burn_block_height,
+          address: r.address,
+          slot_index: r.slot_index,
+        };
+        return slotHolder;
+      });
+      const response: BurnchainRewardSlotHolderListResponse = {
+        limit,
+        offset,
+        total: queryResults.total,
+        results: results,
       };
-      return reward;
-    });
-    const response: BurnchainRewardListResponse = { limit, offset, results };
-    // TODO: schema validation
-    res.json(response);
-  });
+      res.json(response);
+    })
+  );
 
-  router.getAsync('/rewards/:address/total', async (req, res) => {
-    const { address } = req.params;
+  router.get(
+    '/rewards',
+    asyncHandler(async (req, res) => {
+      const limit = parseQueryLimit(req.query.limit ?? 96);
+      const offset = parsePagingQueryInput(req.query.offset ?? 0);
 
-    let burnchainAddress: string | undefined = undefined;
-    const queryAddr = address.trim();
-    if (isValidBitcoinAddress(queryAddr)) {
-      burnchainAddress = queryAddr;
-    } else {
-      const convertedAddr = tryConvertC32ToBtc(queryAddr);
-      if (convertedAddr) {
-        burnchainAddress = convertedAddr;
+      const queryResults = await db.getBurnchainRewards({ offset, limit });
+      const results = queryResults.map(r => {
+        const reward: BurnchainReward = {
+          canonical: r.canonical,
+          burn_block_hash: r.burn_block_hash,
+          burn_block_height: r.burn_block_height,
+          burn_amount: r.burn_amount.toString(),
+          reward_recipient: r.reward_recipient,
+          reward_amount: r.reward_amount.toString(),
+          reward_index: r.reward_index,
+        };
+        return reward;
+      });
+      const response: BurnchainRewardListResponse = { limit, offset, results };
+      // TODO: schema validation
+      res.json(response);
+    })
+  );
+
+  router.get(
+    '/rewards/:address',
+    asyncHandler(async (req, res) => {
+      const limit = parseQueryLimit(req.query.limit ?? 96);
+      const offset = parsePagingQueryInput(req.query.offset ?? 0);
+      const { address } = req.params;
+
+      let burnchainAddress: string | undefined = undefined;
+      const queryAddr = address.trim();
+      if (isValidBitcoinAddress(queryAddr)) {
+        burnchainAddress = queryAddr;
+      } else {
+        const convertedAddr = tryConvertC32ToBtc(queryAddr);
+        if (convertedAddr) {
+          burnchainAddress = convertedAddr;
+        }
       }
-    }
-    if (!burnchainAddress) {
-      res
-        .status(400)
-        .json({ error: `Address ${queryAddr} is not a valid Bitcoin or STX address.` });
-      return;
-    }
+      if (!burnchainAddress) {
+        res
+          .status(400)
+          .json({ error: `Address ${queryAddr} is not a valid Bitcoin or STX address.` });
+        return;
+      }
 
-    const queryResults = await db.getBurnchainRewardsTotal(burnchainAddress);
-    const response: BurnchainRewardsTotal = {
-      reward_recipient: queryResults.reward_recipient,
-      reward_amount: queryResults.reward_amount.toString(),
-    };
-    // TODO: schema validation
-    res.json(response);
-  });
+      const queryResults = await db.getBurnchainRewards({
+        burnchainRecipient: burnchainAddress,
+        offset,
+        limit,
+      });
+      const results = queryResults.map(r => {
+        const reward: BurnchainReward = {
+          canonical: r.canonical,
+          burn_block_hash: r.burn_block_hash,
+          burn_block_height: r.burn_block_height,
+          burn_amount: r.burn_amount.toString(),
+          reward_recipient: r.reward_recipient,
+          reward_amount: r.reward_amount.toString(),
+          reward_index: r.reward_index,
+        };
+        return reward;
+      });
+      const response: BurnchainRewardListResponse = { limit, offset, results };
+      // TODO: schema validation
+      res.json(response);
+    })
+  );
+
+  router.get(
+    '/rewards/:address/total',
+    asyncHandler(async (req, res) => {
+      const { address } = req.params;
+
+      let burnchainAddress: string | undefined = undefined;
+      const queryAddr = address.trim();
+      if (isValidBitcoinAddress(queryAddr)) {
+        burnchainAddress = queryAddr;
+      } else {
+        const convertedAddr = tryConvertC32ToBtc(queryAddr);
+        if (convertedAddr) {
+          burnchainAddress = convertedAddr;
+        }
+      }
+      if (!burnchainAddress) {
+        res
+          .status(400)
+          .json({ error: `Address ${queryAddr} is not a valid Bitcoin or STX address.` });
+        return;
+      }
+
+      const queryResults = await db.getBurnchainRewardsTotal(burnchainAddress);
+      const response: BurnchainRewardsTotal = {
+        reward_recipient: queryResults.reward_recipient,
+        reward_amount: queryResults.reward_amount.toString(),
+      };
+      // TODO: schema validation
+      res.json(response);
+    })
+  );
 
   return router;
 }

--- a/src/api/routes/contract.ts
+++ b/src/api/routes/contract.ts
@@ -1,5 +1,5 @@
 import * as express from 'express';
-import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { asyncHandler } from '../async-handler';
 import { DataStore } from '../../datastore/common';
 import { parseLimitQuery, parsePagingQueryInput } from '../pagination';
 import { parseDbEvent } from '../controllers/db-controller';
@@ -12,55 +12,68 @@ const parseContractEventsQueryLimit = parseLimitQuery({
   errorMsg: '`limit` must be equal to or less than ' + MAX_EVENTS_PER_REQUEST,
 });
 
-export function createContractRouter(db: DataStore): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createContractRouter(db: DataStore): express.Router {
+  const router = express.Router();
 
-  router.getAsync('/by_trait', async (req, res, next) => {
-    const trait_abi = parseTraitAbi(req, res, next);
-    const limit = parseContractEventsQueryLimit(req.query.limit ?? 20);
-    const offset = parsePagingQueryInput(req.query.offset ?? 0);
-    const smartContracts = await db.getSmartContractByTrait({
-      trait: trait_abi,
-      limit,
-      offset,
-    });
-    if (!smartContracts.found) {
-      res.status(404).json({ error: `cannot find contract for this trait` });
-      return;
-    }
-    const contractResults = smartContracts.result.map(contract => ({
-      ...contract,
-      abi: JSON.stringify(contract.abi),
-    }));
-    res.json({ limit, offset, results: contractResults });
-  });
+  router.get(
+    '/by_trait',
+    asyncHandler(async (req, res, next) => {
+      const trait_abi = parseTraitAbi(req, res, next);
+      const limit = parseContractEventsQueryLimit(req.query.limit ?? 20);
+      const offset = parsePagingQueryInput(req.query.offset ?? 0);
+      const smartContracts = await db.getSmartContractByTrait({
+        trait: trait_abi,
+        limit,
+        offset,
+      });
+      if (!smartContracts.found) {
+        res.status(404).json({ error: `cannot find contract for this trait` });
+        return;
+      }
+      const contractResults = smartContracts.result.map(contract => ({
+        ...contract,
+        abi: JSON.stringify(contract.abi),
+      }));
+      res.json({ limit, offset, results: contractResults });
+    })
+  );
 
-  router.getAsync('/:contract_id', async (req, res) => {
-    const { contract_id } = req.params;
-    const contractQuery = await db.getSmartContract(contract_id);
-    if (!contractQuery.found) {
-      res.status(404).json({ error: `cannot find contract by ID ${contract_id}` });
-      return;
-    }
-    const contractResult = {
-      ...contractQuery.result,
-      abi: JSON.stringify(contractQuery.result.abi),
-    };
-    res.json(contractResult);
-  });
+  router.get(
+    '/:contract_id',
+    asyncHandler(async (req, res) => {
+      const { contract_id } = req.params;
+      const contractQuery = await db.getSmartContract(contract_id);
+      if (!contractQuery.found) {
+        res.status(404).json({ error: `cannot find contract by ID ${contract_id}` });
+        return;
+      }
+      const contractResult = {
+        ...contractQuery.result,
+        abi: JSON.stringify(contractQuery.result.abi),
+      };
+      res.json(contractResult);
+    })
+  );
 
-  router.getAsync('/:contract_id/events', async (req, res) => {
-    const { contract_id } = req.params;
-    const limit = parseContractEventsQueryLimit(req.query.limit ?? 20);
-    const offset = parsePagingQueryInput(req.query.offset ?? 0);
-    const eventsQuery = await db.getSmartContractEvents({ contractId: contract_id, limit, offset });
-    if (!eventsQuery.found) {
-      res.status(404).json({ error: `cannot find events for contract by ID: ${contract_id}` });
-      return;
-    }
-    const parsedEvents = eventsQuery.result.map(event => parseDbEvent(event));
-    res.json({ limit, offset, results: parsedEvents });
-  });
+  router.get(
+    '/:contract_id/events',
+    asyncHandler(async (req, res) => {
+      const { contract_id } = req.params;
+      const limit = parseContractEventsQueryLimit(req.query.limit ?? 20);
+      const offset = parsePagingQueryInput(req.query.offset ?? 0);
+      const eventsQuery = await db.getSmartContractEvents({
+        contractId: contract_id,
+        limit,
+        offset,
+      });
+      if (!eventsQuery.found) {
+        res.status(404).json({ error: `cannot find events for contract by ID: ${contract_id}` });
+        return;
+      }
+      const parsedEvents = eventsQuery.result.map(event => parseDbEvent(event));
+      res.json({ limit, offset, results: parsedEvents });
+    })
+  );
 
   return router;
 }

--- a/src/api/routes/faucets.ts
+++ b/src/api/routes/faucets.ts
@@ -1,6 +1,6 @@
 import * as process from 'process';
 import * as express from 'express';
-import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { asyncHandler } from '../async-handler';
 import * as btc from 'bitcoinjs-lib';
 import PQueue from 'p-queue';
 import * as BN from 'bn.js';
@@ -59,57 +59,63 @@ function clientFromNetwork(network: StacksNetwork): StacksCoreRpcClient {
   return new StacksCoreRpcClient({ host: coreUrl.hostname, port: coreUrl.port });
 }
 
-export function createFaucetRouter(db: DataStore): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createFaucetRouter(db: DataStore): express.Router {
+  const router = express.Router();
   router.use(express.urlencoded({ extended: true }));
   router.use(express.json());
 
   const btcFaucetRequestQueue = new PQueue({ concurrency: 1 });
 
-  router.postAsync('/btc', async (req, res) => {
-    await btcFaucetRequestQueue.add(async () => {
-      const address: string = req.query.address || req.body.address;
-      const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+  router.post(
+    '/btc',
+    asyncHandler(async (req, res) => {
+      await btcFaucetRequestQueue.add(async () => {
+        const address: string = req.query.address || req.body.address;
+        const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
 
-      // Guard condition: requests are limited to 5 times per 5 minutes.
-      // Only based on address for now, but we're keeping the IP in case
-      // we want to escalate and implement a per IP policy
-      const lastRequests = await db.getBTCFaucetRequests(address);
-      const now = Date.now();
-      const window = 5 * 60 * 1000; // 5 minutes
-      const requestsInWindow = lastRequests.results
-        .map(r => now - r.occurred_at)
-        .filter(r => r <= window);
-      if (requestsInWindow.length >= 5) {
-        logger.warn(`BTC faucet rate limit hit for address ${address}`);
-        res.status(429).json({
-          error: 'Too many requests',
-          success: false,
+        // Guard condition: requests are limited to 5 times per 5 minutes.
+        // Only based on address for now, but we're keeping the IP in case
+        // we want to escalate and implement a per IP policy
+        const lastRequests = await db.getBTCFaucetRequests(address);
+        const now = Date.now();
+        const window = 5 * 60 * 1000; // 5 minutes
+        const requestsInWindow = lastRequests.results
+          .map(r => now - r.occurred_at)
+          .filter(r => r <= window);
+        if (requestsInWindow.length >= 5) {
+          logger.warn(`BTC faucet rate limit hit for address ${address}`);
+          res.status(429).json({
+            error: 'Too many requests',
+            success: false,
+          });
+          return;
+        }
+
+        const tx = await makeBtcFaucetPayment(btc.networks.regtest, address, 0.5);
+        await db.insertFaucetRequest({
+          ip: `${ip}`,
+          address: address,
+          currency: DbFaucetRequestCurrency.BTC,
+          occurred_at: now,
         });
-        return;
-      }
 
-      const tx = await makeBtcFaucetPayment(btc.networks.regtest, address, 0.5);
-      await db.insertFaucetRequest({
-        ip: `${ip}`,
-        address: address,
-        currency: DbFaucetRequestCurrency.BTC,
-        occurred_at: now,
+        res.json({
+          txid: tx.txId,
+          raw_tx: tx.rawTx,
+          success: true,
+        });
       });
+    })
+  );
 
-      res.json({
-        txid: tx.txId,
-        raw_tx: tx.rawTx,
-        success: true,
-      });
-    });
-  });
-
-  router.getAsync('/btc/:address', async (req, res) => {
-    const { address } = req.params;
-    const balance = await getBtcBalance(btc.networks.regtest, address);
-    res.json({ balance });
-  });
+  router.get(
+    '/btc/:address',
+    asyncHandler(async (req, res) => {
+      const { address } = req.params;
+      const balance = await getBtcBalance(btc.networks.regtest, address);
+      res.json({ balance });
+    })
+  );
 
   const stxFaucetRequestQueue = new PQueue({ concurrency: 1 });
 
@@ -120,161 +126,166 @@ export function createFaucetRouter(db: DataStore): RouterWithAsync {
   const FAUCET_STACKING_WINDOW = 2 * 24 * 60 * 60 * 1000; // 2 days
   const FAUCET_STACKING_TRIGGER_COUNT = 1;
 
-  router.postAsync('/stx', async (req, res) => {
-    await stxFaucetRequestQueue.add(async () => {
-      const address: string = req.query.address || req.body.address;
-      const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
-      const lastRequests = await db.getSTXFaucetRequests(address);
+  router.post(
+    '/stx',
+    asyncHandler(async (req, res) => {
+      await stxFaucetRequestQueue.add(async () => {
+        const address: string = req.query.address || req.body.address;
+        const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+        const lastRequests = await db.getSTXFaucetRequests(address);
 
-      const privateKey = process.env.FAUCET_PRIVATE_KEY || testnetKeys[0].secretKey;
+        const privateKey = process.env.FAUCET_PRIVATE_KEY || testnetKeys[0].secretKey;
 
-      const isStackingReq =
-        req.query['stacking'] === 'true' || [true, 'true'].includes(req.body['stacking']);
+        const isStackingReq =
+          req.query['stacking'] === 'true' || [true, 'true'].includes(req.body['stacking']);
 
-      // Guard condition: requests are limited to x times per y minutes.
-      // Only based on address for now, but we're keeping the IP in case
-      // we want to escalate and implement a per IP policy
-      const now = Date.now();
-      const [window, triggerCount] = isStackingReq
-        ? [FAUCET_STACKING_WINDOW, FAUCET_STACKING_TRIGGER_COUNT]
-        : [FAUCET_DEFAULT_WINDOW, FAUCET_DEFAULT_TRIGGER_COUNT];
+        // Guard condition: requests are limited to x times per y minutes.
+        // Only based on address for now, but we're keeping the IP in case
+        // we want to escalate and implement a per IP policy
+        const now = Date.now();
+        const [window, triggerCount] = isStackingReq
+          ? [FAUCET_STACKING_WINDOW, FAUCET_STACKING_TRIGGER_COUNT]
+          : [FAUCET_DEFAULT_WINDOW, FAUCET_DEFAULT_TRIGGER_COUNT];
 
-      const requestsInWindow = lastRequests.results
-        .map(r => now - r.occurred_at)
-        .filter(r => r <= window);
-      if (requestsInWindow.length >= triggerCount) {
-        logger.warn(`STX faucet rate limit hit for address ${address}`);
-        res.status(429).json({
-          error: 'Too many requests',
-          success: false,
-        });
-        return;
-      }
-
-      const networks = getStxFaucetNetworks();
-
-      const stxAmounts: bigint[] = [];
-      for (const network of networks) {
-        try {
-          let stxAmount = FAUCET_DEFAULT_STX_AMOUNT;
-          if (isStackingReq) {
-            const poxInfo = await clientFromNetwork(network).getPox();
-            stxAmount = BigInt(poxInfo.min_amount_ustx);
-            const padPercent = new BigNumber(0.2);
-            const padAmount = new BigNumber(stxAmount.toString())
-              .times(padPercent)
-              .integerValue()
-              .toString();
-            stxAmount = stxAmount + BigInt(padAmount);
-          }
-          stxAmounts.push(stxAmount);
-        } catch (error) {
-          // ignore
+        const requestsInWindow = lastRequests.results
+          .map(r => now - r.occurred_at)
+          .filter(r => r <= window);
+        if (requestsInWindow.length >= triggerCount) {
+          logger.warn(`STX faucet rate limit hit for address ${address}`);
+          res.status(429).json({
+            error: 'Too many requests',
+            success: false,
+          });
+          return;
         }
-      }
-      const stxAmount = intMax(stxAmounts);
 
-      const generateTx = async (network: StacksNetwork, nonce?: bigint, fee?: bigint) => {
-        const txOpts: SignedTokenTransferOptions = {
-          recipient: address,
-          amount: new BN(stxAmount.toString()),
-          senderKey: privateKey,
-          network: network,
-          memo: 'Faucet',
-          anchorMode: AnchorMode.Any,
-        };
-        if (fee !== undefined) {
-          txOpts.fee = fee;
-        }
-        if (nonce !== undefined) {
-          txOpts.nonce = nonce;
-        }
-        return await makeSTXTokenTransfer(txOpts);
-      };
+        const networks = getStxFaucetNetworks();
 
-      const nonces: bigint[] = [];
-      const fees: bigint[] = [];
-      let txGenFetchError: Error | undefined;
-      for (const network of networks) {
-        try {
-          const tx = await generateTx(network);
-          nonces.push(tx.auth.spendingCondition?.nonce ?? BigInt(0));
-          fees.push(tx.auth.getFee());
-        } catch (error: any) {
-          txGenFetchError = error;
-        }
-      }
-      if (nonces.length === 0) {
-        throw txGenFetchError;
-      }
-      let nextNonce = intMax(nonces);
-      const fee = intMax(fees);
-
-      const sendTxResults: TxSendResult[] = [];
-      let retrySend = false;
-      let sendSuccess: { txId: string; txRaw: string } | undefined;
-      let lastSendError: Error | undefined;
-      do {
-        const tx = await generateTx(networks[0], nextNonce, fee);
-        const rawTx = tx.serialize();
+        const stxAmounts: bigint[] = [];
         for (const network of networks) {
-          const rpcClient = clientFromNetwork(network);
           try {
-            const res = await rpcClient.sendTransaction(rawTx);
-            sendSuccess = { txId: res.txId, txRaw: rawTx.toString('hex') };
-            sendTxResults.push({
-              status: TxSendResultStatus.Success,
-              txId: res.txId,
-            });
+            let stxAmount = FAUCET_DEFAULT_STX_AMOUNT;
+            if (isStackingReq) {
+              const poxInfo = await clientFromNetwork(network).getPox();
+              stxAmount = BigInt(poxInfo.min_amount_ustx);
+              const padPercent = new BigNumber(0.2);
+              const padAmount = new BigNumber(stxAmount.toString())
+                .times(padPercent)
+                .integerValue()
+                .toString();
+              stxAmount = stxAmount + BigInt(padAmount);
+            }
+            stxAmounts.push(stxAmount);
+          } catch (error) {
+            // ignore
+          }
+        }
+        const stxAmount = intMax(stxAmounts);
+
+        const generateTx = async (network: StacksNetwork, nonce?: bigint, fee?: bigint) => {
+          const txOpts: SignedTokenTransferOptions = {
+            recipient: address,
+            amount: new BN(stxAmount.toString()),
+            senderKey: privateKey,
+            network: network,
+            memo: 'Faucet',
+            anchorMode: AnchorMode.Any,
+          };
+          if (fee !== undefined) {
+            txOpts.fee = fee;
+          }
+          if (nonce !== undefined) {
+            txOpts.nonce = nonce;
+          }
+          return await makeSTXTokenTransfer(txOpts);
+        };
+
+        const nonces: bigint[] = [];
+        const fees: bigint[] = [];
+        let txGenFetchError: Error | undefined;
+        for (const network of networks) {
+          try {
+            const tx = await generateTx(network);
+            nonces.push(tx.auth.spendingCondition?.nonce ?? BigInt(0));
+            fees.push(tx.auth.getFee());
           } catch (error: any) {
-            lastSendError = error;
-            if (error.message?.includes('ConflictingNonceInMempool')) {
+            txGenFetchError = error;
+          }
+        }
+        if (nonces.length === 0) {
+          throw txGenFetchError;
+        }
+        let nextNonce = intMax(nonces);
+        const fee = intMax(fees);
+
+        const sendTxResults: TxSendResult[] = [];
+        let retrySend = false;
+        let sendSuccess: { txId: string; txRaw: string } | undefined;
+        let lastSendError: Error | undefined;
+        do {
+          const tx = await generateTx(networks[0], nextNonce, fee);
+          const rawTx = tx.serialize();
+          for (const network of networks) {
+            const rpcClient = clientFromNetwork(network);
+            try {
+              const res = await rpcClient.sendTransaction(rawTx);
+              sendSuccess = { txId: res.txId, txRaw: rawTx.toString('hex') };
               sendTxResults.push({
-                status: TxSendResultStatus.ConflictingNonce,
-                error,
+                status: TxSendResultStatus.Success,
+                txId: res.txId,
               });
-            } else {
-              sendTxResults.push({
-                status: TxSendResultStatus.Error,
-                error,
-              });
+            } catch (error: any) {
+              lastSendError = error;
+              if (error.message?.includes('ConflictingNonceInMempool')) {
+                sendTxResults.push({
+                  status: TxSendResultStatus.ConflictingNonce,
+                  error,
+                });
+              } else {
+                sendTxResults.push({
+                  status: TxSendResultStatus.Error,
+                  error,
+                });
+              }
             }
           }
-        }
-        if (sendTxResults.every(res => res.status === TxSendResultStatus.Success)) {
-          retrySend = false;
-        } else if (sendTxResults.every(res => res.status === TxSendResultStatus.ConflictingNonce)) {
-          retrySend = true;
-          sendTxResults.length = 0;
-          nextNonce = nextNonce + 1n;
-        } else {
-          retrySend = false;
-        }
-      } while (retrySend);
+          if (sendTxResults.every(res => res.status === TxSendResultStatus.Success)) {
+            retrySend = false;
+          } else if (
+            sendTxResults.every(res => res.status === TxSendResultStatus.ConflictingNonce)
+          ) {
+            retrySend = true;
+            sendTxResults.length = 0;
+            nextNonce = nextNonce + 1n;
+          } else {
+            retrySend = false;
+          }
+        } while (retrySend);
 
-      if (!sendSuccess) {
-        if (lastSendError) {
-          throw lastSendError;
+        if (!sendSuccess) {
+          if (lastSendError) {
+            throw lastSendError;
+          } else {
+            throw new Error(`Unexpected failure to send or capture error`);
+          }
         } else {
-          throw new Error(`Unexpected failure to send or capture error`);
+          const response: RunFaucetResponse = {
+            success: true,
+            txId: sendSuccess.txId,
+            txRaw: sendSuccess.txRaw,
+          };
+          res.json(response);
         }
-      } else {
-        const response: RunFaucetResponse = {
-          success: true,
-          txId: sendSuccess.txId,
-          txRaw: sendSuccess.txRaw,
-        };
-        res.json(response);
-      }
 
-      await db.insertFaucetRequest({
-        ip: `${ip}`,
-        address: address,
-        currency: DbFaucetRequestCurrency.STX,
-        occurred_at: now,
+        await db.insertFaucetRequest({
+          ip: `${ip}`,
+          address: address,
+          currency: DbFaucetRequestCurrency.STX,
+          occurred_at: now,
+        });
       });
-    });
-  });
+    })
+  );
 
   return router;
 }

--- a/src/api/routes/fee-rate.ts
+++ b/src/api/routes/fee-rate.ts
@@ -1,12 +1,11 @@
 import * as express from 'express';
-import { addAsync, RouterWithAsync } from '@awaitjs/express';
 import { DataStore } from '../../datastore/common';
 import { FeeRate } from '@stacks/stacks-blockchain-api-types';
 
 export const FEE_RATE = 400;
 
-export function createFeeRateRouter(_: DataStore): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createFeeRateRouter(_: DataStore): express.Router {
+  const router = express.Router();
 
   router.post('/', (req, res) => {
     //validate and use req.body.transaction when we want to use it

--- a/src/api/routes/microblock.ts
+++ b/src/api/routes/microblock.ts
@@ -1,5 +1,5 @@
 import * as express from 'express';
-import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { asyncHandler } from '../async-handler';
 import {
   Microblock,
   MicroblockListResponse,
@@ -22,50 +22,59 @@ const parseMicroblockQueryLimit = parseLimitQuery({
   errorMsg: '`limit` must be equal to or less than ' + MAX_MICROBLOCKS_PER_REQUEST,
 });
 
-export function createMicroblockRouter(db: DataStore): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createMicroblockRouter(db: DataStore): express.Router {
+  const router = express.Router();
 
-  router.getAsync('/', async (req, res) => {
-    const limit = parseMicroblockQueryLimit(req.query.limit ?? 20);
-    const offset = parsePagingQueryInput(req.query.offset ?? 0);
-    const query = await getMicroblocksFromDataStore({ db, offset, limit });
-    const response: MicroblockListResponse = {
-      limit,
-      offset,
-      total: query.total,
-      results: query.result,
-    };
+  router.get(
+    '/',
+    asyncHandler(async (req, res) => {
+      const limit = parseMicroblockQueryLimit(req.query.limit ?? 20);
+      const offset = parsePagingQueryInput(req.query.offset ?? 0);
+      const query = await getMicroblocksFromDataStore({ db, offset, limit });
+      const response: MicroblockListResponse = {
+        limit,
+        offset,
+        total: query.total,
+        results: query.result,
+      };
 
-    // TODO: block schema validation
-    res.json(response);
-  });
+      // TODO: block schema validation
+      res.json(response);
+    })
+  );
 
-  router.getAsync('/:hash', async (req, res) => {
-    const { hash } = req.params;
+  router.get(
+    '/:hash',
+    asyncHandler(async (req, res) => {
+      const { hash } = req.params;
 
-    if (!has0xPrefix(hash)) {
-      return res.redirect('/extended/v1/microblock/0x' + hash);
-    }
+      if (!has0xPrefix(hash)) {
+        return res.redirect('/extended/v1/microblock/0x' + hash);
+      }
 
-    const block = await getMicroblockFromDataStore({ db, microblockHash: hash });
-    if (!block.found) {
-      res.status(404).json({ error: `cannot find microblock by hash ${hash}` });
-      return;
-    }
-    const response: Microblock = block.result;
-    // TODO: block schema validation
-    res.json(response);
-  });
+      const block = await getMicroblockFromDataStore({ db, microblockHash: hash });
+      if (!block.found) {
+        res.status(404).json({ error: `cannot find microblock by hash ${hash}` });
+        return;
+      }
+      const response: Microblock = block.result;
+      // TODO: block schema validation
+      res.json(response);
+    })
+  );
 
-  router.getAsync('/unanchored/txs', async (req, res) => {
-    // TODO: implement pagination for /unanchored/txs
-    const txs = await getUnanchoredTxsFromDataStore(db);
-    const response: UnanchoredTransactionListResponse = {
-      total: txs.length,
-      results: txs,
-    };
-    res.json(response);
-  });
+  router.get(
+    '/unanchored/txs',
+    asyncHandler(async (req, res) => {
+      // TODO: implement pagination for /unanchored/txs
+      const txs = await getUnanchoredTxsFromDataStore(db);
+      const response: UnanchoredTransactionListResponse = {
+        total: txs.length,
+        results: txs,
+      };
+      res.json(response);
+    })
+  );
 
   return router;
 }

--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -1,5 +1,5 @@
 import * as express from 'express';
-import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { asyncHandler } from '../../async-handler';
 import { DataStore, DbBlock } from '../../../datastore/common';
 import { has0xPrefix, FoundOrNot } from '../../../helpers';
 import {
@@ -16,113 +16,124 @@ import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../ros
 import { ChainID } from '@stacks/transactions';
 import { StacksCoreRpcClient } from '../../../core-rpc/client';
 
-export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): express.Router {
+  const router = express.Router();
   router.use(express.json());
 
-  router.postAsync('/balance', async (req, res) => {
-    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
-    if (!valid.valid) {
-      res.status(500).json(makeRosettaError(valid));
-      return;
-    }
-
-    const accountIdentifier: RosettaAccount = req.body.account_identifier;
-    const subAccountIdentifier: RosettaSubAccount = req.body.account_identifier.sub_account;
-    const blockIdentifier: RosettaBlockIdentifier = req.body.block_identifier;
-    let blockQuery: FoundOrNot<DbBlock>;
-    let blockHash: string = '0x';
-
-    if (accountIdentifier === undefined) {
-      return res.status(500).json(RosettaErrors[RosettaErrorsTypes.emptyAccountIdentifier]);
-    }
-
-    // we need to return the block height/hash in the response, so we
-    // need to fetch the block first.
-    if (blockIdentifier === undefined) {
-      blockQuery = await db.getCurrentBlock();
-    } else if (blockIdentifier.index > 0) {
-      blockQuery = await db.getBlock({ height: blockIdentifier.index });
-    } else if (blockIdentifier.hash !== undefined) {
-      blockHash = blockIdentifier.hash;
-      if (!has0xPrefix(blockHash)) {
-        blockHash = '0x' + blockHash;
+  router.post(
+    '/balance',
+    asyncHandler(async (req, res) => {
+      const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
+      if (!valid.valid) {
+        res.status(500).json(makeRosettaError(valid));
+        return;
       }
-      blockQuery = await db.getBlock({ hash: blockHash });
-    } else {
-      return res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidBlockIdentifier]);
-    }
 
-    if (!blockQuery.found) {
-      return res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
-    }
+      const accountIdentifier: RosettaAccount = req.body.account_identifier;
+      const subAccountIdentifier: RosettaSubAccount = req.body.account_identifier.sub_account;
+      const blockIdentifier: RosettaBlockIdentifier = req.body.block_identifier;
+      let blockQuery: FoundOrNot<DbBlock>;
+      let blockHash: string = '0x';
 
-    const block = blockQuery.result;
-
-    if (blockIdentifier?.hash !== undefined && block.block_hash !== blockIdentifier.hash) {
-      return res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidBlockHash]);
-    }
-
-    const stxBalance = await db.getStxBalanceAtBlock(accountIdentifier.address, block.block_height);
-    // return spendable balance (liquid) if no sub-account is specified
-    let balance = (stxBalance.balance - stxBalance.locked).toString();
-
-    const accountInfo = await new StacksCoreRpcClient().getAccount(accountIdentifier.address);
-
-    const extra_metadata: any = {};
-
-    if (subAccountIdentifier !== undefined) {
-      switch (subAccountIdentifier.address) {
-        case RosettaConstants.StackedBalance:
-          const lockedBalance = stxBalance.locked;
-          balance = lockedBalance.toString();
-          break;
-        case RosettaConstants.SpendableBalance:
-          const spendableBalance = stxBalance.balance - stxBalance.locked;
-          balance = spendableBalance.toString();
-          break;
-        case RosettaConstants.VestingLockedBalance:
-        case RosettaConstants.VestingUnlockedBalance:
-          const stxVesting = await db.getTokenOfferingLocked(
-            accountIdentifier.address,
-            block.block_height
-          );
-          if (stxVesting.found) {
-            const vestingInfo = getVestingInfo(stxVesting.result);
-            balance = vestingInfo[subAccountIdentifier.address].toString();
-            extra_metadata[RosettaConstants.VestingSchedule] =
-              vestingInfo[RosettaConstants.VestingSchedule];
-          } else {
-            balance = '0';
-          }
-          break;
-        default:
-          return res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidSubAccount]);
+      if (accountIdentifier === undefined) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.emptyAccountIdentifier]);
+        return;
       }
-    }
 
-    const response: RosettaAccountBalanceResponse = {
-      block_identifier: {
-        index: block.block_height,
-        hash: block.block_hash,
-      },
-      balances: [
-        {
-          value: balance,
-          currency: {
-            symbol: RosettaConstants.symbol,
-            decimals: RosettaConstants.decimals,
-          },
-          metadata: Object.keys(extra_metadata).length > 0 ? extra_metadata : undefined,
+      // we need to return the block height/hash in the response, so we
+      // need to fetch the block first.
+      if (blockIdentifier === undefined) {
+        blockQuery = await db.getCurrentBlock();
+      } else if (blockIdentifier.index > 0) {
+        blockQuery = await db.getBlock({ height: blockIdentifier.index });
+      } else if (blockIdentifier.hash !== undefined) {
+        blockHash = blockIdentifier.hash;
+        if (!has0xPrefix(blockHash)) {
+          blockHash = '0x' + blockHash;
+        }
+        blockQuery = await db.getBlock({ hash: blockHash });
+      } else {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidBlockIdentifier]);
+        return;
+      }
+
+      if (!blockQuery.found) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
+        return;
+      }
+
+      const block = blockQuery.result;
+
+      if (blockIdentifier?.hash !== undefined && block.block_hash !== blockIdentifier.hash) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidBlockHash]);
+        return;
+      }
+
+      const stxBalance = await db.getStxBalanceAtBlock(
+        accountIdentifier.address,
+        block.block_height
+      );
+      // return spendable balance (liquid) if no sub-account is specified
+      let balance = (stxBalance.balance - stxBalance.locked).toString();
+
+      const accountInfo = await new StacksCoreRpcClient().getAccount(accountIdentifier.address);
+
+      const extra_metadata: any = {};
+
+      if (subAccountIdentifier !== undefined) {
+        switch (subAccountIdentifier.address) {
+          case RosettaConstants.StackedBalance:
+            const lockedBalance = stxBalance.locked;
+            balance = lockedBalance.toString();
+            break;
+          case RosettaConstants.SpendableBalance:
+            const spendableBalance = stxBalance.balance - stxBalance.locked;
+            balance = spendableBalance.toString();
+            break;
+          case RosettaConstants.VestingLockedBalance:
+          case RosettaConstants.VestingUnlockedBalance:
+            const stxVesting = await db.getTokenOfferingLocked(
+              accountIdentifier.address,
+              block.block_height
+            );
+            if (stxVesting.found) {
+              const vestingInfo = getVestingInfo(stxVesting.result);
+              balance = vestingInfo[subAccountIdentifier.address].toString();
+              extra_metadata[RosettaConstants.VestingSchedule] =
+                vestingInfo[RosettaConstants.VestingSchedule];
+            } else {
+              balance = '0';
+            }
+            break;
+          default:
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidSubAccount]);
+            return;
+        }
+      }
+
+      const response: RosettaAccountBalanceResponse = {
+        block_identifier: {
+          index: block.block_height,
+          hash: block.block_hash,
         },
-      ],
-      metadata: {
-        sequence_number: accountInfo.nonce ? accountInfo.nonce : 0,
-      },
-    };
+        balances: [
+          {
+            value: balance,
+            currency: {
+              symbol: RosettaConstants.symbol,
+              decimals: RosettaConstants.decimals,
+            },
+            metadata: Object.keys(extra_metadata).length > 0 ? extra_metadata : undefined,
+          },
+        ],
+        metadata: {
+          sequence_number: accountInfo.nonce ? accountInfo.nonce : 0,
+        },
+      };
 
-    res.json(response);
-  });
+      res.json(response);
+    })
+  );
 
   return router;
 }

--- a/src/api/routes/rosetta/block.ts
+++ b/src/api/routes/rosetta/block.ts
@@ -1,5 +1,5 @@
 import * as express from 'express';
-import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { asyncHandler } from '../../async-handler';
 import { RosettaBlock, RosettaBlockResponse } from '@stacks/stacks-blockchain-api-types';
 import { DataStore } from '../../../datastore/common';
 import {
@@ -11,55 +11,61 @@ import { RosettaErrors, RosettaErrorsTypes } from '../../rosetta-constants';
 import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../rosetta-validate';
 import { ChainID } from '@stacks/transactions';
 
-export function createRosettaBlockRouter(db: DataStore, chainId: ChainID): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createRosettaBlockRouter(db: DataStore, chainId: ChainID): express.Router {
+  const router = express.Router();
   router.use(express.json());
 
-  router.postAsync('/', async (req, res) => {
-    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
-    if (!valid.valid) {
-      res.status(500).json(makeRosettaError(valid));
-      return;
-    }
+  router.post(
+    '/',
+    asyncHandler(async (req, res) => {
+      const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
+      if (!valid.valid) {
+        res.status(500).json(makeRosettaError(valid));
+        return;
+      }
 
-    let block_hash = req.body.block_identifier?.hash;
-    const index = req.body.block_identifier?.index;
-    if (block_hash && !has0xPrefix(block_hash)) {
-      block_hash = '0x' + block_hash;
-    }
+      let block_hash = req.body.block_identifier?.hash;
+      const index = req.body.block_identifier?.index;
+      if (block_hash && !has0xPrefix(block_hash)) {
+        block_hash = '0x' + block_hash;
+      }
 
-    const block = await getRosettaBlockFromDataStore(db, true, block_hash, index);
+      const block = await getRosettaBlockFromDataStore(db, true, block_hash, index);
 
-    if (!block.found) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
-      return;
-    }
-    const blockResponse: RosettaBlockResponse = {
-      block: block.result,
-    };
-    res.json(blockResponse);
-  });
+      if (!block.found) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
+        return;
+      }
+      const blockResponse: RosettaBlockResponse = {
+        block: block.result,
+      };
+      res.json(blockResponse);
+    })
+  );
 
-  router.postAsync('/transaction', async (req, res) => {
-    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
-    if (!valid.valid) {
-      res.status(500).json(makeRosettaError(valid));
-      return;
-    }
+  router.post(
+    '/transaction',
+    asyncHandler(async (req, res) => {
+      const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
+      if (!valid.valid) {
+        res.status(500).json(makeRosettaError(valid));
+        return;
+      }
 
-    let tx_hash = req.body.transaction_identifier.hash;
-    if (!has0xPrefix(tx_hash)) {
-      tx_hash = '0x' + tx_hash;
-    }
+      let tx_hash = req.body.transaction_identifier.hash;
+      if (!has0xPrefix(tx_hash)) {
+        tx_hash = '0x' + tx_hash;
+      }
 
-    const transaction = await getRosettaTransactionFromDataStore(tx_hash, db);
-    if (!transaction.found) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotFound]);
-      return;
-    }
+      const transaction = await getRosettaTransactionFromDataStore(tx_hash, db);
+      if (!transaction.found) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotFound]);
+        return;
+      }
 
-    res.json(transaction.result);
-  });
+      res.json(transaction.result);
+    })
+  );
 
   return router;
 }

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -1,4 +1,4 @@
-import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { asyncHandler } from '../../async-handler';
 import { address as btcAddress } from 'bitcoinjs-lib';
 import * as BN from 'bn.js';
 import {
@@ -78,799 +78,823 @@ import {
 } from './../../../rosetta-helpers';
 import { makeRosettaError, rosettaValidateRequest, ValidSchema } from './../../rosetta-validate';
 
-export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID): express.Router {
+  const router = express.Router();
   router.use(express.json());
 
   //construction/derive endpoint
-  router.postAsync('/derive', async (req, res) => {
-    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
-    if (!valid.valid) {
-      //TODO have to fix this and make error generic
-      if (valid.error?.includes('should be equal to one of the allowed values')) {
-        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
-      }
-      res.status(500).json(makeRosettaError(valid));
-      return;
-    }
-
-    const publicKey: RosettaPublicKey = req.body.public_key;
-    const network: NetworkIdentifier = req.body.network_identifier;
-
-    if (has0xPrefix(publicKey.hex_bytes)) {
-      publicKey.hex_bytes = publicKey.hex_bytes.replace('0x', '');
-    }
-
-    try {
-      const btcAddress = publicKeyToBitcoinAddress(publicKey.hex_bytes, network.network);
-      if (btcAddress === undefined) {
-        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+  router.post(
+    '/derive',
+    asyncHandler(async (req, res) => {
+      const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
+      if (!valid.valid) {
+        //TODO have to fix this and make error generic
+        if (valid.error?.includes('should be equal to one of the allowed values')) {
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
+        }
+        res.status(500).json(makeRosettaError(valid));
         return;
       }
-      const stxAddress = bitcoinAddressToSTXAddress(btcAddress);
 
-      const accountIdentifier: RosettaAccountIdentifier = {
-        address: stxAddress,
-      };
-      const response: RosettaConstructionDeriveResponse = {
-        account_identifier: accountIdentifier,
-      };
-      res.json(response);
-    } catch (e) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
-    }
-  });
+      const publicKey: RosettaPublicKey = req.body.public_key;
+      const network: NetworkIdentifier = req.body.network_identifier;
+
+      if (has0xPrefix(publicKey.hex_bytes)) {
+        publicKey.hex_bytes = publicKey.hex_bytes.replace('0x', '');
+      }
+
+      try {
+        const btcAddress = publicKeyToBitcoinAddress(publicKey.hex_bytes, network.network);
+        if (btcAddress === undefined) {
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+          return;
+        }
+        const stxAddress = bitcoinAddressToSTXAddress(btcAddress);
+
+        const accountIdentifier: RosettaAccountIdentifier = {
+          address: stxAddress,
+        };
+        const response: RosettaConstructionDeriveResponse = {
+          account_identifier: accountIdentifier,
+        };
+        res.json(response);
+      } catch (e) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+      }
+    })
+  );
 
   //construction/preprocess endpoint
-  router.postAsync('/preprocess', async (req, res) => {
-    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
-    if (!valid.valid) {
-      res.status(500).json(makeRosettaError(valid));
-      return;
-    }
-
-    const operations: RosettaOperation[] = req.body.operations;
-
-    // Max operations should be 3 for one transaction
-    if (operations.length > 3) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
-      return;
-    }
-
-    if (!isSymbolSupported(req.body.operations)) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencySymbol]);
-      return;
-    }
-
-    if (!isDecimalsSupported(req.body.operations)) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencyDecimals]);
-      return;
-    }
-
-    const options = getOptionsFromOperations(req.body.operations);
-    if (options == null) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
-      return;
-    }
-
-    if (req.body.metadata) {
-      if (req.body.metadata.gas_limit) {
-        options.gas_limit = req.body.metadata.gas_limit;
+  router.post(
+    '/preprocess',
+    asyncHandler(async (req, res) => {
+      const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
+      if (!valid.valid) {
+        res.status(500).json(makeRosettaError(valid));
+        return;
       }
 
-      if (req.body.metadata.gas_price) {
-        options.gas_price = req.body.metadata.gas_price;
+      const operations: RosettaOperation[] = req.body.operations;
+
+      // Max operations should be 3 for one transaction
+      if (operations.length > 3) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+        return;
       }
 
-      if (req.body.suggested_fee_multiplier) {
-        options.suggested_fee_multiplier = req.body.suggested_fee_multiplier;
+      if (!isSymbolSupported(req.body.operations)) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencySymbol]);
+        return;
       }
-    }
 
-    if (req.body.max_fee) {
-      const max_fee: RosettaMaxFeeAmount = req.body.max_fee[0];
-      if (
-        max_fee.currency.symbol === RosettaConstants.symbol &&
-        max_fee.currency.decimals === RosettaConstants.decimals
-      ) {
-        options.max_fee = max_fee.value;
-      } else {
+      if (!isDecimalsSupported(req.body.operations)) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencyDecimals]);
+        return;
+      }
+
+      const options = getOptionsFromOperations(req.body.operations);
+      if (options == null) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+        return;
+      }
+
+      if (req.body.metadata) {
+        if (req.body.metadata.gas_limit) {
+          options.gas_limit = req.body.metadata.gas_limit;
+        }
+
+        if (req.body.metadata.gas_price) {
+          options.gas_price = req.body.metadata.gas_price;
+        }
+
+        if (req.body.suggested_fee_multiplier) {
+          options.suggested_fee_multiplier = req.body.suggested_fee_multiplier;
+        }
+      }
+
+      if (req.body.max_fee) {
+        const max_fee: RosettaMaxFeeAmount = req.body.max_fee[0];
+        if (
+          max_fee.currency.symbol === RosettaConstants.symbol &&
+          max_fee.currency.decimals === RosettaConstants.decimals
+        ) {
+          options.max_fee = max_fee.value;
+        } else {
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidFee]);
+          return;
+        }
+      }
+
+      let transaction: StacksTransaction;
+      switch (options.type) {
+        case RosettaOperationType.TokenTransfer:
+          // dummy transaction to calculate size
+          const dummyTokenTransferTx: UnsignedTokenTransferOptions = {
+            recipient: options.token_transfer_recipient_address as string,
+            amount: new BN(options.amount as string),
+            // We don't know the fee yet but need a placeholder
+            fee: new BN(0),
+            // placeholder public key
+            publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
+            network: getStacksNetwork(),
+            // We don't know the non yet but need a placeholder
+            nonce: new BN(0),
+            memo: req.body.metadata?.memo,
+            anchorMode: AnchorMode.Any,
+          };
+
+          transaction = await makeUnsignedSTXTokenTransfer(dummyTokenTransferTx);
+          break;
+        case RosettaOperationType.StackStx: {
+          if (!options.number_of_cycles) {
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+            return;
+          }
+
+          if (!options.pox_addr) {
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+            return;
+          }
+          // dummy transaction to calculate size
+          const poxAddress = options.pox_addr;
+          const { hashMode, data } = decodeBtcAddress(poxAddress);
+          const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
+          const hashbytes = bufferCV(data);
+          const poxAddressCV = tupleCV({
+            hashbytes,
+            version: hashModeBuffer,
+          });
+          if (!options.amount) {
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+            return;
+          }
+          const dummyStackingTx: UnsignedContractCallOptions = {
+            contractAddress: 'ST000000000000000000002AMW42H',
+            contractName: 'pox',
+            functionName: 'stack-stx',
+            publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
+            functionArgs: [
+              uintCV(options.amount),
+              poxAddressCV,
+              uintCV(0),
+              uintCV(options.number_of_cycles),
+            ],
+            validateWithAbi: false,
+            network: getStacksNetwork(),
+            fee: new BN(0),
+            nonce: new BN(0),
+            anchorMode: AnchorMode.Any,
+          };
+          transaction = await makeUnsignedContractCall(dummyStackingTx);
+          break;
+        }
+        case RosettaOperationType.DelegateStx: {
+          // dummy transaction to calculate size
+          if (!options.amount) {
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+            return;
+          }
+          if (!options.delegate_to) {
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+            return;
+          }
+
+          let optionalPoxAddressCV: OptionalCV = noneCV();
+          if (options.pox_addr) {
+            const dummyPoxAddress = options.pox_addr;
+            const { hashMode, data } = decodeBtcAddress(dummyPoxAddress);
+            const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
+            const hashbytes = bufferCV(data);
+            optionalPoxAddressCV = someCV(
+              tupleCV({
+                hashbytes,
+                version: hashModeBuffer,
+              })
+            );
+          }
+
+          const dummyStackingTx: UnsignedContractCallOptions = {
+            contractAddress: 'ST000000000000000000002AMW42H',
+            contractName: 'pox',
+            functionName: 'delegate-stx',
+            publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
+            functionArgs: [
+              uintCV(options.amount),
+              standardPrincipalCV(options.delegate_to),
+              noneCV(),
+              optionalPoxAddressCV,
+            ],
+            validateWithAbi: false,
+            network: getStacksNetwork(),
+            fee: new BN(0),
+            nonce: new BN(0),
+            anchorMode: AnchorMode.Any,
+          };
+          transaction = await makeUnsignedContractCall(dummyStackingTx);
+          break;
+        }
+        default:
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+          return;
+      }
+
+      const unsignedTransaction = transaction.serialize();
+
+      options.size = unsignedTransaction.length;
+
+      if (req.body.metadata?.memo) {
+        options.memo = req.body.metadata?.memo;
+      }
+
+      const rosettaPreprocessResponse: RosettaConstructionPreprocessResponse = {
+        options,
+        required_public_keys: [
+          {
+            address: options.sender_address as string,
+          },
+        ],
+      };
+      res.json(rosettaPreprocessResponse);
+    })
+  );
+
+  //construction/metadata endpoint
+  router.post(
+    '/metadata',
+    asyncHandler(async (req, res) => {
+      const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
+      if (!valid.valid) {
+        res.status(500).json(makeRosettaError(valid));
+        return;
+      }
+
+      const request: RosettaConstructionMetadataRequest = req.body;
+      const options: RosettaOptions = req.body.options;
+
+      if (options?.sender_address && !isValidC32Address(options.sender_address)) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidSender]);
+        return;
+      }
+      if (options?.symbol !== RosettaConstants.symbol) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencySymbol]);
+        return;
+      }
+
+      if (!options?.fee && options?.size === undefined) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingTransactionSize]);
+        return;
+      }
+
+      let response = {} as RosettaConstructionMetadataResponse;
+      switch (options.type) {
+        case RosettaOperationType.TokenTransfer:
+          const recipientAddress = options.token_transfer_recipient_address;
+          if (options?.decimals !== RosettaConstants.decimals) {
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencyDecimals]);
+            return;
+          }
+
+          if (recipientAddress == null || !isValidC32Address(recipientAddress)) {
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidRecipient]);
+            return;
+          }
+          break;
+        case RosettaOperationType.StackStx: {
+          // Getting stacking info
+          const poxInfo = await new StacksCoreRpcClient().getPox();
+          const coreInfo = await new StacksCoreRpcClient().getInfo();
+          const contractInfo = poxInfo.contract_id.split('.');
+          options.contract_address = contractInfo[0];
+          options.contract_name = contractInfo[1];
+          options.burn_block_height = coreInfo.burn_block_height;
+          break;
+        }
+        case RosettaOperationType.DelegateStx: {
+          // delegate stacking
+          const poxInfo = await new StacksCoreRpcClient().getPox();
+          const contractInfo = poxInfo.contract_id.split('.');
+          options.contract_address = contractInfo[0];
+          options.contract_name = contractInfo[1];
+          break;
+        }
+        default:
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionType]);
+          return;
+      }
+
+      if (typeof options.sender_address === 'undefined') {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingSenderAddress]);
+        return;
+      }
+      const stxAddress = options.sender_address;
+
+      // Getting nonce info
+      const accountInfo = await new StacksCoreRpcClient().getAccount(stxAddress);
+      const nonce = accountInfo.nonce;
+
+      let recentBlockHash = undefined;
+      const blockQuery: FoundOrNot<DbBlock> = await db.getCurrentBlock();
+      if (blockQuery.found) {
+        recentBlockHash = blockQuery.result.block_hash;
+      }
+
+      response = {
+        metadata: {
+          ...req.body.options,
+          account_sequence: nonce,
+          recent_block_hash: recentBlockHash,
+        },
+      };
+
+      // Getting fee info if not operation fee was given in /preprocess
+      const feeInfo = await new StacksCoreRpcClient().getEstimatedTransferFee();
+      if (feeInfo === undefined || feeInfo === '0') {
         res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidFee]);
         return;
       }
-    }
 
-    let transaction: StacksTransaction;
-    switch (options.type) {
-      case RosettaOperationType.TokenTransfer:
-        // dummy transaction to calculate size
-        const dummyTokenTransferTx: UnsignedTokenTransferOptions = {
-          recipient: options.token_transfer_recipient_address as string,
-          amount: new BN(options.amount as string),
-          // We don't know the fee yet but need a placeholder
-          fee: new BN(0),
-          // placeholder public key
-          publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
-          network: getStacksNetwork(),
-          // We don't know the non yet but need a placeholder
-          nonce: new BN(0),
-          memo: req.body.metadata?.memo,
-          anchorMode: AnchorMode.Any,
-        };
-
-        transaction = await makeUnsignedSTXTokenTransfer(dummyTokenTransferTx);
-        break;
-      case RosettaOperationType.StackStx: {
-        if (!options.number_of_cycles) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
-          return;
-        }
-
-        if (!options.pox_addr) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
-          return;
-        }
-        // dummy transaction to calculate size
-        const poxAddress = options.pox_addr;
-        const { hashMode, data } = decodeBtcAddress(poxAddress);
-        const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
-        const hashbytes = bufferCV(data);
-        const poxAddressCV = tupleCV({
-          hashbytes,
-          version: hashModeBuffer,
-        });
-        if (!options.amount) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
-          return;
-        }
-        const dummyStackingTx: UnsignedContractCallOptions = {
-          contractAddress: 'ST000000000000000000002AMW42H',
-          contractName: 'pox',
-          functionName: 'stack-stx',
-          publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
-          functionArgs: [
-            uintCV(options.amount),
-            poxAddressCV,
-            uintCV(0),
-            uintCV(options.number_of_cycles),
-          ],
-          validateWithAbi: false,
-          network: getStacksNetwork(),
-          fee: new BN(0),
-          nonce: new BN(0),
-          anchorMode: AnchorMode.Any,
-        };
-        transaction = await makeUnsignedContractCall(dummyStackingTx);
-        break;
-      }
-      case RosettaOperationType.DelegateStx: {
-        // dummy transaction to calculate size
-        if (!options.amount) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
-          return;
-        }
-        if (!options.delegate_to) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
-          return;
-        }
-
-        let optionalPoxAddressCV: OptionalCV = noneCV();
-        if (options.pox_addr) {
-          const dummyPoxAddress = options.pox_addr;
-          const { hashMode, data } = decodeBtcAddress(dummyPoxAddress);
-          const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
-          const hashbytes = bufferCV(data);
-          optionalPoxAddressCV = someCV(
-            tupleCV({
-              hashbytes,
-              version: hashModeBuffer,
-            })
-          );
-        }
-
-        const dummyStackingTx: UnsignedContractCallOptions = {
-          contractAddress: 'ST000000000000000000002AMW42H',
-          contractName: 'pox',
-          functionName: 'delegate-stx',
-          publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
-          functionArgs: [
-            uintCV(options.amount),
-            standardPrincipalCV(options.delegate_to),
-            noneCV(),
-            optionalPoxAddressCV,
-          ],
-          validateWithAbi: false,
-          network: getStacksNetwork(),
-          fee: new BN(0),
-          nonce: new BN(0),
-          anchorMode: AnchorMode.Any,
-        };
-        transaction = await makeUnsignedContractCall(dummyStackingTx);
-        break;
-      }
-      default:
-        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+      if (!options.size) {
+        res.status(500).json(RosettaErrorsTypes.missingTransactionSize);
         return;
-    }
-
-    const unsignedTransaction = transaction.serialize();
-
-    options.size = unsignedTransaction.length;
-
-    if (req.body.metadata?.memo) {
-      options.memo = req.body.metadata?.memo;
-    }
-
-    const rosettaPreprocessResponse: RosettaConstructionPreprocessResponse = {
-      options,
-      required_public_keys: [
-        {
-          address: options.sender_address as string,
-        },
-      ],
-    };
-    res.json(rosettaPreprocessResponse);
-  });
-
-  //construction/metadata endpoint
-  router.postAsync('/metadata', async (req, res) => {
-    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
-    if (!valid.valid) {
-      res.status(500).json(makeRosettaError(valid));
-      return;
-    }
-
-    const request: RosettaConstructionMetadataRequest = req.body;
-    const options: RosettaOptions = req.body.options;
-
-    if (options?.sender_address && !isValidC32Address(options.sender_address)) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidSender]);
-      return;
-    }
-    if (options?.symbol !== RosettaConstants.symbol) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencySymbol]);
-      return;
-    }
-
-    if (!options?.fee && options?.size === undefined) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingTransactionSize]);
-      return;
-    }
-
-    let response = {} as RosettaConstructionMetadataResponse;
-    switch (options.type) {
-      case RosettaOperationType.TokenTransfer:
-        const recipientAddress = options.token_transfer_recipient_address;
-        if (options?.decimals !== RosettaConstants.decimals) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencyDecimals]);
-          return;
-        }
-
-        if (recipientAddress == null || !isValidC32Address(recipientAddress)) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidRecipient]);
-          return;
-        }
-        break;
-      case RosettaOperationType.StackStx: {
-        // Getting stacking info
-        const poxInfo = await new StacksCoreRpcClient().getPox();
-        const coreInfo = await new StacksCoreRpcClient().getInfo();
-        const contractInfo = poxInfo.contract_id.split('.');
-        options.contract_address = contractInfo[0];
-        options.contract_name = contractInfo[1];
-        options.burn_block_height = coreInfo.burn_block_height;
-        break;
       }
-      case RosettaOperationType.DelegateStx: {
-        // delegate stacking
-        const poxInfo = await new StacksCoreRpcClient().getPox();
-        const contractInfo = poxInfo.contract_id.split('.');
-        options.contract_address = contractInfo[0];
-        options.contract_name = contractInfo[1];
-        break;
-      }
-      default:
-        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionType]);
-        return;
-    }
+      const feeValue = (BigInt(feeInfo) * BigInt(options.size)).toString();
+      const currency: RosettaCurrency = {
+        symbol: RosettaConstants.symbol,
+        decimals: RosettaConstants.decimals,
+      };
 
-    if (typeof options.sender_address === 'undefined') {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingSenderAddress]);
-      return;
-    }
-    const stxAddress = options.sender_address;
+      const fee: RosettaAmount = {
+        value: feeValue,
+        currency,
+      };
 
-    // Getting nonce info
-    const accountInfo = await new StacksCoreRpcClient().getAccount(stxAddress);
-    const nonce = accountInfo.nonce;
+      response.suggested_fee = [fee];
 
-    let recentBlockHash = undefined;
-    const blockQuery: FoundOrNot<DbBlock> = await db.getCurrentBlock();
-    if (blockQuery.found) {
-      recentBlockHash = blockQuery.result.block_hash;
-    }
-
-    response = {
-      metadata: {
-        ...req.body.options,
-        account_sequence: nonce,
-        recent_block_hash: recentBlockHash,
-      },
-    };
-
-    // Getting fee info if not operation fee was given in /preprocess
-    const feeInfo = await new StacksCoreRpcClient().getEstimatedTransferFee();
-    if (feeInfo === undefined || feeInfo === '0') {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidFee]);
-      return;
-    }
-
-    if (!options.size) {
-      res.status(500).json(RosettaErrorsTypes.missingTransactionSize);
-      return;
-    }
-    const feeValue = (BigInt(feeInfo) * BigInt(options.size)).toString();
-    const currency: RosettaCurrency = {
-      symbol: RosettaConstants.symbol,
-      decimals: RosettaConstants.decimals,
-    };
-
-    const fee: RosettaAmount = {
-      value: feeValue,
-      currency,
-    };
-
-    response.suggested_fee = [fee];
-
-    res.json(response);
-  });
+      res.json(response);
+    })
+  );
 
   //construction/hash endpoint
-  router.postAsync('/hash', async (req, res) => {
-    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
-    if (!valid.valid) {
-      res.status(500).json(makeRosettaError(valid));
-      return;
-    }
+  router.post(
+    '/hash',
+    asyncHandler(async (req, res) => {
+      const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
+      if (!valid.valid) {
+        res.status(500).json(makeRosettaError(valid));
+        return;
+      }
 
-    const request: RosettaConstructionHashRequest = req.body;
+      const request: RosettaConstructionHashRequest = req.body;
 
-    if (!has0xPrefix(request.signed_transaction)) {
-      request.signed_transaction = '0x' + request.signed_transaction;
-    }
+      if (!has0xPrefix(request.signed_transaction)) {
+        request.signed_transaction = '0x' + request.signed_transaction;
+      }
 
-    let buffer: Buffer;
-    try {
-      buffer = hexToBuffer(request.signed_transaction);
-    } catch (error) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
-      return;
-    }
+      let buffer: Buffer;
+      try {
+        buffer = hexToBuffer(request.signed_transaction);
+      } catch (error) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
+        return;
+      }
 
-    const transaction = deserializeTransaction(BufferReader.fromBuffer(buffer));
-    const hash = transaction.txid();
+      const transaction = deserializeTransaction(BufferReader.fromBuffer(buffer));
+      const hash = transaction.txid();
 
-    if (!transaction.auth.spendingCondition) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotSigned]);
-      return;
-    }
-    if (isSingleSig(transaction.auth.spendingCondition)) {
-      /**Single signature Transaction has an empty signature, so the transaction is not signed */
-      if (
-        !transaction.auth.spendingCondition.signature.data ||
-        emptyMessageSignature().data === transaction.auth.spendingCondition.signature.data
-      ) {
+      if (!transaction.auth.spendingCondition) {
         res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotSigned]);
         return;
       }
-    } else {
-      /**Multi-signature transaction does not have signature fields thus the transaction not signed */
-      if (transaction.auth.spendingCondition.fields.length === 0) {
-        res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotSigned]);
-        return;
-      }
-    }
-
-    const hashResponse: RosettaConstructionHashResponse = {
-      transaction_identifier: {
-        hash: '0x' + hash,
-      },
-    };
-    res.status(200).json(hashResponse);
-  });
-
-  //construction/parse endpoint
-  router.postAsync('/parse', async (req, res) => {
-    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
-    if (!valid.valid) {
-      res.status(500).json(makeRosettaError(valid));
-      return;
-    }
-    let inputTx = req.body.transaction;
-    const signed = req.body.signed;
-
-    if (!has0xPrefix(inputTx)) {
-      inputTx = '0x' + inputTx;
-    }
-
-    const transaction = rawTxToStacksTransaction(inputTx);
-    const checkSigned = isSignedTransaction(transaction);
-    if (signed != checkSigned) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidParams]);
-      return;
-    }
-    try {
-      const baseTx = rawTxToBaseTx(inputTx);
-      const operations = await getOperations(baseTx, db);
-      const txMemo = parseTransactionMemo(baseTx);
-      let response: RosettaConstructionParseResponse;
-      if (signed) {
-        response = {
-          operations: operations,
-          account_identifier_signers: getSigners(transaction),
-        };
+      if (isSingleSig(transaction.auth.spendingCondition)) {
+        /**Single signature Transaction has an empty signature, so the transaction is not signed */
+        if (
+          !transaction.auth.spendingCondition.signature.data ||
+          emptyMessageSignature().data === transaction.auth.spendingCondition.signature.data
+        ) {
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotSigned]);
+          return;
+        }
       } else {
-        response = {
-          operations: operations,
-        };
+        /**Multi-signature transaction does not have signature fields thus the transaction not signed */
+        if (transaction.auth.spendingCondition.fields.length === 0) {
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotSigned]);
+          return;
+        }
       }
-      if (txMemo) {
-        response.metadata = {
-          memo: txMemo,
-        };
-      }
-      res.json(response);
-    } catch (error) {
-      console.error(error);
-    }
-  });
 
-  //construction/submit endpoint
-  router.postAsync('/submit', async (req, res) => {
-    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
-    if (!valid.valid) {
-      res.status(500).json(makeRosettaError(valid));
-      return;
-    }
-    let transaction = req.body.signed_transaction;
-    let buffer: Buffer;
-
-    if (!has0xPrefix(transaction)) {
-      transaction = '0x' + transaction;
-    }
-
-    try {
-      buffer = hexToBuffer(transaction);
-    } catch (error) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
-      return;
-    }
-    try {
-      const submitResult = await new StacksCoreRpcClient().sendTransaction(buffer);
-      const response: RosettaConstructionSubmitResponse = {
+      const hashResponse: RosettaConstructionHashResponse = {
         transaction_identifier: {
-          hash: submitResult.txId,
+          hash: '0x' + hash,
         },
       };
-      res.status(200).json(response);
-    } catch (e: any) {
-      const err: RosettaError = {
-        ...RosettaErrors[RosettaErrorsTypes.invalidTransactionString],
-        details: { message: e.message },
-      };
-      res.status(500).json(err);
-    }
-  });
+      res.status(200).json(hashResponse);
+    })
+  );
+
+  //construction/parse endpoint
+  router.post(
+    '/parse',
+    asyncHandler(async (req, res) => {
+      const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
+      if (!valid.valid) {
+        res.status(500).json(makeRosettaError(valid));
+        return;
+      }
+      let inputTx = req.body.transaction;
+      const signed = req.body.signed;
+
+      if (!has0xPrefix(inputTx)) {
+        inputTx = '0x' + inputTx;
+      }
+
+      const transaction = rawTxToStacksTransaction(inputTx);
+      const checkSigned = isSignedTransaction(transaction);
+      if (signed != checkSigned) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidParams]);
+        return;
+      }
+      try {
+        const baseTx = rawTxToBaseTx(inputTx);
+        const operations = await getOperations(baseTx, db);
+        const txMemo = parseTransactionMemo(baseTx);
+        let response: RosettaConstructionParseResponse;
+        if (signed) {
+          response = {
+            operations: operations,
+            account_identifier_signers: getSigners(transaction),
+          };
+        } else {
+          response = {
+            operations: operations,
+          };
+        }
+        if (txMemo) {
+          response.metadata = {
+            memo: txMemo,
+          };
+        }
+        res.json(response);
+      } catch (error) {
+        console.error(error);
+      }
+    })
+  );
+
+  //construction/submit endpoint
+  router.post(
+    '/submit',
+    asyncHandler(async (req, res) => {
+      const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
+      if (!valid.valid) {
+        res.status(500).json(makeRosettaError(valid));
+        return;
+      }
+      let transaction = req.body.signed_transaction;
+      let buffer: Buffer;
+
+      if (!has0xPrefix(transaction)) {
+        transaction = '0x' + transaction;
+      }
+
+      try {
+        buffer = hexToBuffer(transaction);
+      } catch (error) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
+        return;
+      }
+      try {
+        const submitResult = await new StacksCoreRpcClient().sendTransaction(buffer);
+        const response: RosettaConstructionSubmitResponse = {
+          transaction_identifier: {
+            hash: submitResult.txId,
+          },
+        };
+        res.status(200).json(response);
+      } catch (e: any) {
+        const err: RosettaError = {
+          ...RosettaErrors[RosettaErrorsTypes.invalidTransactionString],
+          details: { message: e.message },
+        };
+        res.status(500).json(err);
+      }
+    })
+  );
 
   //construction/payloads endpoint
-  router.postAsync('/payloads', async (req, res) => {
-    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
-    if (!valid.valid) {
-      res.status(500).json(makeRosettaError(valid));
-      return;
-    }
-
-    const options = getOptionsFromOperations(req.body.operations);
-    if (options == null) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
-      return;
-    }
-
-    const amount = options.amount;
-    if (!amount) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidAmount]);
-      return;
-    }
-
-    if (!options.fee || typeof options.fee !== 'string') {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidFees]);
-      return;
-    }
-    const fee: string = options.fee;
-
-    const publicKeys: RosettaPublicKey[] = req.body.public_keys;
-    if (!publicKeys) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.emptyPublicKey]);
-      return;
-    }
-
-    const senderAddress = options.sender_address;
-    if (!senderAddress) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidSender]);
-      return;
-    }
-
-    if (!('metadata' in req.body) || !('account_sequence' in req.body.metadata)) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingNonce]);
-      return;
-    }
-
-    const nonce = new BN(req.body.metadata.account_sequence);
-
-    if (publicKeys.length !== 1) {
-      //TODO support multi-sig in the future.
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.needOnePublicKey]);
-      return;
-    }
-
-    if (publicKeys[0].curve_type !== 'secp256k1') {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
-      return;
-    }
-
-    if (has0xPrefix(publicKeys[0].hex_bytes)) {
-      publicKeys[0].hex_bytes = publicKeys[0].hex_bytes.slice(2);
-    }
-
-    let transaction: StacksTransaction;
-    switch (options.type) {
-      case RosettaOperationType.TokenTransfer: {
-        const recipientAddress = options.token_transfer_recipient_address;
-        if (!recipientAddress) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidRecipient]);
-          return;
-        }
-        // signel signature
-        const tokenTransferOptions: UnsignedTokenTransferOptions = {
-          recipient: recipientAddress,
-          amount: new BN(amount),
-          fee: new BN(fee),
-          publicKey: publicKeys[0].hex_bytes,
-          network: getStacksNetwork(),
-          nonce: nonce,
-          memo: req.body.metadata?.memo,
-          anchorMode: AnchorMode.Any,
-        };
-
-        transaction = await makeUnsignedSTXTokenTransfer(tokenTransferOptions);
-
-        break;
+  router.post(
+    '/payloads',
+    asyncHandler(async (req, res) => {
+      const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
+      if (!valid.valid) {
+        res.status(500).json(makeRosettaError(valid));
+        return;
       }
-      case RosettaOperationType.StackStx: {
-        if (!options.pox_addr) {
-          res.status(500).json(RosettaErrorsTypes.invalidOperation);
-          return;
-        }
-        const poxBTCAddress = options.pox_addr;
-        const { hashMode, data } = decodeBtcAddress(poxBTCAddress);
-        const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
-        const hashbytes = bufferCV(data);
-        const poxAddressCV = tupleCV({
-          hashbytes,
-          version: hashModeBuffer,
-        });
-        if (!options.amount) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
-          return;
-        }
-        if (!req.body.metadata.contract_address) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingContractAddress]);
-          return;
-        }
-        if (!req.body.metadata.contract_name) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingContractName]);
-          return;
-        }
-        if (!req.body.metadata.burn_block_height) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
-          return;
-        }
-        if (!options.number_of_cycles) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
-          return;
-        }
-        const stackingTx: UnsignedContractCallOptions = {
-          contractAddress: req.body.metadata.contract_address,
-          contractName: req.body.metadata.contract_name,
-          functionName: 'stack-stx',
-          publicKey: publicKeys[0].hex_bytes,
-          functionArgs: [
-            uintCV(options.amount),
-            poxAddressCV,
-            uintCV(req.body.metadata.burn_block_height),
-            uintCV(options.number_of_cycles),
-          ],
-          fee: new BN(options.fee),
-          nonce: nonce,
-          validateWithAbi: false,
-          network: getStacksNetwork(),
-          anchorMode: AnchorMode.Any,
-        };
-        transaction = await makeUnsignedContractCall(stackingTx);
-        break;
-      }
-      case RosettaOperationType.DelegateStx: {
-        let poxAddressCV: OptionalCV = noneCV();
 
-        if (options.pox_addr) {
+      const options = getOptionsFromOperations(req.body.operations);
+      if (options == null) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+        return;
+      }
+
+      const amount = options.amount;
+      if (!amount) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidAmount]);
+        return;
+      }
+
+      if (!options.fee || typeof options.fee !== 'string') {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidFees]);
+        return;
+      }
+      const fee: string = options.fee;
+
+      const publicKeys: RosettaPublicKey[] = req.body.public_keys;
+      if (!publicKeys) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.emptyPublicKey]);
+        return;
+      }
+
+      const senderAddress = options.sender_address;
+      if (!senderAddress) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidSender]);
+        return;
+      }
+
+      if (!('metadata' in req.body) || !('account_sequence' in req.body.metadata)) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingNonce]);
+        return;
+      }
+
+      const nonce = new BN(req.body.metadata.account_sequence);
+
+      if (publicKeys.length !== 1) {
+        //TODO support multi-sig in the future.
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.needOnePublicKey]);
+        return;
+      }
+
+      if (publicKeys[0].curve_type !== 'secp256k1') {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
+        return;
+      }
+
+      if (has0xPrefix(publicKeys[0].hex_bytes)) {
+        publicKeys[0].hex_bytes = publicKeys[0].hex_bytes.slice(2);
+      }
+
+      let transaction: StacksTransaction;
+      switch (options.type) {
+        case RosettaOperationType.TokenTransfer: {
+          const recipientAddress = options.token_transfer_recipient_address;
+          if (!recipientAddress) {
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidRecipient]);
+            return;
+          }
+          // signel signature
+          const tokenTransferOptions: UnsignedTokenTransferOptions = {
+            recipient: recipientAddress,
+            amount: new BN(amount),
+            fee: new BN(fee),
+            publicKey: publicKeys[0].hex_bytes,
+            network: getStacksNetwork(),
+            nonce: nonce,
+            memo: req.body.metadata?.memo,
+            anchorMode: AnchorMode.Any,
+          };
+
+          transaction = await makeUnsignedSTXTokenTransfer(tokenTransferOptions);
+
+          break;
+        }
+        case RosettaOperationType.StackStx: {
+          if (!options.pox_addr) {
+            res.status(500).json(RosettaErrorsTypes.invalidOperation);
+            return;
+          }
           const poxBTCAddress = options.pox_addr;
           const { hashMode, data } = decodeBtcAddress(poxBTCAddress);
           const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
           const hashbytes = bufferCV(data);
-          poxAddressCV = someCV(
-            tupleCV({
-              hashbytes,
-              version: hashModeBuffer,
-            })
-          );
+          const poxAddressCV = tupleCV({
+            hashbytes,
+            version: hashModeBuffer,
+          });
+          if (!options.amount) {
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+            return;
+          }
+          if (!req.body.metadata.contract_address) {
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingContractAddress]);
+            return;
+          }
+          if (!req.body.metadata.contract_name) {
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingContractName]);
+            return;
+          }
+          if (!req.body.metadata.burn_block_height) {
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+            return;
+          }
+          if (!options.number_of_cycles) {
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+            return;
+          }
+          const stackingTx: UnsignedContractCallOptions = {
+            contractAddress: req.body.metadata.contract_address,
+            contractName: req.body.metadata.contract_name,
+            functionName: 'stack-stx',
+            publicKey: publicKeys[0].hex_bytes,
+            functionArgs: [
+              uintCV(options.amount),
+              poxAddressCV,
+              uintCV(req.body.metadata.burn_block_height),
+              uintCV(options.number_of_cycles),
+            ],
+            fee: new BN(options.fee),
+            nonce: nonce,
+            validateWithAbi: false,
+            network: getStacksNetwork(),
+            anchorMode: AnchorMode.Any,
+          };
+          transaction = await makeUnsignedContractCall(stackingTx);
+          break;
         }
-        if (!options.amount) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
-          return;
-        }
-        if (!req.body.metadata.contract_address) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingContractAddress]);
-          return;
-        }
-        if (!req.body.metadata.contract_name) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingContractName]);
-          return;
-        }
+        case RosettaOperationType.DelegateStx: {
+          let poxAddressCV: OptionalCV = noneCV();
 
-        let expire_burn_block_heightCV: OptionalCV = noneCV();
-        if (req.body.metadata.burn_block_height) {
-          const burn_block_height = req.body.metadata.burn_block_height;
-          if (typeof burn_block_height !== 'number' || typeof burn_block_height !== 'string')
-            expire_burn_block_heightCV = someCV(uintCV(burn_block_height));
+          if (options.pox_addr) {
+            const poxBTCAddress = options.pox_addr;
+            const { hashMode, data } = decodeBtcAddress(poxBTCAddress);
+            const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
+            const hashbytes = bufferCV(data);
+            poxAddressCV = someCV(
+              tupleCV({
+                hashbytes,
+                version: hashModeBuffer,
+              })
+            );
+          }
+          if (!options.amount) {
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+            return;
+          }
+          if (!req.body.metadata.contract_address) {
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingContractAddress]);
+            return;
+          }
+          if (!req.body.metadata.contract_name) {
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingContractName]);
+            return;
+          }
+
+          let expire_burn_block_heightCV: OptionalCV = noneCV();
+          if (req.body.metadata.burn_block_height) {
+            const burn_block_height = req.body.metadata.burn_block_height;
+            if (typeof burn_block_height !== 'number' || typeof burn_block_height !== 'string')
+              expire_burn_block_heightCV = someCV(uintCV(burn_block_height));
+          }
+          if (!options.delegate_to) {
+            res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+            return;
+          }
+          const stackingTx: UnsignedContractCallOptions = {
+            contractAddress: req.body.metadata.contract_address,
+            contractName: req.body.metadata.contract_name,
+            functionName: 'delegate-stx',
+            publicKey: publicKeys[0].hex_bytes,
+            functionArgs: [
+              uintCV(options.amount),
+              standardPrincipalCV(options.delegate_to),
+              expire_burn_block_heightCV,
+              poxAddressCV,
+            ],
+            fee: new BN(options.fee),
+            nonce: nonce,
+            validateWithAbi: false,
+            network: getStacksNetwork(),
+            anchorMode: AnchorMode.Any,
+          };
+          transaction = await makeUnsignedContractCall(stackingTx);
+          break;
         }
-        if (!options.delegate_to) {
+        default:
           res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
-        }
-        const stackingTx: UnsignedContractCallOptions = {
-          contractAddress: req.body.metadata.contract_address,
-          contractName: req.body.metadata.contract_name,
-          functionName: 'delegate-stx',
-          publicKey: publicKeys[0].hex_bytes,
-          functionArgs: [
-            uintCV(options.amount),
-            standardPrincipalCV(options.delegate_to),
-            expire_burn_block_heightCV,
-            poxAddressCV,
-          ],
-          fee: new BN(options.fee),
-          nonce: nonce,
-          validateWithAbi: false,
-          network: getStacksNetwork(),
-          anchorMode: AnchorMode.Any,
-        };
-        transaction = await makeUnsignedContractCall(stackingTx);
-        break;
       }
-      default:
-        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
-        return;
-    }
 
-    const unsignedTransaction = transaction.serialize();
+      const unsignedTransaction = transaction.serialize();
 
-    const signer = new TransactionSigner(transaction);
+      const signer = new TransactionSigner(transaction);
 
-    const prehash = makeSigHashPreSign(signer.sigHash, AuthType.Standard, new BN(fee), nonce);
-    const accountIdentifier: RosettaAccountIdentifier = {
-      address: senderAddress,
-    };
-    const response: RosettaConstructionPayloadResponse = {
-      unsigned_transaction: '0x' + unsignedTransaction.toString('hex'),
-      payloads: [
-        {
-          address: senderAddress,
-          account_identifier: accountIdentifier,
-          hex_bytes: prehash,
-          signature_type: 'ecdsa_recovery',
-        },
-      ],
-    };
-    res.json(response);
-  });
+      const prehash = makeSigHashPreSign(signer.sigHash, AuthType.Standard, new BN(fee), nonce);
+      const accountIdentifier: RosettaAccountIdentifier = {
+        address: senderAddress,
+      };
+      const response: RosettaConstructionPayloadResponse = {
+        unsigned_transaction: '0x' + unsignedTransaction.toString('hex'),
+        payloads: [
+          {
+            address: senderAddress,
+            account_identifier: accountIdentifier,
+            hex_bytes: prehash,
+            signature_type: 'ecdsa_recovery',
+          },
+        ],
+      };
+      res.json(response);
+    })
+  );
 
   //construction/combine endpoint
-  router.postAsync('/combine', async (req, res) => {
-    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
-    if (!valid.valid) {
-      res.status(500).json(makeRosettaError(valid));
-      return;
-    }
-    const combineRequest: RosettaConstructionCombineRequest = req.body;
-    const signatures = combineRequest.signatures;
+  router.post(
+    '/combine',
+    asyncHandler(async (req, res) => {
+      const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
+      if (!valid.valid) {
+        res.status(500).json(makeRosettaError(valid));
+        return;
+      }
+      const combineRequest: RosettaConstructionCombineRequest = req.body;
+      const signatures = combineRequest.signatures;
 
-    if (!has0xPrefix(combineRequest.unsigned_transaction)) {
-      combineRequest.unsigned_transaction = '0x' + combineRequest.unsigned_transaction;
-    }
+      if (!has0xPrefix(combineRequest.unsigned_transaction)) {
+        combineRequest.unsigned_transaction = '0x' + combineRequest.unsigned_transaction;
+      }
 
-    if (signatures.length === 0) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.noSignatures]);
-      return;
-    }
+      if (signatures.length === 0) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.noSignatures]);
+        return;
+      }
 
-    let unsigned_transaction_buffer: Buffer;
-    let transaction: StacksTransaction;
+      let unsigned_transaction_buffer: Buffer;
+      let transaction: StacksTransaction;
 
-    try {
-      unsigned_transaction_buffer = hexToBuffer(combineRequest.unsigned_transaction);
-      transaction = deserializeTransaction(BufferReader.fromBuffer(unsigned_transaction_buffer));
-    } catch (e) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
-      return;
-    }
+      try {
+        unsigned_transaction_buffer = hexToBuffer(combineRequest.unsigned_transaction);
+        transaction = deserializeTransaction(BufferReader.fromBuffer(unsigned_transaction_buffer));
+      } catch (e) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
+        return;
+      }
 
-    if (signatures.length !== 1)
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.needOnlyOneSignature]);
+      if (signatures.length !== 1)
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.needOnlyOneSignature]);
 
-    if (signatures[0].public_key.curve_type !== 'secp256k1') {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
-      return;
-    }
-    const preSignHash = makePresignHash(transaction);
-    if (!preSignHash) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
-      return;
-    }
+      if (signatures[0].public_key.curve_type !== 'secp256k1') {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
+        return;
+      }
+      const preSignHash = makePresignHash(transaction);
+      if (!preSignHash) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
+        return;
+      }
 
-    let newSignature: MessageSignature;
+      let newSignature: MessageSignature;
 
-    try {
-      /**
-       * the elliptic library produces signatures that aren't in an "allowed" format
-       * it preapend v (i.e 01) while it should append it at the end, to incorporate that rotate
-       * the signature to match the elipcitc library
-       * Discussion here: https://github.com/coinbase/rosetta-sdk-go/issues/201
-       */
-      const hash = signatures[0].hex_bytes.slice(128) + signatures[0].hex_bytes.slice(0, -2);
-      newSignature = createMessageSignature(hash);
-    } catch (error) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidSignature]);
-      return;
-    }
+      try {
+        /**
+         * the elliptic library produces signatures that aren't in an "allowed" format
+         * it preapend v (i.e 01) while it should append it at the end, to incorporate that rotate
+         * the signature to match the elipcitc library
+         * Discussion here: https://github.com/coinbase/rosetta-sdk-go/issues/201
+         */
+        const hash = signatures[0].hex_bytes.slice(128) + signatures[0].hex_bytes.slice(0, -2);
+        newSignature = createMessageSignature(hash);
+      } catch (error) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidSignature]);
+        return;
+      }
 
-    if (has0xPrefix(signatures[0].public_key.hex_bytes)) {
-      signatures[0].public_key.hex_bytes = signatures[0].public_key.hex_bytes.slice(2);
-    }
+      if (has0xPrefix(signatures[0].public_key.hex_bytes)) {
+        signatures[0].public_key.hex_bytes = signatures[0].public_key.hex_bytes.slice(2);
+      }
 
-    if (
-      !verifySignature(
-        signatures[0].signing_payload.hex_bytes,
-        signatures[0].public_key.hex_bytes,
-        newSignature
-      )
-    ) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.signatureNotVerified]);
-    }
+      if (
+        !verifySignature(
+          signatures[0].signing_payload.hex_bytes,
+          signatures[0].public_key.hex_bytes,
+          newSignature
+        )
+      ) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.signatureNotVerified]);
+      }
 
-    if (transaction.auth.spendingCondition && isSingleSig(transaction.auth.spendingCondition)) {
-      transaction.auth.spendingCondition.signature = newSignature;
-    } else {
-      //support multi-sig
-    }
+      if (transaction.auth.spendingCondition && isSingleSig(transaction.auth.spendingCondition)) {
+        transaction.auth.spendingCondition.signature = newSignature;
+      } else {
+        //support multi-sig
+      }
 
-    const serializedTx = transaction.serialize().toString('hex');
+      const serializedTx = transaction.serialize().toString('hex');
 
-    const combineResponse: RosettaConstructionCombineResponse = {
-      signed_transaction: '0x' + serializedTx,
-    };
+      const combineResponse: RosettaConstructionCombineResponse = {
+        signed_transaction: '0x' + serializedTx,
+      };
 
-    res.status(200).json(combineResponse);
-  });
+      res.status(200).json(combineResponse);
+    })
+  );
 
   return router;
 }

--- a/src/api/routes/rosetta/mempool.ts
+++ b/src/api/routes/rosetta/mempool.ts
@@ -1,5 +1,5 @@
 import * as express from 'express';
-import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { asyncHandler } from '../../async-handler';
 import { DataStore } from '../../../datastore/common';
 import { has0xPrefix } from '../../../helpers';
 import { parseLimitQuery, parsePagingQueryInput } from '../../pagination';
@@ -19,66 +19,73 @@ const parseMempoolTxQueryLimit = parseLimitQuery({
   errorMsg: `'limit' must be equal to or less than ${MAX_MEMPOOL_TXS_PER_REQUEST}`,
 });
 
-export function createRosettaMempoolRouter(db: DataStore, chainId: ChainID): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createRosettaMempoolRouter(db: DataStore, chainId: ChainID): express.Router {
+  const router = express.Router();
   router.use(express.json());
 
-  router.postAsync('/', async (req, res) => {
-    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
-    if (!valid.valid) {
-      res.status(500).json(makeRosettaError(valid));
-      return;
-    }
+  router.post(
+    '/',
+    asyncHandler(async (req, res) => {
+      const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
+      if (!valid.valid) {
+        res.status(500).json(makeRosettaError(valid));
+        return;
+      }
 
-    const { results: txResults } = await db.getMempoolTxList({
-      limit: Number.MAX_SAFE_INTEGER,
-      offset: 0,
-      includeUnanchored: false,
-    });
+      const { results: txResults } = await db.getMempoolTxList({
+        limit: Number.MAX_SAFE_INTEGER,
+        offset: 0,
+        includeUnanchored: false,
+      });
 
-    const transaction_identifiers = txResults.map(tx => {
-      return { hash: tx.tx_id };
-    });
-    const response: RosettaMempoolResponse = {
-      transaction_identifiers,
-    };
-    res.json(response);
-  });
-
-  router.postAsync('/transaction', async (req, res) => {
-    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
-    if (!valid.valid) {
-      res.status(500).json(makeRosettaError(valid));
-      return;
-    }
-
-    let tx_id: string = req.body.transaction_identifier.hash;
-
-    if (!has0xPrefix(tx_id)) {
-      tx_id = '0x' + tx_id;
-    }
-    const mempoolTxQuery = await db.getMempoolTx({ txId: tx_id, includeUnanchored: false });
-
-    if (!mempoolTxQuery.found) {
-      return res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotFound]);
-    }
-
-    const operations = await getOperations(mempoolTxQuery.result, db);
-    const txMemo = parseTransactionMemo(mempoolTxQuery.result);
-    const transaction: RosettaTransaction = {
-      transaction_identifier: { hash: tx_id },
-      operations: operations,
-    };
-    if (txMemo) {
-      transaction.metadata = {
-        memo: txMemo,
+      const transaction_identifiers = txResults.map(tx => {
+        return { hash: tx.tx_id };
+      });
+      const response: RosettaMempoolResponse = {
+        transaction_identifiers,
       };
-    }
-    const result: RosettaMempoolTransactionResponse = {
-      transaction: transaction,
-    };
-    res.json(result);
-  });
+      res.json(response);
+    })
+  );
+
+  router.post(
+    '/transaction',
+    asyncHandler(async (req, res) => {
+      const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
+      if (!valid.valid) {
+        res.status(500).json(makeRosettaError(valid));
+        return;
+      }
+
+      let tx_id: string = req.body.transaction_identifier.hash;
+
+      if (!has0xPrefix(tx_id)) {
+        tx_id = '0x' + tx_id;
+      }
+      const mempoolTxQuery = await db.getMempoolTx({ txId: tx_id, includeUnanchored: false });
+
+      if (!mempoolTxQuery.found) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotFound]);
+        return;
+      }
+
+      const operations = await getOperations(mempoolTxQuery.result, db);
+      const txMemo = parseTransactionMemo(mempoolTxQuery.result);
+      const transaction: RosettaTransaction = {
+        transaction_identifier: { hash: tx_id },
+        operations: operations,
+      };
+      if (txMemo) {
+        transaction.metadata = {
+          memo: txMemo,
+        };
+      }
+      const result: RosettaMempoolTransactionResponse = {
+        transaction: transaction,
+      };
+      res.json(result);
+    })
+  );
 
   return router;
 }

--- a/src/api/routes/rosetta/network.ts
+++ b/src/api/routes/rosetta/network.ts
@@ -1,5 +1,5 @@
 import * as express from 'express';
-import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { asyncHandler } from '../../async-handler';
 import { DataStore } from '../../../datastore/common';
 import { logger } from '../../../helpers';
 import { getRosettaBlockFromDataStore } from '../../controllers/db-controller';
@@ -24,8 +24,8 @@ import {
 import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../rosetta-validate';
 import { ChainID } from '@stacks/transactions';
 
-export function createRosettaNetworkRouter(db: DataStore, chainId: ChainID): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createRosettaNetworkRouter(db: DataStore, chainId: ChainID): express.Router {
+  const router = express.Router();
   router.use(express.json());
 
   router.post('/list', (_req, res) => {
@@ -41,92 +41,98 @@ export function createRosettaNetworkRouter(db: DataStore, chainId: ChainID): Rou
     res.json(response);
   });
 
-  router.postAsync('/status', async (req, res) => {
-    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
-    if (!valid.valid) {
-      res.status(500).json(makeRosettaError(valid));
-      return;
-    }
+  router.post(
+    '/status',
+    asyncHandler(async (req, res) => {
+      const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
+      if (!valid.valid) {
+        res.status(500).json(makeRosettaError(valid));
+        return;
+      }
 
-    const block = await getRosettaBlockFromDataStore(db, false);
-    if (!block.found) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
-      return;
-    }
+      const block = await getRosettaBlockFromDataStore(db, false);
+      if (!block.found) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
+        return;
+      }
 
-    const genesis = await getRosettaBlockFromDataStore(db, false, undefined, 1);
-    if (!genesis.found) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
-      return;
-    }
+      const genesis = await getRosettaBlockFromDataStore(db, false, undefined, 1);
+      if (!genesis.found) {
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
+        return;
+      }
 
-    const stacksCoreRpcClient = new StacksCoreRpcClient();
+      const stacksCoreRpcClient = new StacksCoreRpcClient();
 
-    const neighborsResp = await stacksCoreRpcClient.getNeighbors();
-    const neighbors: Neighbor[] = [...neighborsResp.inbound, ...neighborsResp.outbound];
+      const neighborsResp = await stacksCoreRpcClient.getNeighbors();
+      const neighbors: Neighbor[] = [...neighborsResp.inbound, ...neighborsResp.outbound];
 
-    const set_of_peer_ids = new Set(
-      neighbors.map(neighbor => {
-        return neighbor.public_key_hash;
-      })
-    );
+      const set_of_peer_ids = new Set(
+        neighbors.map(neighbor => {
+          return neighbor.public_key_hash;
+        })
+      );
 
-    const peers = [...set_of_peer_ids].map(peerId => {
-      return { peer_id: peerId };
-    });
+      const peers = [...set_of_peer_ids].map(peerId => {
+        return { peer_id: peerId };
+      });
 
-    const currentTipHeight = block.result.block_identifier.index;
+      const currentTipHeight = block.result.block_identifier.index;
 
-    const response: RosettaNetworkStatusResponse = {
-      current_block_identifier: {
-        index: block.result.block_identifier.index,
-        hash: block.result.block_identifier.hash,
-      },
-      current_block_timestamp: block.result.timestamp,
-      genesis_block_identifier: {
-        index: genesis.result.block_identifier.index,
-        hash: genesis.result.block_identifier.hash,
-      },
-      peers,
-    };
+      const response: RosettaNetworkStatusResponse = {
+        current_block_identifier: {
+          index: block.result.block_identifier.index,
+          hash: block.result.block_identifier.hash,
+        },
+        current_block_timestamp: block.result.timestamp,
+        genesis_block_identifier: {
+          index: genesis.result.block_identifier.index,
+          hash: genesis.result.block_identifier.hash,
+        },
+        peers,
+      };
 
-    const nodeInfo = await stacksCoreRpcClient.getInfo();
-    const referenceNodeTipHeight = nodeInfo.stacks_tip_height;
-    const synced = currentTipHeight === referenceNodeTipHeight;
+      const nodeInfo = await stacksCoreRpcClient.getInfo();
+      const referenceNodeTipHeight = nodeInfo.stacks_tip_height;
+      const synced = currentTipHeight === referenceNodeTipHeight;
 
-    const status: RosettaSyncStatus = {
-      current_index: currentTipHeight,
-      target_index: referenceNodeTipHeight,
-      synced: synced,
-    };
-    response.sync_status = status;
+      const status: RosettaSyncStatus = {
+        current_index: currentTipHeight,
+        target_index: referenceNodeTipHeight,
+        synced: synced,
+      };
+      response.sync_status = status;
 
-    res.json(response);
-  });
+      res.json(response);
+    })
+  );
 
-  router.postAsync('/options', async (req, res) => {
-    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
-    if (!valid.valid) {
-      res.status(500).json(makeRosettaError(valid));
-      return;
-    }
+  router.post(
+    '/options',
+    asyncHandler(async (req, res) => {
+      const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
+      if (!valid.valid) {
+        res.status(500).json(makeRosettaError(valid));
+        return;
+      }
 
-    const response: RosettaNetworkOptionsResponse = {
-      version: {
-        rosetta_version: RosettaConstants.rosettaVersion,
-        node_version: process.version,
-        middleware_version: middleware_version,
-      },
-      allow: {
-        operation_statuses: RosettaOperationStatuses,
-        operation_types: RosettaOperationTypes,
-        errors: Object.values(RosettaErrors),
-        historical_balance_lookup: true,
-      },
-    };
+      const response: RosettaNetworkOptionsResponse = {
+        version: {
+          rosetta_version: RosettaConstants.rosettaVersion,
+          node_version: process.version,
+          middleware_version: middleware_version,
+        },
+        allow: {
+          operation_statuses: RosettaOperationStatuses,
+          operation_types: RosettaOperationTypes,
+          errors: Object.values(RosettaErrors),
+          historical_balance_lookup: true,
+        },
+      };
 
-    res.json(response);
-  });
+      res.json(response);
+    })
+  );
 
   return router;
 }

--- a/src/api/routes/status.ts
+++ b/src/api/routes/status.ts
@@ -1,12 +1,11 @@
 import * as express from 'express';
 import * as fs from 'fs';
-import { addAsync, RouterWithAsync } from '@awaitjs/express';
 import { DataStore } from '../../datastore/common';
 import { ServerStatusResponse } from '@stacks/stacks-blockchain-api-types';
 import { logger } from '../../helpers';
 
-export function createStatusRouter(_: DataStore): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createStatusRouter(_: DataStore): express.Router {
+  const router = express.Router();
 
   const statusHandler = (_: Request, res: any) => {
     try {

--- a/src/api/routes/tokens/tokens.ts
+++ b/src/api/routes/tokens/tokens.ts
@@ -1,4 +1,4 @@
-import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { asyncHandler } from '../../async-handler';
 import * as express from 'express';
 import { DataStore } from '../../../datastore/common';
 import {
@@ -19,132 +19,148 @@ const parseTokenQueryLimit = parseLimitQuery({
   errorMsg: '`limit` must be equal to or less than ' + MAX_TOKENS_PER_REQUEST,
 });
 
-export function createTokenRouter(db: DataStore): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createTokenRouter(db: DataStore): express.Router {
+  const router = express.Router();
   router.use(express.json());
 
-  router.getAsync('/ft/metadata', async (req, res) => {
-    if (!isFtMetadataEnabled()) {
-      return res.status(500).json({
-        error: 'FT metadata processing is not enabled on this server',
-      });
-    }
+  router.get(
+    '/ft/metadata',
+    asyncHandler(async (req, res) => {
+      if (!isFtMetadataEnabled()) {
+        res.status(500).json({
+          error: 'FT metadata processing is not enabled on this server',
+        });
+        return;
+      }
 
-    const limit = parseTokenQueryLimit(req.query.limit ?? 96);
-    const offset = parsePagingQueryInput(req.query.offset ?? 0);
+      const limit = parseTokenQueryLimit(req.query.limit ?? 96);
+      const offset = parsePagingQueryInput(req.query.offset ?? 0);
 
-    const { results, total } = await db.getFtMetadataList({ offset, limit });
+      const { results, total } = await db.getFtMetadataList({ offset, limit });
 
-    const response: FungibleTokensMetadataList = {
-      limit: limit,
-      offset: offset,
-      total: total,
-      results: results,
-    };
+      const response: FungibleTokensMetadataList = {
+        limit: limit,
+        offset: offset,
+        total: total,
+        results: results,
+      };
 
-    res.status(200).json(response);
-  });
+      res.status(200).json(response);
+    })
+  );
 
-  router.getAsync('/nft/metadata', async (req, res) => {
-    if (!isNftMetadataEnabled()) {
-      return res.status(500).json({
-        error: 'NFT metadata processing is not enabled on this server',
-      });
-    }
+  router.get(
+    '/nft/metadata',
+    asyncHandler(async (req, res) => {
+      if (!isNftMetadataEnabled()) {
+        res.status(500).json({
+          error: 'NFT metadata processing is not enabled on this server',
+        });
+        return;
+      }
 
-    const limit = parseTokenQueryLimit(req.query.limit ?? 96);
-    const offset = parsePagingQueryInput(req.query.offset ?? 0);
+      const limit = parseTokenQueryLimit(req.query.limit ?? 96);
+      const offset = parsePagingQueryInput(req.query.offset ?? 0);
 
-    const { results, total } = await db.getNftMetadataList({ offset, limit });
+      const { results, total } = await db.getNftMetadataList({ offset, limit });
 
-    const response: NonFungibleTokensMetadataList = {
-      limit: limit,
-      offset: offset,
-      total: total,
-      results: results,
-    };
+      const response: NonFungibleTokensMetadataList = {
+        limit: limit,
+        offset: offset,
+        total: total,
+        results: results,
+      };
 
-    res.status(200).json(response);
-  });
+      res.status(200).json(response);
+    })
+  );
 
   //router for fungible tokens
-  router.getAsync('/:contractId/ft/metadata', async (req, res) => {
-    if (!isFtMetadataEnabled()) {
-      return res.status(500).json({
-        error: 'FT metadata processing is not enabled on this server',
-      });
-    }
+  router.get(
+    '/:contractId/ft/metadata',
+    asyncHandler(async (req, res) => {
+      if (!isFtMetadataEnabled()) {
+        res.status(500).json({
+          error: 'FT metadata processing is not enabled on this server',
+        });
+        return;
+      }
 
-    const { contractId } = req.params;
+      const { contractId } = req.params;
 
-    const metadata = await db.getFtMetadata(contractId);
-    if (!metadata.found) {
-      res.status(404).json({ error: 'tokens not found' });
-      return;
-    }
+      const metadata = await db.getFtMetadata(contractId);
+      if (!metadata.found) {
+        res.status(404).json({ error: 'tokens not found' });
+        return;
+      }
 
-    const {
-      token_uri,
-      name,
-      description,
-      image_uri,
-      image_canonical_uri,
-      symbol,
-      decimals,
-      tx_id,
-      sender_address,
-    } = metadata.result;
+      const {
+        token_uri,
+        name,
+        description,
+        image_uri,
+        image_canonical_uri,
+        symbol,
+        decimals,
+        tx_id,
+        sender_address,
+      } = metadata.result;
 
-    const response: FungibleTokenMetadata = {
-      token_uri: token_uri,
-      name: name,
-      description: description,
-      image_uri: image_uri,
-      image_canonical_uri: image_canonical_uri,
-      symbol: symbol,
-      decimals: decimals,
-      tx_id: tx_id,
-      sender_address: sender_address,
-    };
-    res.status(200).json(response);
-  });
+      const response: FungibleTokenMetadata = {
+        token_uri: token_uri,
+        name: name,
+        description: description,
+        image_uri: image_uri,
+        image_canonical_uri: image_canonical_uri,
+        symbol: symbol,
+        decimals: decimals,
+        tx_id: tx_id,
+        sender_address: sender_address,
+      };
+      res.status(200).json(response);
+    })
+  );
 
   //router for non-fungible tokens
-  router.getAsync('/:contractId/nft/metadata', async (req, res) => {
-    if (!isNftMetadataEnabled()) {
-      return res.status(500).json({
-        error: 'NFT metadata processing is not enabled on this server',
-      });
-    }
+  router.get(
+    '/:contractId/nft/metadata',
+    asyncHandler(async (req, res) => {
+      if (!isNftMetadataEnabled()) {
+        res.status(500).json({
+          error: 'NFT metadata processing is not enabled on this server',
+        });
+        return;
+      }
 
-    const { contractId } = req.params;
-    const metadata = await db.getNftMetadata(contractId);
+      const { contractId } = req.params;
+      const metadata = await db.getNftMetadata(contractId);
 
-    if (!metadata.found) {
-      res.status(404).json({ error: 'tokens not found' });
-      return;
-    }
-    const {
-      token_uri,
-      name,
-      description,
-      image_uri,
-      image_canonical_uri,
-      tx_id,
-      sender_address,
-    } = metadata.result;
+      if (!metadata.found) {
+        res.status(404).json({ error: 'tokens not found' });
+        return;
+      }
+      const {
+        token_uri,
+        name,
+        description,
+        image_uri,
+        image_canonical_uri,
+        tx_id,
+        sender_address,
+      } = metadata.result;
 
-    const response: NonFungibleTokenMetadata = {
-      token_uri: token_uri,
-      name: name,
-      description: description,
-      image_uri: image_uri,
-      image_canonical_uri: image_canonical_uri,
-      tx_id: tx_id,
-      sender_address: sender_address,
-    };
-    res.status(200).json(response);
-  });
+      const response: NonFungibleTokenMetadata = {
+        token_uri: token_uri,
+        name: name,
+        description: description,
+        image_uri: image_uri,
+        image_canonical_uri: image_canonical_uri,
+        tx_id: tx_id,
+        sender_address: sender_address,
+      };
+      res.status(200).json(response);
+    })
+  );
 
   return router;
 }

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -1,5 +1,5 @@
 import * as express from 'express';
-import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { asyncHandler } from '../async-handler';
 import * as Bluebird from 'bluebird';
 import { DataStore, DbTx, DbMempoolTx } from '../../datastore/common';
 import {
@@ -30,7 +30,6 @@ import {
   Transaction,
 } from '@stacks/stacks-blockchain-api-types';
 import { getChainTipCacheHandler, setChainTipCacheHeaders } from '../controllers/cache-controller';
-import { asyncHandler } from '../async-handler';
 
 const MAX_TXS_PER_REQUEST = 200;
 const parseTxQueryLimit = parseLimitQuery({
@@ -50,8 +49,8 @@ const parseTxQueryEventsLimit = parseLimitQuery({
   errorMsg: '`event_limit` must be equal to or less than ' + MAX_EVENTS_PER_REQUEST,
 });
 
-export function createTxRouter(db: DataStore): RouterWithAsync {
-  const router = addAsync(express.Router());
+export function createTxRouter(db: DataStore): express.Router {
+  const router = express.Router();
 
   const cacheHandler = getChainTipCacheHandler(db);
 
@@ -93,256 +92,286 @@ export function createTxRouter(db: DataStore): RouterWithAsync {
     })
   );
 
-  router.getAsync('/multiple', async (req, res, next) => {
-    const txList: string[] = req.query.tx_id as string[];
-    const eventLimit = parseTxQueryEventsLimit(req.query['event_limit'] ?? 96);
-    const eventOffset = parsePagingQueryInput(req.query['event_offset'] ?? 0);
-    const includeUnanchored = isUnanchoredRequest(req, res, next);
-    const txQuery = await searchTxs(db, {
-      txIds: txList,
-      eventLimit,
-      eventOffset,
-      includeUnanchored,
-    });
-    // TODO: this validation needs fixed now that the mempool-tx and mined-tx types no longer overlap
-    /*
+  router.get(
+    '/multiple',
+    asyncHandler(async (req, res, next) => {
+      const txList: string[] = req.query.tx_id as string[];
+      const eventLimit = parseTxQueryEventsLimit(req.query['event_limit'] ?? 96);
+      const eventOffset = parsePagingQueryInput(req.query['event_offset'] ?? 0);
+      const includeUnanchored = isUnanchoredRequest(req, res, next);
+      const txQuery = await searchTxs(db, {
+        txIds: txList,
+        eventLimit,
+        eventOffset,
+        includeUnanchored,
+      });
+      // TODO: this validation needs fixed now that the mempool-tx and mined-tx types no longer overlap
+      /*
     const schemaPath = require.resolve(
       '@stacks/stacks-blockchain-api-types/entities/transactions/transaction.schema.json'
     );
     await validate(schemaPath, txQuery.result);
     */
-    res.json(txQuery);
-  });
+      res.json(txQuery);
+    })
+  );
 
-  router.getAsync('/mempool', async (req, res, next) => {
-    const limit = parseTxQueryLimit(req.query.limit ?? 96);
-    const offset = parsePagingQueryInput(req.query.offset ?? 0);
+  router.get(
+    '/mempool',
+    asyncHandler(async (req, res, next) => {
+      const limit = parseTxQueryLimit(req.query.limit ?? 96);
+      const offset = parsePagingQueryInput(req.query.offset ?? 0);
 
-    let addrParams: (string | undefined)[];
-    try {
-      addrParams = ['sender_address', 'recipient_address', 'address'].map(p => {
-        const addr: string | undefined = req.query[p] as string;
-        if (!addr) {
-          return undefined;
-        }
-        switch (p) {
-          case 'sender_address':
-            if (!isValidC32Address(addr)) {
-              throw new Error(
-                `Invalid query parameter for "${p}": "${addr}" is not a valid STX address`
-              );
-            }
-            break;
-          case 'recipient_address':
-          case 'address':
-            if (!(isValidC32Address(addr) || isValidPrincipal(addr))) {
-              throw new Error(
-                `Invalid query parameter for "${p}": "${addr}" is not a valid STX address or principal`
-              );
-            }
-            break;
-        }
-        return addr;
-      });
-    } catch (error) {
-      res.status(400).json({ error: `${error}` });
-      return;
-    }
-
-    const includeUnanchored = isUnanchoredRequest(req, res, next);
-    const [senderAddress, recipientAddress, address] = addrParams;
-    if (address && (recipientAddress || senderAddress)) {
-      res
-        .status(400)
-        .json({ error: 'The "address" filter cannot be specified with other address filters' });
-      return;
-    }
-    const { results: txResults, total } = await db.getMempoolTxList({
-      offset,
-      limit,
-      includeUnanchored,
-      senderAddress,
-      recipientAddress,
-      address,
-    });
-
-    const results = txResults.map(tx => parseDbMempoolTx(tx));
-    const response: MempoolTransactionListResponse = { limit, offset, total, results };
-    res.json(response);
-  });
-
-  router.getAsync('/mempool/dropped', async (req, res) => {
-    const limit = parseTxQueryLimit(req.query.limit ?? 96);
-    const offset = parsePagingQueryInput(req.query.offset ?? 0);
-    const { results: txResults, total } = await db.getDroppedTxs({
-      offset,
-      limit,
-    });
-    const results = txResults.map(tx => parseDbMempoolTx(tx));
-    const response: MempoolTransactionListResponse = { limit, offset, total, results };
-    res.json(response);
-  });
-
-  router.getAsync('/stream', async (req, res) => {
-    const protocol = req.query['protocol'];
-    const useEventSource = protocol === 'eventsource';
-    const useWebSocket = protocol === 'websocket';
-    if (!useEventSource && !useWebSocket) {
-      throw new Error(`Unsupported stream protocol "${protocol}"`);
-    }
-
-    if (useEventSource) {
-      res.writeHead(200, {
-        'Content-Type': 'text/event-stream',
-        'Cache-Control': 'no-cache',
-        Connection: 'keep-alive',
-      });
-    } else if (useWebSocket) {
-      throw new Error('WebSocket stream not yet implemented');
-    }
-
-    const dbTxUpdate = async (txId: string): Promise<void> => {
+      let addrParams: (string | undefined)[];
       try {
-        const txQuery = await searchTx(db, { txId, includeUnanchored: true });
-        if (!txQuery.found) {
-          throw new Error('error in tx stream, tx not found');
-        }
-        if (useEventSource) {
-          res.write(`event: tx\ndata: ${JSON.stringify(txQuery.result)}\n\n`);
-          res.flush();
-        }
+        addrParams = ['sender_address', 'recipient_address', 'address'].map(p => {
+          const addr: string | undefined = req.query[p] as string;
+          if (!addr) {
+            return undefined;
+          }
+          switch (p) {
+            case 'sender_address':
+              if (!isValidC32Address(addr)) {
+                throw new Error(
+                  `Invalid query parameter for "${p}": "${addr}" is not a valid STX address`
+                );
+              }
+              break;
+            case 'recipient_address':
+            case 'address':
+              if (!(isValidC32Address(addr) || isValidPrincipal(addr))) {
+                throw new Error(
+                  `Invalid query parameter for "${p}": "${addr}" is not a valid STX address or principal`
+                );
+              }
+              break;
+          }
+          return addr;
+        });
       } catch (error) {
-        // TODO: real error handling
-        logError('error streaming tx updates', error);
+        res.status(400).json({ error: `${error}` });
+        return;
       }
-    };
 
-    // EventEmitters don't like being passed Promise functions so wrap the async handler
-    const onTxUpdate = (txId: string): void => {
-      void dbTxUpdate(txId);
-    };
+      const includeUnanchored = isUnanchoredRequest(req, res, next);
+      const [senderAddress, recipientAddress, address] = addrParams;
+      if (address && (recipientAddress || senderAddress)) {
+        res
+          .status(400)
+          .json({ error: 'The "address" filter cannot be specified with other address filters' });
+        return;
+      }
+      const { results: txResults, total } = await db.getMempoolTxList({
+        offset,
+        limit,
+        includeUnanchored,
+        senderAddress,
+        recipientAddress,
+        address,
+      });
 
-    const endWaiter = waiter();
-    db.addListener('txUpdate', onTxUpdate);
-    res.on('close', () => {
-      endWaiter.finish();
-      db.removeListener('txUpdate', onTxUpdate);
-    });
-    await endWaiter;
-  });
+      const results = txResults.map(tx => parseDbMempoolTx(tx));
+      const response: MempoolTransactionListResponse = { limit, offset, total, results };
+      res.json(response);
+    })
+  );
 
-  router.getAsync('/:tx_id', async (req, res, next) => {
-    const { tx_id } = req.params;
-    if (!has0xPrefix(tx_id)) {
-      return res.redirect('/extended/v1/tx/0x' + tx_id);
-    }
+  router.get(
+    '/mempool/dropped',
+    asyncHandler(async (req, res) => {
+      const limit = parseTxQueryLimit(req.query.limit ?? 96);
+      const offset = parsePagingQueryInput(req.query.offset ?? 0);
+      const { results: txResults, total } = await db.getDroppedTxs({
+        offset,
+        limit,
+      });
+      const results = txResults.map(tx => parseDbMempoolTx(tx));
+      const response: MempoolTransactionListResponse = { limit, offset, total, results };
+      res.json(response);
+    })
+  );
 
-    const eventLimit = parseTxQueryEventsLimit(req.query['event_limit'] ?? 96);
-    const eventOffset = parsePagingQueryInput(req.query['event_offset'] ?? 0);
-    const includeUnanchored = isUnanchoredRequest(req, res, next);
-    const txQuery = await searchTx(db, { txId: tx_id, eventLimit, eventOffset, includeUnanchored });
-    if (!txQuery.found) {
-      res.status(404).json({ error: `could not find transaction by ID ${tx_id}` });
-      return;
-    }
-    // TODO: this validation needs fixed now that the mempool-tx and mined-tx types no longer overlap
-    /*
+  router.get(
+    '/stream',
+    asyncHandler(async (req, res) => {
+      const protocol = req.query['protocol'];
+      const useEventSource = protocol === 'eventsource';
+      const useWebSocket = protocol === 'websocket';
+      if (!useEventSource && !useWebSocket) {
+        throw new Error(`Unsupported stream protocol "${protocol}"`);
+      }
+
+      if (useEventSource) {
+        res.writeHead(200, {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          Connection: 'keep-alive',
+        });
+      } else if (useWebSocket) {
+        throw new Error('WebSocket stream not yet implemented');
+      }
+
+      const dbTxUpdate = async (txId: string): Promise<void> => {
+        try {
+          const txQuery = await searchTx(db, { txId, includeUnanchored: true });
+          if (!txQuery.found) {
+            throw new Error('error in tx stream, tx not found');
+          }
+          if (useEventSource) {
+            res.write(`event: tx\ndata: ${JSON.stringify(txQuery.result)}\n\n`);
+            res.flush();
+          }
+        } catch (error) {
+          // TODO: real error handling
+          logError('error streaming tx updates', error);
+        }
+      };
+
+      // EventEmitters don't like being passed Promise functions so wrap the async handler
+      const onTxUpdate = (txId: string): void => {
+        void dbTxUpdate(txId);
+      };
+
+      const endWaiter = waiter();
+      db.addListener('txUpdate', onTxUpdate);
+      res.on('close', () => {
+        endWaiter.finish();
+        db.removeListener('txUpdate', onTxUpdate);
+      });
+      await endWaiter;
+    })
+  );
+
+  router.get(
+    '/:tx_id',
+    asyncHandler(async (req, res, next) => {
+      const { tx_id } = req.params;
+      if (!has0xPrefix(tx_id)) {
+        return res.redirect('/extended/v1/tx/0x' + tx_id);
+      }
+
+      const eventLimit = parseTxQueryEventsLimit(req.query['event_limit'] ?? 96);
+      const eventOffset = parsePagingQueryInput(req.query['event_offset'] ?? 0);
+      const includeUnanchored = isUnanchoredRequest(req, res, next);
+      const txQuery = await searchTx(db, {
+        txId: tx_id,
+        eventLimit,
+        eventOffset,
+        includeUnanchored,
+      });
+      if (!txQuery.found) {
+        res.status(404).json({ error: `could not find transaction by ID ${tx_id}` });
+        return;
+      }
+      // TODO: this validation needs fixed now that the mempool-tx and mined-tx types no longer overlap
+      /*
     const schemaPath = require.resolve(
       '@stacks/stacks-blockchain-api-types/entities/transactions/transaction.schema.json'
     );
     await validate(schemaPath, txQuery.result);
     */
-    res.json(txQuery.result);
-  });
+      res.json(txQuery.result);
+    })
+  );
 
-  router.getAsync('/:tx_id/raw', async (req, res) => {
-    const { tx_id } = req.params;
-    if (!has0xPrefix(tx_id)) {
-      return res.redirect('/extended/v1/tx/0x' + tx_id + '/raw');
-    }
+  router.get(
+    '/:tx_id/raw',
+    asyncHandler(async (req, res) => {
+      const { tx_id } = req.params;
+      if (!has0xPrefix(tx_id)) {
+        return res.redirect('/extended/v1/tx/0x' + tx_id + '/raw');
+      }
 
-    const rawTxQuery = await db.getRawTx(tx_id);
+      const rawTxQuery = await db.getRawTx(tx_id);
 
-    if (rawTxQuery.found) {
-      const response: GetRawTransactionResult = {
-        raw_tx: bufferToHexPrefixString(rawTxQuery.result.raw_tx),
+      if (rawTxQuery.found) {
+        const response: GetRawTransactionResult = {
+          raw_tx: bufferToHexPrefixString(rawTxQuery.result.raw_tx),
+        };
+        res.json(response);
+      } else {
+        res.status(404).json({ error: `could not find transaction by ID ${tx_id}` });
+      }
+    })
+  );
+
+  router.get(
+    '/block/:block_hash',
+    asyncHandler(async (req, res) => {
+      const { block_hash } = req.params;
+      const limit = parseTxQueryEventsLimit(req.query['limit'] ?? 96);
+      const offset = parsePagingQueryInput(req.query['offset'] ?? 0);
+
+      // TODO: use getBlockWithMetadata or similar to avoid transaction integrity issues from lazy resolving block tx data (primarily the contract-call ABI data)
+      const dbTxs = await db.getTxsFromBlock(block_hash, limit, offset);
+
+      const results = await Bluebird.mapSeries(dbTxs.results, async tx => {
+        const txQuery = await getTxFromDataStore(db, {
+          txId: tx.tx_id,
+          dbTx: tx,
+          includeUnanchored: true,
+        });
+        if (!txQuery.found) {
+          throw new Error('unexpected tx not found -- fix tx enumeration query');
+        }
+        return txQuery.result;
+      });
+
+      const response: TransactionResults = {
+        limit: limit,
+        offset: offset,
+        results: results,
+        total: dbTxs.total,
       };
+      if (!isProdEnv) {
+        const schemaPath =
+          '@stacks/stacks-blockchain-api-types/api/transaction/get-transactions.schema.json';
+        await validate(schemaPath, response);
+      }
       res.json(response);
-    } else {
-      res.status(404).json({ error: `could not find transaction by ID ${tx_id}` });
-    }
-  });
+    })
+  );
 
-  router.getAsync('/block/:block_hash', async (req, res) => {
-    const { block_hash } = req.params;
-    const limit = parseTxQueryEventsLimit(req.query['limit'] ?? 96);
-    const offset = parsePagingQueryInput(req.query['offset'] ?? 0);
-
-    // TODO: use getBlockWithMetadata or similar to avoid transaction integrity issues from lazy resolving block tx data (primarily the contract-call ABI data)
-    const dbTxs = await db.getTxsFromBlock(block_hash, limit, offset);
-
-    const results = await Bluebird.mapSeries(dbTxs.results, async tx => {
-      const txQuery = await getTxFromDataStore(db, {
-        txId: tx.tx_id,
-        dbTx: tx,
-        includeUnanchored: true,
-      });
-      if (!txQuery.found) {
-        throw new Error('unexpected tx not found -- fix tx enumeration query');
+  router.get(
+    '/block_height/:height',
+    asyncHandler(async (req, res, next) => {
+      const height = getBlockHeightPathParam(req, res, next);
+      const limit = parseTxQueryEventsLimit(req.query['limit'] ?? 96);
+      const offset = parsePagingQueryInput(req.query['offset'] ?? 0);
+      // TODO: use getBlockWithMetadata or similar to avoid transaction integrity issues from lazy resolving block tx data (primarily the contract-call ABI data)
+      const blockHash = await db.getBlock({ height: height });
+      if (!blockHash.found) {
+        res.status(404).json({ error: `no block found at height ${height}` });
+        return;
       }
-      return txQuery.result;
-    });
+      const dbTxs = await db.getTxsFromBlock(blockHash.result.block_hash, limit, offset);
 
-    const response: TransactionResults = {
-      limit: limit,
-      offset: offset,
-      results: results,
-      total: dbTxs.total,
-    };
-    if (!isProdEnv) {
-      const schemaPath =
-        '@stacks/stacks-blockchain-api-types/api/transaction/get-transactions.schema.json';
-      await validate(schemaPath, response);
-    }
-    res.json(response);
-  });
-
-  router.getAsync('/block_height/:height', async (req, res, next) => {
-    const height = getBlockHeightPathParam(req, res, next);
-    const limit = parseTxQueryEventsLimit(req.query['limit'] ?? 96);
-    const offset = parsePagingQueryInput(req.query['offset'] ?? 0);
-    // TODO: use getBlockWithMetadata or similar to avoid transaction integrity issues from lazy resolving block tx data (primarily the contract-call ABI data)
-    const blockHash = await db.getBlock({ height: height });
-    if (!blockHash.found) {
-      return res.status(404).json({ error: `no block found at height ${height}` });
-    }
-    const dbTxs = await db.getTxsFromBlock(blockHash.result.block_hash, limit, offset);
-
-    const results = await Bluebird.mapSeries(dbTxs.results, async tx => {
-      const txQuery = await getTxFromDataStore(db, {
-        txId: tx.tx_id,
-        dbTx: tx,
-        includeUnanchored: true,
+      const results = await Bluebird.mapSeries(dbTxs.results, async tx => {
+        const txQuery = await getTxFromDataStore(db, {
+          txId: tx.tx_id,
+          dbTx: tx,
+          includeUnanchored: true,
+        });
+        if (!txQuery.found) {
+          throw new Error('unexpected tx not found -- fix tx enumeration query');
+        }
+        return txQuery.result;
       });
-      if (!txQuery.found) {
-        throw new Error('unexpected tx not found -- fix tx enumeration query');
-      }
-      return txQuery.result;
-    });
 
-    const response: TransactionResults = {
-      limit: limit,
-      offset: offset,
-      results: results,
-      total: dbTxs.total,
-    };
-    if (!isProdEnv) {
-      const schemaPath =
-        '@stacks/stacks-blockchain-api-types/api/transaction/get-transactions.schema.json';
-      await validate(schemaPath, response);
-    }
-    res.json(response);
-  });
+      const response: TransactionResults = {
+        limit: limit,
+        offset: offset,
+        results: results,
+        total: dbTxs.total,
+      };
+      if (!isProdEnv) {
+        const schemaPath =
+          '@stacks/stacks-blockchain-api-types/api/transaction/get-transactions.schema.json';
+        await validate(schemaPath, response);
+      }
+      res.json(response);
+    })
+  );
 
   return router;
 }

--- a/src/inspector-util.ts
+++ b/src/inspector-util.ts
@@ -3,7 +3,7 @@ import * as stream from 'stream';
 import { once } from 'events';
 import { createServer, Server } from 'http';
 import * as express from 'express';
-import { addAsync } from '@awaitjs/express';
+import { asyncHandler } from './api/async-handler';
 import { logError, logger, parsePort, stopwatch, timeout, pipelineAsync } from './helpers';
 import { Socket } from 'net';
 import * as os from 'os';
@@ -289,115 +289,124 @@ export async function startProfilerServer(
   if (httpServerPort !== undefined) {
     serverPort = parsePort(httpServerPort);
   }
-  const app = addAsync(express());
+  const app = express();
 
   let existingSession:
     | { instance: ProfilerInstance<unknown>; response: express.Response }
     | undefined;
 
-  app.getAsync('/profile/cpu', async (req, res) => {
-    if (existingSession) {
-      res.status(409).json({ error: 'Profile session already in progress' });
-      return;
-    }
-    const durationParam = req.query['duration'];
-    const seconds = Number.parseFloat(durationParam as string);
-    if (!Number.isFinite(seconds) || seconds < 0) {
-      res.status(400).json({ error: `Invalid 'duration' query parameter "${durationParam}"` });
-      return;
-    }
-    const samplingIntervalParam = req.query['sampling_interval'];
-    let samplingInterval: number | undefined;
-    if (samplingIntervalParam !== undefined) {
-      samplingInterval = Number.parseFloat(samplingIntervalParam as string);
-      if (!Number.isInteger(samplingInterval) || samplingInterval < 0) {
-        res.status(400).json({
-          error: `Invalid 'sampling_interval' query parameter "${samplingIntervalParam}"`,
-        });
+  app.get(
+    '/profile/cpu',
+    asyncHandler(async (req, res) => {
+      if (existingSession) {
+        res.status(409).json({ error: 'Profile session already in progress' });
         return;
       }
-    }
-    const cpuProfiler = initCpuProfiling(samplingInterval);
-    existingSession = { instance: cpuProfiler, response: res };
-    try {
-      const filename = `cpu_${Math.round(Date.now() / 1000)}_${seconds}-seconds.cpuprofile`;
-      res.setHeader('Cache-Control', 'no-store');
-      res.setHeader('Transfer-Encoding', 'chunked');
-      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
-      res.setHeader('Content-Type', 'application/json; charset=utf-8');
-      res.flushHeaders();
-      await cpuProfiler.start();
-      const ac = new AbortController();
-      const timeoutPromise = timeout(seconds * 1000, ac);
-      await Promise.race([timeoutPromise, once(res, 'close')]);
-      if (res.writableEnded || res.destroyed) {
-        // session was cancelled
-        ac.abort();
+      const durationParam = req.query['duration'];
+      const seconds = Number.parseFloat(durationParam as string);
+      if (!Number.isFinite(seconds) || seconds < 0) {
+        res.status(400).json({ error: `Invalid 'duration' query parameter "${durationParam}"` });
         return;
       }
-      const result = await cpuProfiler.stop();
-      const resultString = JSON.stringify(result);
-      logger.info(
-        `[CpuProfiler] Completed, total profile report JSON string length: ${resultString.length}`
-      );
-      res.end(resultString);
-    } finally {
-      await existingSession.instance.dispose().catch();
-      existingSession = undefined;
-    }
-  });
-
-  app.getAsync('/profile/heap_snapshot', async (req, res) => {
-    if (existingSession) {
-      res.status(409).json({ error: 'Profile session already in progress' });
-      return;
-    }
-    const filename = `heap_${Math.round(Date.now() / 1000)}.heapsnapshot`;
-    const tmpFile = path.join(os.tmpdir(), filename);
-    const fileWriteStream = fs.createWriteStream(tmpFile);
-    const heapProfiler = initHeapSnapshot(fileWriteStream);
-    existingSession = { instance: heapProfiler, response: res };
-    try {
-      res.setHeader('Cache-Control', 'no-store');
-      res.setHeader('Transfer-Encoding', 'chunked');
-      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
-      res.setHeader('Content-Type', 'application/json; charset=utf-8');
-      res.flushHeaders();
-      // Taking a heap snapshot (with current implementation) is a one-shot process ran to get the
-      // applications current heap memory usage, rather than something done over time. So start and
-      // stop without waiting.
-      await heapProfiler.start();
-      const result = await heapProfiler.stop();
-      logger.info(
-        `[HeapProfiler] Completed, total snapshot byte size: ${result.totalSnapshotByteSize}`
-      );
-      await pipelineAsync(fs.createReadStream(tmpFile), res);
-    } finally {
-      await existingSession.instance.dispose().catch();
-      existingSession = undefined;
+      const samplingIntervalParam = req.query['sampling_interval'];
+      let samplingInterval: number | undefined;
+      if (samplingIntervalParam !== undefined) {
+        samplingInterval = Number.parseFloat(samplingIntervalParam as string);
+        if (!Number.isInteger(samplingInterval) || samplingInterval < 0) {
+          res.status(400).json({
+            error: `Invalid 'sampling_interval' query parameter "${samplingIntervalParam}"`,
+          });
+          return;
+        }
+      }
+      const cpuProfiler = initCpuProfiling(samplingInterval);
+      existingSession = { instance: cpuProfiler, response: res };
       try {
-        fileWriteStream.destroy();
-      } catch (_) {}
-      try {
-        logger.info(`[HeapProfiler] Cleaning up tmp file ${tmpFile}`);
-        fs.unlinkSync(tmpFile);
-      } catch (_) {}
-    }
-  });
+        const filename = `cpu_${Math.round(Date.now() / 1000)}_${seconds}-seconds.cpuprofile`;
+        res.setHeader('Cache-Control', 'no-store');
+        res.setHeader('Transfer-Encoding', 'chunked');
+        res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+        res.flushHeaders();
+        await cpuProfiler.start();
+        const ac = new AbortController();
+        const timeoutPromise = timeout(seconds * 1000, ac);
+        await Promise.race([timeoutPromise, once(res, 'close')]);
+        if (res.writableEnded || res.destroyed) {
+          // session was cancelled
+          ac.abort();
+          return;
+        }
+        const result = await cpuProfiler.stop();
+        const resultString = JSON.stringify(result);
+        logger.info(
+          `[CpuProfiler] Completed, total profile report JSON string length: ${resultString.length}`
+        );
+        res.end(resultString);
+      } finally {
+        await existingSession.instance.dispose().catch();
+        existingSession = undefined;
+      }
+    })
+  );
 
-  app.getAsync('/profile/cancel', async (req, res) => {
-    if (!existingSession) {
-      res.status(409).json({ error: 'No existing profile session is exists to cancel' });
-      return;
-    }
-    const session = existingSession;
-    await session.instance.stop().catch();
-    await session.instance.dispose().catch();
-    session.response.destroy();
-    existingSession = undefined;
-    await Promise.resolve();
-    res.json({ ok: 'existing profile session stopped' });
-  });
+  app.get(
+    '/profile/heap_snapshot',
+    asyncHandler(async (req, res) => {
+      if (existingSession) {
+        res.status(409).json({ error: 'Profile session already in progress' });
+        return;
+      }
+      const filename = `heap_${Math.round(Date.now() / 1000)}.heapsnapshot`;
+      const tmpFile = path.join(os.tmpdir(), filename);
+      const fileWriteStream = fs.createWriteStream(tmpFile);
+      const heapProfiler = initHeapSnapshot(fileWriteStream);
+      existingSession = { instance: heapProfiler, response: res };
+      try {
+        res.setHeader('Cache-Control', 'no-store');
+        res.setHeader('Transfer-Encoding', 'chunked');
+        res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+        res.flushHeaders();
+        // Taking a heap snapshot (with current implementation) is a one-shot process ran to get the
+        // applications current heap memory usage, rather than something done over time. So start and
+        // stop without waiting.
+        await heapProfiler.start();
+        const result = await heapProfiler.stop();
+        logger.info(
+          `[HeapProfiler] Completed, total snapshot byte size: ${result.totalSnapshotByteSize}`
+        );
+        await pipelineAsync(fs.createReadStream(tmpFile), res);
+      } finally {
+        await existingSession.instance.dispose().catch();
+        existingSession = undefined;
+        try {
+          fileWriteStream.destroy();
+        } catch (_) {}
+        try {
+          logger.info(`[HeapProfiler] Cleaning up tmp file ${tmpFile}`);
+          fs.unlinkSync(tmpFile);
+        } catch (_) {}
+      }
+    })
+  );
+
+  app.get(
+    '/profile/cancel',
+    asyncHandler(async (req, res) => {
+      if (!existingSession) {
+        res.status(409).json({ error: 'No existing profile session is exists to cancel' });
+        return;
+      }
+      const session = existingSession;
+      await session.instance.stop().catch();
+      await session.instance.dispose().catch();
+      session.response.destroy();
+      existingSession = undefined;
+      await Promise.resolve();
+      res.json({ ok: 'existing profile session stopped' });
+    })
+  );
 
   const server = createServer(app);
 

--- a/src/tests/microblocks-tests.ts
+++ b/src/tests/microblocks-tests.ts
@@ -103,6 +103,7 @@ describe('microblock tests', () => {
         expect(mbResult1.status).toBe(404);
         const mbHash2 = '0xab9112694f13f7b04996d4b4554af5b5890271fa4e0c9099e67353b42dcf9989';
         const mbResult2 = await supertest(api.server).get(`/extended/v1/microblock/${mbHash2}`);
+        expect(mbResult2.status).toBe(404);
       }
     );
   });


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/878

Removed the buggy `@awaitjs/express` lib and replaced all instances of `router.getAsync('/', async (req, res) => { ... })` with `router.get('/', asyncHandler(async (req, res) => { ... })`.

This PR _should_ have only been around 60 LOC changes, but the linting enforced whitespace changes make the changeset look huge. No routes should have any actual code changes.

With this refactor out of the way, the follow-up PR(s) adding cache-control support will be much more readable, since those will actually change the route handling code.