### PR TITLE
chore: fix missing contract-call tx data in tx list endpoint response

### DIFF
--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -6463,6 +6463,17 @@ describe('api tests', () => {
     expect(fetchTx.status).toBe(200);
     expect(fetchTx.type).toBe('application/json');
     expect(JSON.parse(fetchTx.text)).toEqual(expectedResp);
+
+    const expectedListResp = {
+      limit: 96,
+      offset: 0,
+      total: 1,
+      results: [excludedEvents],
+    };
+    const fetchTxList = await supertest(api.server).get(`/extended/v1/tx`);
+    expect(fetchTxList.status).toBe(200);
+    expect(fetchTxList.type).toBe('application/json');
+    expect(JSON.parse(fetchTxList.text)).toEqual(expectedListResp);
   });
 
   test('tx store and processing - abort_by_response', async () => {


### PR DESCRIPTION
Regression introduced in https://github.com/hirosystems/stacks-blockchain-api/pull/807

Contract-call txs are not being constructed properly, see https://stacks-node-api-pr-877.stacks.co/extended/v1/tx

![image](https://user-images.githubusercontent.com/1447546/145433044-6aeb73fd-2dff-4f96-8719-c5ce4fa0ef9d.png)
