### PR TITLE
fix: create latest_contract_txs materialized view for unanchored blocks

### DIFF
--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -221,7 +221,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
       offset,
       blockHeight,
       atSingleBlock,
-      isUnanchoredRequest: isUnanchoredRequest(req, res, next),
+      isUnanchoredRequest: blockParams.includeUnanchored ?? false,
     });
     // TODO: use getBlockWithMetadata or similar to avoid transaction integrity issues from lazy resolving block tx data (primarily the contract-call ABI data)
     const results = await Bluebird.mapSeries(txResults, async tx => {

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -221,6 +221,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
       offset,
       blockHeight,
       atSingleBlock,
+      isUnanchoredRequest: isUnanchoredRequest(req, res, next),
     });
     // TODO: use getBlockWithMetadata or similar to avoid transaction integrity issues from lazy resolving block tx data (primarily the contract-call ABI data)
     const results = await Bluebird.mapSeries(txResults, async tx => {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -755,6 +755,7 @@ export interface DataStore extends DataStoreEventEmitter {
     atSingleBlock: boolean;
     limit: number;
     offset: number;
+    isUnanchoredRequest: boolean;
   }): Promise<{ results: DbTx[]; total: number }>;
 
   getAddressTxsWithAssetTransfers(args: {

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -540,6 +540,7 @@ export class MemoryDataStore
     atSingleBlock: boolean;
     limit: number;
     offset: number;
+    isUnanchoredRequest: boolean;
   }): Promise<{ results: DbTx[]; total: number }> {
     throw new Error('not yet implemented');
   }

--- a/src/migrations/1640326036413_latest_contract_txs_unanchored.ts
+++ b/src/migrations/1640326036413_latest_contract_txs_unanchored.ts
@@ -1,0 +1,81 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createMaterializedView('latest_contract_txs_unanchored', {}, `
+    WITH contract_txs AS (
+      SELECT
+        contract_call_contract_id AS contract_id, tx_id,
+        block_height, microblock_sequence, tx_index
+      FROM txs
+      WHERE
+        contract_call_contract_id IS NOT NULL
+        AND canonical = TRUE
+        AND microblock_canonical = TRUE
+      UNION
+      SELECT
+        smart_contract_contract_id AS contract_id, tx_id,
+        block_height, microblock_sequence, tx_index
+      FROM txs
+      WHERE
+        smart_contract_contract_id IS NOT NULL
+        AND canonical = TRUE
+        AND microblock_canonical = TRUE
+      UNION
+      SELECT
+        sender_address AS contract_id, tx_id,
+        block_height, microblock_sequence, tx_index
+      FROM txs
+      WHERE
+        sender_address LIKE '%.%'
+        AND canonical = TRUE
+        AND microblock_canonical = TRUE
+      UNION
+      SELECT
+        token_transfer_recipient_address AS contract_id, tx_id,
+        block_height, microblock_sequence, tx_index
+      FROM txs
+      WHERE
+        token_transfer_recipient_address LIKE '%.%'
+        AND canonical = TRUE
+        AND microblock_canonical = TRUE
+    ),
+    numbered_txs AS (
+      SELECT
+        ROW_NUMBER() OVER (
+          PARTITION BY contract_id
+          ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC
+        ) AS r,
+        COUNT(*) OVER (
+          PARTITION BY contract_id
+        )::integer AS count,
+        contract_txs.*
+      FROM contract_txs
+    )
+    SELECT
+      numbered_txs.contract_id,
+      txs.*,
+      CASE
+        WHEN txs.type_id = 2 THEN (
+          SELECT abi
+          FROM smart_contracts
+          WHERE smart_contracts.contract_id = txs.contract_call_contract_id
+          ORDER BY abi != 'null' DESC, canonical DESC, microblock_canonical DESC, block_height DESC
+          LIMIT 1
+        )
+      END as abi,
+      numbered_txs.count
+    FROM numbered_txs
+    INNER JOIN txs USING (tx_id)
+    WHERE numbered_txs.r <= 50
+  `);
+
+  pgm.createIndex('latest_contract_txs_unanchored', 'contract_id');
+  pgm.createIndex('latest_contract_txs_unanchored', [
+    { name: 'block_height', sort: 'DESC' },
+    { name: 'microblock_sequence', sort: 'DESC'},
+    { name: 'tx_index', sort: 'DESC' }
+  ]);
+}

--- a/src/migrations/1640326036413_latest_contract_txs_unanchored.ts
+++ b/src/migrations/1640326036413_latest_contract_txs_unanchored.ts
@@ -73,6 +73,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   `);
 
   pgm.createIndex('latest_contract_txs_unanchored', 'contract_id');
+  pgm.createIndex('latest_contract_txs_unanchored', 'block_height');
   pgm.createIndex('latest_contract_txs_unanchored', [
     { name: 'block_height', sort: 'DESC' },
     { name: 'microblock_sequence', sort: 'DESC'},

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -43,6 +43,8 @@ import {
   DbTokenOfferingLocked,
   DataStoreTxEventData,
   DbTxAnchorMode,
+  DbMicroblockPartial,
+  DataStoreMicroblockUpdateData,
 } from '../datastore/common';
 import { startApiServer, ApiServer } from '../api/init';
 import { PgDataStore, cycleMigrations, runMigrations } from '../datastore/postgres-store';
@@ -2026,6 +2028,124 @@ describe('api tests', () => {
     expect(transactionsResult.type).toBe('application/json');
     expect(JSON.parse(transactionsResult.text).total).toEqual(1);
     expect(JSON.parse(transactionsResult.text).results[0].tx_id).toEqual('0x123123');
+  });
+
+  test('/transactions materialized view separates anchored and unanchored counts correctly', async () => {
+    const contractId = 'SP3D6PV2ACBPEKYJTCMH7HEN02KP87QSP8KTEH335.megapont-ape-club-nft';
+
+    // Base block
+    const block1 = new TestBlockBuilder({
+      block_height: 1,
+      block_hash: '0x01',
+      index_block_hash: '0x01',
+    })
+      .addTx()
+      .addTxSmartContract({ contract_id: contractId })
+      .addTxContractLogEvent({ contract_identifier: contractId })
+      .build();
+    await db.update(block1);
+
+    // Create 50 contract txs to fill up the materialized view at block_height=2
+    const blockBuilder2 = new TestBlockBuilder({
+      block_height: 2,
+      block_hash: '0x02',
+      index_block_hash: '0x02',
+      parent_block_hash: '0x01',
+      parent_index_block_hash: '0x01',
+    });
+    for (let i = 0; i < 50; i++) {
+      blockBuilder2.addTx({
+        tx_id: '0x1234' + i.toString().padStart(4, '0'),
+        index_block_hash: '0x02',
+        smart_contract_contract_id: contractId,
+      });
+    }
+    const block2 = blockBuilder2.build();
+    await db.update(block2);
+
+    // Now create 10 contract txs in the next microblock.
+    const mbData: DataStoreMicroblockUpdateData = {
+      microblocks: [
+        {
+          microblock_hash: '0xff01',
+          microblock_sequence: 0,
+          microblock_parent_hash: block2.block.block_hash,
+          parent_index_block_hash: block2.block.index_block_hash,
+          parent_burn_block_height: 123,
+          parent_burn_block_hash: '0xaa',
+          parent_burn_block_time: 1626122935,
+        },
+      ],
+      txs: [],
+    };
+    for (let i = 0; i < 10; i++) {
+      mbData.txs.push({
+        tx: {
+          tx_id: '0x1235' + i.toString().padStart(4, '0'),
+          tx_index: 0,
+          anchor_mode: 3,
+          nonce: 0,
+          raw_tx: Buffer.alloc(0),
+          type_id: DbTxTypeId.TokenTransfer,
+          status: 1,
+          raw_result: '0x0100000000000000000000000000000001', // u1
+          canonical: true,
+          post_conditions: Buffer.from([0x01, 0xf5]),
+          fee_rate: 1234n,
+          sponsored: false,
+          sender_address: 'SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27',
+          sponsor_address: undefined,
+          origin_hash_mode: 1,
+          token_transfer_amount: 50n,
+          token_transfer_memo: Buffer.from('hi'),
+          token_transfer_recipient_address: contractId,
+          event_count: 1,
+          parent_index_block_hash: block2.block.index_block_hash,
+          parent_block_hash: block2.block.block_hash,
+          microblock_canonical: true,
+          microblock_sequence: mbData.microblocks[0].microblock_sequence,
+          microblock_hash: mbData.microblocks[0].microblock_hash,
+          parent_burn_block_time: mbData.microblocks[0].parent_burn_block_time,
+          execution_cost_read_count: 0,
+          execution_cost_read_length: 0,
+          execution_cost_runtime: 0,
+          execution_cost_write_count: 0,
+          execution_cost_write_length: 0,
+          smart_contract_contract_id: contractId,
+          index_block_hash: '',
+          block_hash: '',
+          burn_block_time: -1,
+          block_height: -1,
+        },
+        stxLockEvents: [],
+        stxEvents: [],
+        ftEvents: [],
+        nftEvents: [],
+        contractLogEvents: [],
+        smartContracts: [],
+        names: [],
+        namespaces: [],
+      });
+    }
+    await db.updateMicroblocks(mbData);
+
+    // Anchored results first page should be 50 (50 at block_height=2)
+    const anchoredResult = await supertest(api.server).get(
+      `/extended/v1/address/${contractId}/transactions?limit=50&unanchored=false`
+    );
+    expect(anchoredResult.status).toBe(200);
+    expect(anchoredResult.type).toBe('application/json');
+    expect(JSON.parse(anchoredResult.text).total).toEqual(50); // 50 txs up to block_height=2
+    expect(JSON.parse(anchoredResult.text).results.length).toEqual(50);
+
+    // Unanchored results first page should also be 50 (40 at block_height=2, 10 at unanchored block_height=3)
+    const unanchoredResult = await supertest(api.server).get(
+      `/extended/v1/address/${contractId}/transactions?limit=50&unanchored=true`
+    );
+    expect(unanchoredResult.status).toBe(200);
+    expect(unanchoredResult.type).toBe('application/json');
+    expect(JSON.parse(unanchoredResult.text).total).toEqual(60); // 60 txs up to unanchored block_height=3
+    expect(JSON.parse(unanchoredResult.text).results.length).toEqual(50);
   });
 
   test('search term - hash with metadata', async () => {

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -859,6 +859,7 @@ describe('postgres datastore', () => {
       offset: 0,
       blockHeight: blockHeight,
       atSingleBlock: false,
+      isUnanchoredRequest: false,
     });
     const addrBResult = await db.getAddressTxs({
       stxAddress: 'addrB',
@@ -866,6 +867,7 @@ describe('postgres datastore', () => {
       offset: 0,
       blockHeight: blockHeight,
       atSingleBlock: false,
+      isUnanchoredRequest: false,
     });
     const addrCResult = await db.getAddressTxs({
       stxAddress: 'addrC',
@@ -873,6 +875,7 @@ describe('postgres datastore', () => {
       offset: 0,
       blockHeight: blockHeight,
       atSingleBlock: false,
+      isUnanchoredRequest: false,
     });
     const addrDResult = await db.getAddressTxs({
       stxAddress: 'addrD',
@@ -880,6 +883,7 @@ describe('postgres datastore', () => {
       offset: 0,
       blockHeight: blockHeight,
       atSingleBlock: false,
+      isUnanchoredRequest: false,
     });
     const addrEResult = await db.getAddressTxs({
       stxAddress: 'addrE',
@@ -887,6 +891,7 @@ describe('postgres datastore', () => {
       offset: 0,
       blockHeight: blockHeight,
       atSingleBlock: false,
+      isUnanchoredRequest: false,
     });
     const addrEResultP2 = await db.getAddressTxs({
       stxAddress: 'addrE',
@@ -894,6 +899,7 @@ describe('postgres datastore', () => {
       offset: 3,
       blockHeight: blockHeight,
       atSingleBlock: false,
+      isUnanchoredRequest: false,
     });
 
     expect(addrEResult.total).toBe(5);
@@ -1040,6 +1046,7 @@ describe('postgres datastore', () => {
       offset: 0,
       blockHeight: 2,
       atSingleBlock: true,
+      isUnanchoredRequest: false,
     });
 
     const addrAAllBlockResult = await db.getAddressTxs({
@@ -1048,6 +1055,7 @@ describe('postgres datastore', () => {
       offset: 0,
       blockHeight: 2,
       atSingleBlock: false,
+      isUnanchoredRequest: false,
     });
 
     expect(addrAAtBlockResult.total).toBe(4);

--- a/src/tests/test-helpers.ts
+++ b/src/tests/test-helpers.ts
@@ -115,13 +115,19 @@ export class TestBlockBuilder {
   private data: DataStoreBlockUpdateData;
   private txIndex = 0;
 
-  constructor(args?: { block_height?: number; block_hash?: string }) {
+  constructor(args?: {
+    block_height?: number;
+    block_hash?: string;
+    index_block_hash?: string;
+    parent_block_hash?: string;
+    parent_index_block_hash?: string;
+  }) {
     this.data = {
       block: {
         block_hash: args?.block_hash ?? '0x1234',
-        index_block_hash: '0xdeadbeef',
-        parent_index_block_hash: '0x00',
-        parent_block_hash: '0xff0011',
+        index_block_hash: args?.index_block_hash ?? '0xdeadbeef',
+        parent_index_block_hash: args?.parent_block_hash ?? '0x00',
+        parent_block_hash: args?.parent_block_hash ?? '0xff0011',
         parent_microblock_hash: '',
         block_height: args?.block_height ?? 1,
         burn_block_time: 94869286,
@@ -146,6 +152,8 @@ export class TestBlockBuilder {
     sender_address?: string;
     type_id?: DbTxTypeId;
     tx_id?: string;
+    index_block_hash?: string;
+    smart_contract_contract_id?: string;
   }): TestBlockBuilder {
     this.data.txs.push({
       tx: {
@@ -154,7 +162,7 @@ export class TestBlockBuilder {
         anchor_mode: 3,
         nonce: 0,
         raw_tx: Buffer.alloc(0),
-        index_block_hash: this.data.block.index_block_hash,
+        index_block_hash: args?.index_block_hash ?? this.data.block.index_block_hash,
         block_hash: this.data.block.block_hash,
         block_height: this.data.block.block_height,
         burn_block_time: this.data.block.burn_block_time,
@@ -168,6 +176,7 @@ export class TestBlockBuilder {
         sponsored: false,
         sponsor_address: undefined,
         sender_address: args?.sender_address ?? TestBlockBuilder.SENDER_ADDRESS,
+        smart_contract_contract_id: args?.smart_contract_contract_id,
         origin_hash_mode: 1,
         coinbase_payload: Buffer.from('hi'),
         event_count: 1,


### PR DESCRIPTION
Fixes a regression in the `/extended/v1/:addr/transactions` endpoint where if a smart contract had more than 50 transactions in the *anchored* block, and then it received some new transactions (for example 10) in the next *unanchored* block, they both were bundled into the same materialized view that has a limit of 50 cached transactions.

After this happened, if somebody requested the first 50 **anchored** transactions, the API sent back only 40 (50 minus the 10 unanchored txs at the next block).

The solution is to create a copy of the materialized view that is only refreshed in unanchored situations and then choose which one to query when the endpoint is called.