### PR TITLE
fix: join canonical txs on latest_contract_txs view

### DIFF
--- a/src/migrations/1640210247253_latest_contract_txs-canonical.ts
+++ b/src/migrations/1640210247253_latest_contract_txs-canonical.ts
@@ -1,0 +1,164 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropMaterializedView('latest_contract_txs', { ifExists: true, cascade: true });
+  pgm.createMaterializedView('latest_contract_txs', {}, `
+    WITH contract_txs AS (
+      SELECT
+        contract_call_contract_id AS contract_id, tx_id,
+        block_height, microblock_sequence, tx_index
+      FROM txs
+      WHERE
+        contract_call_contract_id IS NOT NULL
+        AND canonical = TRUE
+        AND microblock_canonical = TRUE
+      UNION
+      SELECT
+        smart_contract_contract_id AS contract_id, tx_id,
+        block_height, microblock_sequence, tx_index
+      FROM txs
+      WHERE
+        smart_contract_contract_id IS NOT NULL
+        AND canonical = TRUE
+        AND microblock_canonical = TRUE
+      UNION
+      SELECT
+        sender_address AS contract_id, tx_id,
+        block_height, microblock_sequence, tx_index
+      FROM txs
+      WHERE
+        sender_address LIKE '%.%'
+        AND canonical = TRUE
+        AND microblock_canonical = TRUE
+      UNION
+      SELECT
+        token_transfer_recipient_address AS contract_id, tx_id,
+        block_height, microblock_sequence, tx_index
+      FROM txs
+      WHERE
+        token_transfer_recipient_address LIKE '%.%'
+        AND canonical = TRUE
+        AND microblock_canonical = TRUE
+    ),
+    numbered_txs AS (
+      SELECT
+        ROW_NUMBER() OVER (
+          PARTITION BY contract_id
+          ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC
+        ) AS r,
+        COUNT(*) OVER (
+          PARTITION BY contract_id
+        )::integer AS count,
+        contract_txs.*
+      FROM contract_txs
+    )
+    SELECT
+      numbered_txs.contract_id,
+      txs.*,
+      CASE
+        WHEN txs.type_id = 2 THEN (
+          SELECT abi
+          FROM smart_contracts
+          WHERE smart_contracts.contract_id = txs.contract_call_contract_id
+          ORDER BY abi != 'null' DESC, canonical DESC, microblock_canonical DESC, block_height DESC
+          LIMIT 1
+        )
+      END as abi,
+      numbered_txs.count
+    FROM numbered_txs
+    INNER JOIN txs USING (tx_id)
+    WHERE
+      numbered_txs.r <= 50
+      AND txs.canonical = TRUE
+      AND txs.microblock_canonical = TRUE
+  `);
+
+  pgm.createIndex('latest_contract_txs', 'contract_id');
+  pgm.createIndex('latest_contract_txs', [
+    { name: 'block_height', sort: 'DESC' },
+    { name: 'microblock_sequence', sort: 'DESC'},
+    { name: 'tx_index', sort: 'DESC' }
+  ]);
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  // Go back to the previous materialized view version, otherwise `pgm` complains it can't infer the down migration.
+  pgm.dropMaterializedView('latest_contract_txs', { ifExists: true, cascade: true });
+  pgm.createMaterializedView('latest_contract_txs', {}, `
+    WITH contract_txs AS (
+      SELECT
+        contract_call_contract_id AS contract_id, tx_id,
+        block_height, microblock_sequence, tx_index
+      FROM txs
+      WHERE
+        contract_call_contract_id IS NOT NULL
+        AND canonical = TRUE
+        AND microblock_canonical = TRUE
+      UNION
+      SELECT
+        smart_contract_contract_id AS contract_id, tx_id,
+        block_height, microblock_sequence, tx_index
+      FROM txs
+      WHERE
+        smart_contract_contract_id IS NOT NULL
+        AND canonical = TRUE
+        AND microblock_canonical = TRUE
+      UNION
+      SELECT
+        sender_address AS contract_id, tx_id,
+        block_height, microblock_sequence, tx_index
+      FROM txs
+      WHERE
+        sender_address LIKE '%.%'
+        AND canonical = TRUE
+        AND microblock_canonical = TRUE
+      UNION
+      SELECT
+        token_transfer_recipient_address AS contract_id, tx_id,
+        block_height, microblock_sequence, tx_index
+      FROM txs
+      WHERE
+        token_transfer_recipient_address LIKE '%.%'
+        AND canonical = TRUE
+        AND microblock_canonical = TRUE
+    ),
+    numbered_txs AS (
+      SELECT
+        ROW_NUMBER() OVER (
+          PARTITION BY contract_id
+          ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC
+        ) AS r,
+        COUNT(*) OVER (
+          PARTITION BY contract_id
+        )::integer AS count,
+        contract_txs.*
+      FROM contract_txs
+    )
+    SELECT
+      numbered_txs.contract_id,
+      txs.*,
+      CASE
+        WHEN txs.type_id = 2 THEN (
+          SELECT abi
+          FROM smart_contracts
+          WHERE smart_contracts.contract_id = txs.contract_call_contract_id
+          ORDER BY abi != 'null' DESC, canonical DESC, microblock_canonical DESC, block_height DESC
+          LIMIT 1
+        )
+      END as abi,
+      numbered_txs.count
+    FROM numbered_txs
+    INNER JOIN txs USING (tx_id)
+    WHERE numbered_txs.r <= 50
+  `);
+
+  pgm.createIndex('latest_contract_txs', 'contract_id');
+  pgm.createIndex('latest_contract_txs', [
+    { name: 'block_height', sort: 'DESC' },
+    { name: 'microblock_sequence', sort: 'DESC'},
+    { name: 'tx_index', sort: 'DESC' }
+  ]);
+}

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -1984,6 +1984,55 @@ describe('api tests', () => {
     expect(JSON.parse(searchResult7.text)).toEqual(expectedResp7);
   });
 
+  test('latest_contract_txs view only considers canonical transactions', async () => {
+    const contractId = 'SP3D6PV2ACBPEKYJTCMH7HEN02KP87QSP8KTEH335.megapont-ape-club-nft';
+
+    // Base block
+    const block1 = new TestBlockBuilder({ block_height: 1, block_hash: '0x01' })
+      .addTx()
+      .addTxSmartContract({ contract_id: contractId })
+      .addTxContractLogEvent({ contract_identifier: contractId })
+      .build();
+    block1.block.index_block_hash = '0x01';
+    await db.update(block1);
+
+    // Canonical block with non-canonical tx
+    const block2 = new TestBlockBuilder({ block_height: 2, block_hash: '0x02' })
+      .addTx({ tx_id: '0x123123' })
+      .build();
+    block2.block.index_block_hash = '0x02';
+    block2.block.parent_block_hash = '0x01';
+    block2.block.parent_index_block_hash = '0x01';
+    block2.txs[0].tx.index_block_hash = '0x02';
+    block2.txs[0].tx.smart_contract_contract_id = contractId;
+    block2.txs[0].tx.canonical = false; // <--
+    await db.update(block2);
+
+    // Canonical block with canonical tx
+    const block3 = new TestBlockBuilder({ block_height: 3, block_hash: '0x03' })
+      .addTx({ tx_id: '0x123123' }) // Same tx_id
+      .build();
+    block3.block.index_block_hash = '0x03';
+    block3.block.parent_block_hash = '0x02';
+    block3.block.parent_index_block_hash = '0x02';
+    block3.txs[0].tx.index_block_hash = '0x03';
+    block3.txs[0].tx.smart_contract_contract_id = contractId;
+    await db.update(block3);
+
+    const transactionsResult = await supertest(api.server).get(
+      `/extended/v1/address/${contractId}/transactions`
+    );
+    expect(transactionsResult.status).toBe(200);
+    expect(transactionsResult.type).toBe('application/json');
+    const expectedResp = {
+      found: false,
+      result: { entity_type: 'invalid_term' },
+      error: 'The term',
+    };
+    expect(JSON.parse(transactionsResult.text).total).toEqual(1);
+    expect(JSON.parse(transactionsResult.text).results[0].tx_id).toEqual('0x123123');
+  });
+
   test('search term - hash with metadata', async () => {
     const block: DbBlock = {
       block_hash: '0x1234000000000000000000000000000000000000000000000000000000000000',

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -2024,11 +2024,6 @@ describe('api tests', () => {
     );
     expect(transactionsResult.status).toBe(200);
     expect(transactionsResult.type).toBe('application/json');
-    const expectedResp = {
-      found: false,
-      result: { entity_type: 'invalid_term' },
-      error: 'The term',
-    };
     expect(JSON.parse(transactionsResult.text).total).toEqual(1);
     expect(JSON.parse(transactionsResult.text).results[0].tx_id).toEqual('0x123123');
   });


### PR DESCRIPTION
Fixes duplicate txs regression in the `/transactions` endpoint for smart contracts where we would return non-canonicals too.
```
INNER JOIN txs USING (tx_id)
    WHERE
      numbered_txs.r <= 50
      AND txs.canonical = TRUE
      AND txs.microblock_canonical = TRUE
```