### PR TITLE
chore: add project automation gh workflow

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -12,7 +12,7 @@ jobs:
     name: Assign Auto-Generated PRs
     steps:
     - name: Assign pull requests opened by dependabot or snyk-bot
-      uses: srggrs/assign-one-project-github-action@1
+      uses: srggrs/assign-one-project-github-action@1.3.1
       if: contains(github.event.pull_request.user.login, 'dependabot') || contains(github.event.pull_request.user.login, 'snyk-bot')
       with:
         project: 'https://github.com/orgs/hirosystems/projects/11/'

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,19 @@
+name: Project Automation
+
+on:
+  pull_request:
+    types: [opened, labeled]
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+jobs:
+  auto-generated-prs:
+    runs-on: ubuntu-latest
+    name: Assign Auto-Generated PRs
+    steps:
+    - name: Assign pull requests opened by dependabot or snyk-bot
+      uses: srggrs/assign-one-project-github-action@1
+      if: contains(github.event.pull_request.user.login, 'dependabot') || contains(github.event.pull_request.user.login, 'snyk-bot')
+      with:
+        project: 'https://github.com/orgs/hirosystems/projects/11/'
+        column_name: 'Auto-generated PRs'


### PR DESCRIPTION
## Description
Adds a new GH workflow that will add auto-generated PRs (e.g. from dependabot or snyk) to the Auto-generated PRs column in the API org dashboard.

cc @saralab 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other