### PR TITLE
fix: set explicit context for docker builds in github actions

### DIFF
--- a/.github/workflows/stacks-blockchain-api.yml
+++ b/.github/workflows/stacks-blockchain-api.yml
@@ -496,6 +496,7 @@ jobs:
       - name: Build/Tag/Push Image
         uses: docker/build-push-action@v2
         with:
+          context: .
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
@@ -504,6 +505,7 @@ jobs:
       - name: Build/Tag/Push Standalone Image
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: docker/stx-rosetta.Dockerfile
           tags: ${{ steps.meta_standalone.outputs.tags }}
           labels: ${{ steps.meta_standalone.outputs.labels }}


### PR DESCRIPTION
## Description

This patch fixes the `git-info` build step for Docker Github actions.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other
