### PR TITLE
chore: gh action caching for docker build layers

### DIFF
--- a/.github/workflows/stacks-blockchain-api.yml
+++ b/.github/workflows/stacks-blockchain-api.yml
@@ -505,6 +505,8 @@ jobs:
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
           push: ${{ (github.ref != 'refs/heads/master' || steps.semantic.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM node:14-alpine
 
 WORKDIR /app
-COPY . .
 
 RUN apk add --no-cache --virtual .build-deps alpine-sdk python3 git openjdk8-jre cmake
+COPY package.json package-lock.json ./
+RUN npm config set unsafe-perm true && npm install
+COPY . .
 RUN echo "GIT_TAG=$(git tag --points-at HEAD)" >> .env
-RUN npm config set unsafe-perm true && npm install && npm run build && npm prune --production
+RUN npm run build && npm prune --production
 RUN apk del .build-deps
 
 CMD ["node", "./lib/index.js"]


### PR DESCRIPTION
Enable github action caching for build layers. Minor changes to `Dockerfile` to cache the `apk add ...` and `npm install ...` steps.

Should bring image build time down from minutes to tens of seconds.