### PR TITLE
Fix contract-call tx bug in `address/<principal>/transactions_with_transfers`

### DIFF
--- a/src/api/routes/debug.ts
+++ b/src/api/routes/debug.ts
@@ -729,7 +729,7 @@ export function createDebugRouter(db: DataStore): RouterWithAsync {
       res.status(404).json({ error: `cannot find contract by ID ${contract_id}` });
       return;
     }
-    const contractAbi: ClarityAbi = JSON.parse(dbContractQuery.result.abi);
+    const contractAbi: ClarityAbi = dbContractQuery.result.abi as any;
     let formHtml = contractCallHtml;
     let funcHtml = '';
 
@@ -776,7 +776,7 @@ export function createDebugRouter(db: DataStore): RouterWithAsync {
       res.status(404).json({ error: `could not find contract by ID ${contractId}` });
       return;
     }
-    const contractAbi: ClarityAbi = JSON.parse(dbContractQuery.result.abi);
+    const contractAbi: ClarityAbi = dbContractQuery.result.abi as any;
 
     const body = req.body as Record<string, string>;
     const originKey = body['origin_key'];

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -4722,6 +4722,89 @@ describe('api tests', () => {
       ],
     };
     expect(JSON.parse(fetchAddrTx2.text)).toEqual(expectedResp5);
+
+    const fetchAddrTx3 = await supertest(api.server).get(
+      `/extended/v1/address/${testAddr5}/transactions_with_transfers`
+    );
+    expect(fetchAddrTx3.status).toBe(200);
+    expect(fetchAddrTx3.type).toBe('application/json');
+    const expectedResp6 = {
+      limit: 20,
+      offset: 0,
+      total: 1,
+      results: [
+        {
+          ft_transfers: [],
+          nft_transfers: [],
+          stx_received: '0',
+          stx_sent: '4321',
+          stx_transfers: [
+            {
+              amount: '4321',
+              recipient: 'ST2F8G7616B2F8PYG216BX9AJCHP7YRK7ND7M0ZN3',
+              sender: 'ST3V11C6X2EBFN72RMS3B1NYQ1BX98F61GVYRDRXW',
+            },
+          ],
+          tx: {
+            anchor_mode: 'any',
+            block_hash: '0x1234',
+            block_height: 1,
+            burn_block_time: 39486,
+            burn_block_time_iso: '1970-01-01T10:58:06.000Z',
+            canonical: true,
+            contract_call: {
+              contract_id: 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world',
+              function_args: [
+                {
+                  hex: '0x010000000000000000000000000001e240',
+                  name: 'amount',
+                  repr: 'u123456',
+                  type: 'uint',
+                },
+                {
+                  hex: '0x0d0000000568656c6c6f',
+                  name: 'desc',
+                  repr: '"hello"',
+                  type: 'string-ascii',
+                },
+              ],
+              function_name: 'test-contract-fn',
+              function_signature:
+                '(define-public (test-contract-fn (amount uint) (desc string-ascii)))',
+            },
+            event_count: 5,
+            execution_cost_read_count: 0,
+            execution_cost_read_length: 0,
+            execution_cost_runtime: 0,
+            execution_cost_write_count: 0,
+            execution_cost_write_length: 0,
+            fee_rate: '10',
+            is_unanchored: false,
+            microblock_canonical: true,
+            microblock_hash: '',
+            microblock_sequence: 2147483647,
+            nonce: 0,
+            parent_block_hash: '',
+            parent_burn_block_time: 1626122935,
+            parent_burn_block_time_iso: '2021-07-12T20:48:55.000Z',
+            post_condition_mode: 'allow',
+            post_conditions: [],
+            sender_address: 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world',
+            sponsor_address: 'ST3J8EVYHVKH6XXPD61EE8XEHW4Y2K83861225AB1',
+            sponsored: false,
+            tx_id: '0x1232',
+            tx_index: 5,
+            tx_result: {
+              hex: '0x0100000000000000000000000000000001',
+              repr: 'u1',
+            },
+            tx_status: 'success',
+            tx_type: 'contract_call',
+          },
+        },
+      ],
+    };
+    expect(JSON.parse(fetchAddrTx3.text)).toEqual(expectedResp6);
   });
 
   test('list contract log events', async () => {


### PR DESCRIPTION
Fix another bug introduced in #807.

Contract-call tx args were missing from the endpoint
`/extended/v1/address/<principal>/transactions_with_transfers`