### PR TITLE
fix: get abi for all tx queries

### DIFF
--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -5750,9 +5750,9 @@ export class PgDataStore
             },
           };
         }
-        const contractTxResult = await client.query<TxQueryResult>(
+        const contractTxResult = await client.query<ContractTxQueryResult>(
           `
-          SELECT ${TX_COLUMNS}
+          SELECT ${TX_COLUMNS}. ${abiColumn()}
           FROM txs
           WHERE smart_contract_contract_id = $1
           ORDER BY canonical DESC, microblock_canonical DESC, block_height DESC

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -6104,20 +6104,11 @@ export class PgDataStore
       const maxBlockHeight = await this.getMaxBlockHeight(client, { includeUnanchored });
       const result = await client.query<ContractTxQueryResult>(
         `
-        SELECT ${TX_COLUMNS},
-          CASE
-            WHEN txs.type_id = $3 THEN (
-              SELECT abi
-              FROM smart_contracts
-              WHERE smart_contracts.contract_id = txs.contract_call_contract_id
-              ORDER BY abi != 'null' DESC, canonical DESC, microblock_canonical DESC, block_height DESC
-              LIMIT 1
-            )
-          END as abi
+        SELECT ${TX_COLUMNS}, ${abiColumn()}
         FROM txs
         WHERE tx_id = ANY($1) AND block_height <= $2 AND canonical = true AND microblock_canonical = true
         `,
-        [values, maxBlockHeight, DbTxTypeId.ContractCall]
+        [values, maxBlockHeight]
       );
       if (result.rowCount === 0) {
         return [];

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -2982,7 +2982,7 @@ export class PgDataStore
         `,
         [hexToBuffer(blockQuery.result.index_block_hash)]
       );
-      const result = await client.query<ContractTxQueryResult & { count: number }>(
+      const result = await client.query<ContractTxQueryResult>(
         `
         SELECT ${TX_COLUMNS}, ${abiColumn()}
         FROM txs

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -3656,9 +3656,9 @@ export class PgDataStore
 
   async getTxStrict(args: { txId: string; indexBlockHash: string }): Promise<FoundOrNot<DbTx>> {
     return this.query(async client => {
-      const result = await client.query<TxQueryResult>(
+      const result = await client.query<ContractTxQueryResult>(
         `
-        SELECT ${TX_COLUMNS}
+        SELECT ${TX_COLUMNS}, ${abiColumn()}
         FROM txs
         WHERE tx_id = $1 AND index_block_hash = $2
         ORDER BY canonical DESC, microblock_canonical DESC, block_height DESC

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -2587,9 +2587,9 @@ export class PgDataStore
       let microblocksAccepted: DbMicroblock[] | null = null;
       let microblocksStreamed: DbMicroblock[] | null = null;
       if (metadata?.txs) {
-        const txQuery = await client.query<TxQueryResult>(
+        const txQuery = await client.query<ContractTxQueryResult>(
           `
-          SELECT ${TX_COLUMNS}
+          SELECT ${TX_COLUMNS}, ${abiColumn()}
           FROM txs
           WHERE index_block_hash = $1
           ORDER BY microblock_sequence DESC, tx_index DESC

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -5752,7 +5752,7 @@ export class PgDataStore
         }
         const contractTxResult = await client.query<ContractTxQueryResult>(
           `
-          SELECT ${TX_COLUMNS}. ${abiColumn()}
+          SELECT ${TX_COLUMNS}, ${abiColumn()}
           FROM txs
           WHERE smart_contract_contract_id = $1
           ORDER BY canonical DESC, microblock_canonical DESC, block_height DESC

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -248,6 +248,7 @@ describe('Rosetta API', () => {
     const blockHeight = 2;
     const block = await api.datastore.getBlock({ height: blockHeight });
     assert(block.found);
+    // FIXME: contract call tests
     const txs = await api.datastore.getBlockTxsRows(block.result.block_hash);
     assert(txs.found);
     const query1 = await supertest(api.address)

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -248,7 +248,6 @@ describe('Rosetta API', () => {
     const blockHeight = 2;
     const block = await api.datastore.getBlock({ height: blockHeight });
     assert(block.found);
-    // FIXME: contract call tests
     const txs = await api.datastore.getBlockTxsRows(block.result.block_hash);
     assert(txs.found);
     const query1 = await supertest(api.address)

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -4177,7 +4177,6 @@ describe('api tests', () => {
       burn_block_time: block.burn_block_time,
       parent_burn_block_time: 1626122935,
       type_id: DbTxTypeId.ContractCall,
-      coinbase_payload: Buffer.from('coinbase hi'),
       status: 1,
       raw_result: '0x0100000000000000000000000000000001', // u1
       canonical: true,
@@ -4672,6 +4671,11 @@ describe('api tests', () => {
       ],
     };
     expect(JSON.parse(fetchAddrTx1.text)).toEqual(expectedResp4);
+
+    const blockTxsRows = await api.datastore.getBlockTxsRows(block.block_hash);
+    expect(blockTxsRows.found).toBe(true);
+    const blockTxsRowsResult = blockTxsRows.result as DbTx[];
+    expect(blockTxsRowsResult[6]).toEqual({ ...contractCall, ...{ abi: contractJsonAbi } });
 
     const fetchAddrTx2 = await supertest(api.server).get(
       `/extended/v1/address/${testAddr5}/transactions`

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -2569,7 +2569,6 @@ describe('api tests', () => {
     await db.updateTx(client, smartContract);
 
     // test contract address
-    // FIXME: Contract call test
     const searchResult9 = await supertest(api.server).get(`/extended/v1/search/${contractAddr1}`);
     expect(searchResult9.status).toBe(200);
     expect(searchResult9.type).toBe('application/json');
@@ -4966,6 +4965,10 @@ describe('api tests', () => {
     expect(searchResult8.status).toBe(200);
     expect(searchResult8.type).toBe('application/json');
     expect(JSON.parse(searchResult8.text).result.metadata).toEqual(contractCallExpectedResults);
+
+    const blockQuery = await getBlockFromDataStore({ blockIdentifer: { hash: '0x1234' }, db });
+    expect(blockQuery.found).toBe(true);
+    expect((blockQuery.result as Block).txs[1]).toEqual(contractCallExpectedResults);
   });
 
   test('list contract log events', async () => {
@@ -6473,7 +6476,6 @@ describe('api tests', () => {
     };
     await db.updateTx(client, tx);
 
-    // FIXME: Test contract call
     const blockQuery = await getBlockFromDataStore({
       blockIdentifer: { hash: block.block_hash },
       db,

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -7924,6 +7924,7 @@ describe('api tests', () => {
       execution_cost_write_length: 0,
     };
     await db.updateTx(client, tx);
+    // FIXME: Test contract call
     const result = await supertest(api.server).get(
       `/extended/v1/tx/block/${block.block_hash}?limit=20&offset=0`
     );

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -1783,7 +1783,6 @@ describe('api tests', () => {
     };
     await db.updateMempoolTxs({ mempoolTxs: [mempoolTx] });
 
-    // FIXME: contract call test
     const searchResult1 = await supertest(api.server).get(
       `/extended/v1/search/0x1234000000000000000000000000000000000000000000000000000000000000`
     );
@@ -4166,7 +4165,7 @@ describe('api tests', () => {
       abi: JSON.stringify(contractJsonAbi),
     };
     const contractCall: DbTx = {
-      tx_id: '0x1232',
+      tx_id: '0x1232000000000000000000000000000000000000000000000000000000000000',
       tx_index: 5,
       anchor_mode: 3,
       nonce: 0,
@@ -4533,7 +4532,7 @@ describe('api tests', () => {
           execution_cost_write_length: 0,
         },
         {
-          tx_id: '0x1232',
+          tx_id: '0x1232000000000000000000000000000000000000000000000000000000000000',
           tx_status: 'success',
           tx_result: {
             hex: '0x0100000000000000000000000000000001', // u1
@@ -4688,7 +4687,7 @@ describe('api tests', () => {
       total: 1,
       results: [
         {
-          tx_id: '0x1232',
+          tx_id: '0x1232000000000000000000000000000000000000000000000000000000000000',
           tx_status: 'success',
           tx_result: {
             hex: '0x0100000000000000000000000000000001', // u1
@@ -4816,7 +4815,7 @@ describe('api tests', () => {
             sender_address: 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world',
             sponsor_address: 'ST3J8EVYHVKH6XXPD61EE8XEHW4Y2K83861225AB1',
             sponsored: false,
-            tx_id: '0x1232',
+            tx_id: '0x1232000000000000000000000000000000000000000000000000000000000000',
             tx_index: 5,
             tx_result: {
               hex: '0x0100000000000000000000000000000001',
@@ -4831,7 +4830,7 @@ describe('api tests', () => {
     expect(JSON.parse(fetchAddrTx3.text)).toEqual(expectedResp6);
 
     const fetchAddrTx4 = await supertest(api.server).get(
-      `/extended/v1/address/${testAddr5}/0x1232/with_transfers`
+      `/extended/v1/address/${testAddr5}/0x1232000000000000000000000000000000000000000000000000000000000000/with_transfers`
     );
     expect(fetchAddrTx4.status).toBe(200);
     expect(fetchAddrTx4.type).toBe('application/json');
@@ -4892,7 +4891,7 @@ describe('api tests', () => {
         sender_address: 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world',
         sponsor_address: 'ST3J8EVYHVKH6XXPD61EE8XEHW4Y2K83861225AB1',
         sponsored: false,
-        tx_id: '0x1232',
+        tx_id: '0x1232000000000000000000000000000000000000000000000000000000000000',
         tx_index: 5,
         tx_result: {
           hex: '0x0100000000000000000000000000000001',
@@ -4903,6 +4902,70 @@ describe('api tests', () => {
       },
     };
     expect(JSON.parse(fetchAddrTx4.text)).toEqual(expectedResp7);
+
+    const contractCallExpectedResults = {
+      tx_id: '0x1232000000000000000000000000000000000000000000000000000000000000',
+      tx_status: 'success',
+      tx_result: {
+        hex: '0x0100000000000000000000000000000001', // u1
+        repr: 'u1',
+      },
+      tx_type: 'contract_call',
+      fee_rate: '10',
+      is_unanchored: false,
+      nonce: 0,
+      anchor_mode: 'any',
+      sender_address: 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world',
+      sponsor_address: 'ST3J8EVYHVKH6XXPD61EE8XEHW4Y2K83861225AB1',
+      sponsored: false,
+      post_condition_mode: 'allow',
+      post_conditions: [],
+      block_hash: '0x1234',
+      block_height: 1,
+      burn_block_time: 39486,
+      burn_block_time_iso: '1970-01-01T10:58:06.000Z',
+      canonical: true,
+      microblock_canonical: true,
+      microblock_hash: '',
+      microblock_sequence: I32_MAX,
+      parent_block_hash: '',
+      parent_burn_block_time: 1626122935,
+      parent_burn_block_time_iso: '2021-07-12T20:48:55.000Z',
+      tx_index: 5,
+      contract_call: {
+        contract_id: 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world',
+        function_name: 'test-contract-fn',
+        function_signature: '(define-public (test-contract-fn (amount uint) (desc string-ascii)))',
+        function_args: [
+          {
+            hex: '0x010000000000000000000000000001e240',
+            name: 'amount',
+            repr: 'u123456',
+            type: 'uint',
+          },
+          {
+            hex: '0x0d0000000568656c6c6f',
+            name: 'desc',
+            repr: '"hello"',
+            type: 'string-ascii',
+          },
+        ],
+      },
+      event_count: 5,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
+    };
+
+    // test tx search
+    const searchResult8 = await supertest(api.server).get(
+      `/extended/v1/search/0x1232000000000000000000000000000000000000000000000000000000000000?include_metadata`
+    );
+    expect(searchResult8.status).toBe(200);
+    expect(searchResult8.type).toBe('application/json');
+    expect(JSON.parse(searchResult8.text).result.metadata).toEqual(contractCallExpectedResults);
   });
 
   test('list contract log events', async () => {

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -1783,6 +1783,7 @@ describe('api tests', () => {
     };
     await db.updateMempoolTxs({ mempoolTxs: [mempoolTx] });
 
+    // TODO: contract call test
     const searchResult1 = await supertest(api.server).get(
       `/extended/v1/search/0x1234000000000000000000000000000000000000000000000000000000000000`
     );

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -2570,6 +2570,7 @@ describe('api tests', () => {
     await db.updateTx(client, smartContract);
 
     // test contract address
+    // FIXME: Contract call test
     const searchResult9 = await supertest(api.server).get(`/extended/v1/search/${contractAddr1}`);
     expect(searchResult9.status).toBe(200);
     expect(searchResult9.type).toBe('application/json');

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -1783,7 +1783,7 @@ describe('api tests', () => {
     };
     await db.updateMempoolTxs({ mempoolTxs: [mempoolTx] });
 
-    // TODO: contract call test
+    // FIXME: contract call test
     const searchResult1 = await supertest(api.server).get(
       `/extended/v1/search/0x1234000000000000000000000000000000000000000000000000000000000000`
     );
@@ -6406,7 +6406,7 @@ describe('api tests', () => {
     };
     await db.updateTx(client, tx);
 
-    // TODO: Test contract call
+    // FIXME: Test contract call
     const blockQuery = await getBlockFromDataStore({
       blockIdentifer: { hash: block.block_hash },
       db,

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -6404,6 +6404,7 @@ describe('api tests', () => {
     };
     await db.updateTx(client, tx);
 
+    // TODO: Test contract call
     const blockQuery = await getBlockFromDataStore({
       blockIdentifer: { hash: block.block_hash },
       db,


### PR DESCRIPTION
Adds the rest of abi columns for the remaining `txs` queries.
#858 