### PR TITLE
hotfix: ignore out of order attachments failing to resolve tx data

### DIFF
--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -4273,11 +4273,11 @@ export class PgDataStore
           ]
         );
         if (txQuery.rowCount === 0) {
-          throw new Error(
-            `Could not find tx index for subdomain entry: ${JSON.stringify(subdomain)}`
-          );
+          logger.warn(`Could not find tx index for subdomain entry: ${JSON.stringify(subdomain)}`);
+          txIndex = 0;
+        } else {
+          txIndex = txQuery.rows[0].tx_index;
         }
-        txIndex = txQuery.rows[0].tx_index;
       }
       // preparing bns values for insertion
       values.push(


### PR DESCRIPTION
Event replay/import was failing if a `/attachments/new` event was received out-of-order from the block/tx that anchors it:

```
Raw event requests processed: 94% (102200 / 108623)
Raw event requests processed: 95% (103200 / 108623)
Raw event requests processed: 96% (104300 / 108623)
Raw event requests processed: 97% (105400 / 108623)
Raw event requests processed: 98% (106500 / 108623)
{"message":"Could not find transaction 0xc9c246838ac346ac5b2167bf73e7f20d9e3a431a902713a4538fe700a8d80f42 associated with attachment","level":"warn","timestamp":"2021-12-21T18:48:35.423Z"}
{"level":"error","message":"Error processing new attachment message Could not find tx index for subdomain entry: {\"name\":\"id.stx\",\"namespace_id\":\"stx\",\"fully_qualified_subdomain\":\"peterdutoit.id.stx\",\"owner\":\"SP3M5KQ0PWMQVANE2W1WNJ51QFFBEMW23MMHTCB2N\",\"zonefile_hash\":\"b84aee15ca8b8043bd8a45607488e1c1\",\"zonefile\":\"$ORIGIN peterdutoit.id.stx\\n$TTL 3600\\n_http._tcp\\tIN\\tURI\\t10\\t1\\t\\\"https://gaia.blockstack.org/hub/1NBZR4vxGqgwQVir6bxq3niFC818ofZVPN/profile.json\\\"\\n\\n\",\"tx_id\":\"0xc9c246838ac346ac5b2167bf73e7f20d9e3a431a902713a4538fe700a8d80f42\",\"tx_index\":-1,\"canonical\":true,\"parent_zonefile_hash\":\"9a1a4be850d34c05f651d4b5034c2e84614b70af\",\"parent_zonefile_index\":0,\"block_height\":41788,\"zonefile_offset\":1,\"resolver\":\"https://registrar.stacks.co\"}","stack":"Error: Could not find tx index for subdomain entry: {\"name\":\"id.stx\",\"namespace_id\":\"stx\",\"fully_qualified_subdomain\":\"peterdutoit.id.stx\",\"owner\":\"SP3M5KQ0PWMQVANE2W1WNJ51QFFBEMW23MMHTCB2N\",\"zonefile_hash\":\"b84aee15ca8b8043bd8a45607488e1c1\",\"zonefile\":\"$ORIGIN peterdutoit.id.stx\\n$TTL 3600\\n_http._tcp\\tIN\\tURI\\t10\\t1\\t\\\"https://gaia.blockstack.org/hub/1NBZR4vxGqgwQVir6bxq3niFC818ofZVPN/profile.json\\\"\\n\\n\",\"tx_id\":\"0xc9c246838ac346ac5b2167bf73e7f20d9e3a431a902713a4538fe700a8d80f42\",\"tx_index\":-1,\"canonical\":true,\"parent_zonefile_hash\":\"9a1a4be850d34c05f651d4b5034c2e84614b70af\",\"parent_zonefile_index\":0,\"block_height\":41788,\"zonefile_offset\":1,\"resolver\":\"https://registrar.stacks.co\"}\n    at PgDataStore.updateBatchSubdomains (/Users/matt/Projects/stacks-blockchain-api-pr/src/datastore/postgres-store.ts:4276:17)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at /Users/matt/Projects/stacks-blockchain-api-pr/src/datastore/postgres-store.ts:1850:7\n    at /Users/matt/Projects/stacks-blockchain-api-pr/src/datastore/postgres-store.ts:742:24\n    at PgDataStore.query (/Users/matt/Projects/stacks-blockchain-api-pr/src/datastore/postgres-store.ts:728:22)\n    at PgDataStore.queryTx (/Users/matt/Projects/stacks-blockchain-api-pr/src/datastore/postgres-store.ts:739:12)\n    at PgDataStore.resolveBnsSubdomains (/Users/matt/Projects/stacks-blockchain-api-pr/src/datastore/postgres-store.ts:1849:5)\n    at handleNewAttachmentMessage (/Users/matt/Projects/stacks-blockchain-api-pr/src/event-stream/event-server.ts:647:11)\n    at run (/Users/matt/Projects/stacks-blockchain-api-pr/node_modules/p-queue/dist/index.js:163:29)","timestamp":"2021-12-21T18:48:35.471Z"}
{"level":"error","message":"error processing core-node /attachments/new: Error: Could not find tx index for subdomain entry: {\"name\":\"id.stx\",\"namespace_id\":\"stx\",\"fully_qualified_subdomain\":\"peterdutoit.id.stx\",\"owner\":\"SP3M5KQ0PWMQVANE2W1WNJ51QFFBEMW23MMHTCB2N\",\"zonefile_hash\":\"b84aee15ca8b8043bd8a45607488e1c1\",\"zonefile\":\"$ORIGIN peterdutoit.id.stx\\n$TTL 3600\\n_http._tcp\\tIN\\tURI\\t10\\t1\\t\\\"https://gaia.blockstack.org/hub/1NBZR4vxGqgwQVir6bxq3niFC818ofZVPN/profile.json\\\"\\n\\n\",\"tx_id\":\"0xc9c246838ac346ac5b2167bf73e7f20d9e3a431a902713a4538fe700a8d80f42\",\"tx_index\":-1,\"canonical\":true,\"parent_zonefile_hash\":\"9a1a4be850d34c05f651d4b5034c2e84614b70af\",\"parent_zonefile_index\":0,\"block_height\":41788,\"zonefile_offset\":1,\"resolver\":\"https://registrar.stacks.co\"} Could not find tx index for subdomain entry: {\"name\":\"id.stx\",\"namespace_id\":\"stx\",\"fully_qualified_subdomain\":\"peterdutoit.id.stx\",\"owner\":\"SP3M5KQ0PWMQVANE2W1WNJ51QFFBEMW23MMHTCB2N\",\"zonefile_hash\":\"b84aee15ca8b8043bd8a45607488e1c1\",\"zonefile\":\"$ORIGIN peterdutoit.id.stx\\n$TTL 3600\\n_http._tcp\\tIN\\tURI\\t10\\t1\\t\\\"https://gaia.blockstack.org/hub/1NBZR4vxGqgwQVir6bxq3niFC818ofZVPN/profile.json\\\"\\n\\n\",\"tx_id\":\"0xc9c246838ac346ac5b2167bf73e7f20d9e3a431a902713a4538fe700a8d80f42\",\"tx_index\":-1,\"canonical\":true,\"parent_zonefile_hash\":\"9a1a4be850d34c05f651d4b5034c2e84614b70af\",\"parent_zonefile_index\":0,\"block_height\":41788,\"zonefile_offset\":1,\"resolver\":\"https://registrar.stacks.co\"}","stack":"Error: Could not find tx index for subdomain entry: {\"name\":\"id.stx\",\"namespace_id\":\"stx\",\"fully_qualified_subdomain\":\"peterdutoit.id.stx\",\"owner\":\"SP3M5KQ0PWMQVANE2W1WNJ51QFFBEMW23MMHTCB2N\",\"zonefile_hash\":\"b84aee15ca8b8043bd8a45607488e1c1\",\"zonefile\":\"$ORIGIN peterdutoit.id.stx\\n$TTL 3600\\n_http._tcp\\tIN\\tURI\\t10\\t1\\t\\\"https://gaia.blockstack.org/hub/1NBZR4vxGqgwQVir6bxq3niFC818ofZVPN/profile.json\\\"\\n\\n\",\"tx_id\":\"0xc9c246838ac346ac5b2167bf73e7f20d9e3a431a902713a4538fe700a8d80f42\",\"tx_index\":-1,\"canonical\":true,\"parent_zonefile_hash\":\"9a1a4be850d34c05f651d4b5034c2e84614b70af\",\"parent_zonefile_index\":0,\"block_height\":41788,\"zonefile_offset\":1,\"resolver\":\"https://registrar.stacks.co\"}\n    at PgDataStore.updateBatchSubdomains (/Users/matt/Projects/stacks-blockchain-api-pr/src/datastore/postgres-store.ts:4276:17)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at /Users/matt/Projects/stacks-blockchain-api-pr/src/datastore/postgres-store.ts:1850:7\n    at /Users/matt/Projects/stacks-blockchain-api-pr/src/datastore/postgres-store.ts:742:24\n    at PgDataStore.query (/Users/matt/Projects/stacks-blockchain-api-pr/src/datastore/postgres-store.ts:728:22)\n    at PgDataStore.queryTx (/Users/matt/Projects/stacks-blockchain-api-pr/src/datastore/postgres-store.ts:739:12)\n    at PgDataStore.resolveBnsSubdomains (/Users/matt/Projects/stacks-blockchain-api-pr/src/datastore/postgres-store.ts:1849:5)\n    at handleNewAttachmentMessage (/Users/matt/Projects/stacks-blockchain-api-pr/src/event-stream/event-server.ts:647:11)\n    at run (/Users/matt/Projects/stacks-blockchain-api-pr/node_modules/p-queue/dist/index.js:163:29)","timestamp":"2021-12-21T18:48:35.472Z"}
{"req":{"url":"/attachments/new","headers":{"content-length":"1480","content-type":"application/json","host":"127.0.0.1:50504","connection":"close"},"method":"POST","httpVersion":"1.1","originalUrl":"/attachments/new","query":{}},"res":{"statusCode":500},"responseTime":51,"level":"error","message":"HTTP POST /attachments/new","timestamp":"2021-12-21T18:48:35.473Z"}
Error: Bad status response status code 500: Internal Server Error
    at IncomingMessage.<anonymous> (/Users/matt/Projects/stacks-blockchain-api-pr/src/helpers.ts:343:29)
    at IncomingMessage.emit (node:events:402:35)
    at endReadableNT (node:internal/streams/readable:1343:12)
    at processTicksAndRejections (node:internal/process/task_queues:83:21) {
  requestUrl: 'http://127.0.0.1:50504/attachments/new',
  statusCode: 500,
  response: '{"error":{}}'
}
```

This is the first time we've seen this scenario in 40,000+ blocks. 

This PR changes the fatal error to a warning message. With the current event-replay tsv file used in Hiro production, there are two BNS attachments that are received out of order, and are inserted into the db initially without the correct corresponding tx index. This may result in those two BNS names not resolving correctly in some circumstances, but fully handling and recovering from out of order attachment events will take some time to implement. 

After this fix, event replay finishes successfully:
```
Raw event requests processed: 7% (100 / 1422)
Raw event requests processed: 14% (200 / 1422)
{"message":"Could not find transaction 0xc9c246838ac346ac5b2167bf73e7f20d9e3a431a902713a4538fe700a8d80f42 associated with attachment","level":"warn","timestamp":"2021-12-21T19:17:54.990Z"}
{"message":"Could not find tx index for subdomain entry: {\"name\":\"id.stx\",\"namespace_id\":\"stx\",\"fully_qualified_subdomain\":\"peterdutoit.id.stx\",\"owner\":\"SP3M5KQ0PWMQVANE2W1WNJ51QFFBEMW23MMHTCB2N\",\"zonefile_hash\":\"b84aee15ca8b8043bd8a45607488e1c1\",\"zonefile\":\"$ORIGIN peterdutoit.id.stx\\n$TTL 3600\\n_http._tcp\\tIN\\tURI\\t10\\t1\\t\\\"https://gaia.blockstack.org/hub/1NBZR4vxGqgwQVir6bxq3niFC818ofZVPN/profile.json\\\"\\n\\n\",\"tx_id\":\"0xc9c246838ac346ac5b2167bf73e7f20d9e3a431a902713a4538fe700a8d80f42\",\"tx_index\":-1,\"canonical\":true,\"parent_zonefile_hash\":\"9a1a4be850d34c05f651d4b5034c2e84614b70af\",\"parent_zonefile_index\":0,\"block_height\":41788,\"zonefile_offset\":1,\"resolver\":\"https://registrar.stacks.co\"}","level":"warn","timestamp":"2021-12-21T19:17:54.991Z"}
Raw event requests processed: 21% (300 / 1422)
Raw event requests processed: 28% (400 / 1422)
Raw event requests processed: 35% (500 / 1422)
{"message":"Could not find transaction 0xa8e1f0d4a9bafc77ff9477e5ff75b0836cc20f9820c60c435b450d931e68de9c associated with attachment","level":"warn","timestamp":"2021-12-21T19:18:02.954Z"}
{"message":"Could not find tx index for subdomain entry: {\"name\":\"id.stx\",\"namespace_id\":\"stx\",\"fully_qualified_subdomain\":\"killmeonthursday.id.stx\",\"owner\":\"SP1MYX2KJ4G1RSMTQ9TZJXJ2JK9WW1WTW6P1R2QVB\",\"zonefile_hash\":\"1c50366e39099d3c120f9c767b3ee366\",\"zonefile\":\"$ORIGIN killmeonthursday.id.stx\\n$TTL 3600\\n_http._tcp\\tIN\\tURI\\t10\\t1\\t\\\"https://gaia.blockstack.org/hub/1Af7iFNhazVVNC6sLmhj6pTXbSypUtuuuH/profile.json\\\"\\n\\n\",\"tx_id\":\"0xa8e1f0d4a9bafc77ff9477e5ff75b0836cc20f9820c60c435b450d931e68de9c\",\"tx_index\":-1,\"canonical\":true,\"parent_zonefile_hash\":\"3426727460394b66444aa72e125740b65ce6c200\",\"parent_zonefile_index\":0,\"block_height\":41881,\"zonefile_offset\":1,\"resolver\":\"https://registrar.stacks.co\"}","level":"warn","timestamp":"2021-12-21T19:18:02.955Z"}
{"message":"Invalidated 2 burnchain rewards after fork detected at burnchain block 0x00000000000000000006b6ec2b027aa37b63525ef9a7cbb1449bb51bd44ac4a9","level":"warn","timestamp":"2021-12-21T19:18:03.523Z"}
{"message":"Invalidated 2 burnchain reward slot holders after fork detected at burnchain block 0x00000000000000000006b6ec2b027aa37b63525ef9a7cbb1449bb51bd44ac4a9","level":"warn","timestamp":"2021-12-21T19:18:03.524Z"}
Raw event requests processed: 42% (600 / 1422)
Raw event requests processed: 49% (700 / 1422)
Raw event requests processed: 56% (800 / 1422)
Raw event requests processed: 63% (900 / 1422)
Raw event requests processed: 70% (1000 / 1422)
Raw event requests processed: 77% (1100 / 1422)
Raw event requests processed: 84% (1200 / 1422)
Raw event requests processed: 91% (1300 / 1422)
Raw event requests processed: 98% (1400 / 1422)
Raw event requests processed: 100% (1422 / 1422)
Event import and playback successful.
```