### PR TITLE
ci: test installing client and docs deps

### DIFF
--- a/.github/workflows/stacks-blockchain-api.yml
+++ b/.github/workflows/stacks-blockchain-api.yml
@@ -13,23 +13,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  notify-start:
-    runs-on: ubuntu-latest
-    # Only run on non-PR events or only PRs that aren't from forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    outputs:
-      slack_message_id: ${{ steps.slack.outputs.message_id }}
-    steps:
-      - name: Notify slack start
-        if: success()
-        id: slack
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1.1.2
-        with:
-          channel: devops-notify
-          status: STARTING
-          color: warning
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -139,6 +122,14 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install deps
+        run: npm install --audit=false
+
+      - name: Install client deps
+        working-directory: client
+        run: npm install --audit=false
+
+      - name: Install docs deps
+        working-directory: docs
         run: npm install --audit=false
 
       - name: Setup env vars
@@ -453,7 +444,6 @@ jobs:
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git
-            semantic-release-slack-bot
             @semantic-release/exec
 
       - name: Set up Docker Buildx
@@ -511,37 +501,3 @@ jobs:
           cache-to: type=gha,mode=max
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
           push: ${{ (github.ref != 'refs/heads/master' || steps.semantic.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-
-  notify-end:
-    runs-on: ubuntu-latest
-    needs:
-      - notify-start
-      - lint
-      - lint-docs
-      - test
-      - test-rosetta
-      - build-publish
-    # Only run on non-PR events or only PRs that aren't from forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    steps:
-      - name: Notify slack success
-        if: needs.notify-start.result != 'failure' && needs.lint.result != 'failure' && needs.lint-docs.result != 'failure' && needs.test.result != 'failure' && needs.build-publish.result != 'failure'
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1.1.2
-        with:
-          message_id: ${{ needs.notify-start.outputs.slack_message_id }}
-          channel: devops-notify
-          status: SUCCESS
-          color: good
-
-      - name: Notify slack fail
-        if: needs.notify-start.result == 'failure' || needs.lint.result == 'failure' || needs.lint-docs.result == 'failure' || needs.test.result == 'failure' || needs.build-publish.result == 'failure'
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1.1.2
-        with:
-          message_id: ${{ needs.notify-start.outputs.slack_message_id }}
-          channel: devops-notify
-          status: FAILED
-          color: danger

--- a/package.json
+++ b/package.json
@@ -79,15 +79,7 @@
       ],
       "@semantic-release/github",
       "@semantic-release/changelog",
-      "@semantic-release/git",
-      [
-        "semantic-release-slack-bot",
-        {
-          "notifyOnSuccess": true,
-          "notifyOnFail": true,
-          "markdownReleaseNotes": true
-        }
-      ]
+      "@semantic-release/git"
     ]
   },
   "commitlint": {


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/941

## Description
Adds a couple steps to the CI `test` job which installs dependencies in the `client` and `docs` directories. If there are any issues during the installation, they should now be caught before making their way to the `master` branch.

I also removed the notification jobs in the main CI workflow since they're not helpful anymore as Hiro doesn't use Slack.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No