### PR TITLE
fix(rosetta): off-by-one nonce returned with rosetta /account/balance…

### DIFF
--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -544,8 +544,8 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
         return;
       }
       const results: AddressNonces = {
-        last_executed_tx_nonce: nonceQuery.result.nonce,
-        possible_next_nonce: nonceQuery.result.nonce + 1,
+        last_executed_tx_nonce: nonceQuery.result.lastExecutedTxNonce as number,
+        possible_next_nonce: nonceQuery.result.possibleNextNonce,
         // Note: OpenAPI type generator doesn't support `nullable: true` so force cast it here
         last_mempool_tx_nonce: (null as unknown) as number,
         detected_missing_nonces: [],

--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -71,6 +71,7 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
       stxAddress: accountIdentifier.address,
       blockIdentifier: { height: block.block_height },
     });
+    const sequenceNumber = accountNonceQuery.found ? accountNonceQuery.result.possibleNextNonce : 0;
 
     const extra_metadata: any = {};
 
@@ -120,7 +121,7 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
         },
       ],
       metadata: {
-        sequence_number: accountNonceQuery.found ? accountNonceQuery.result.nonce ?? 0 : 0,
+        sequence_number: sequenceNumber,
       },
     };
 

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -780,7 +780,7 @@ export interface DataStore extends DataStoreEventEmitter {
   getAddressNonceAtBlock(args: {
     stxAddress: string;
     blockIdentifier: BlockIdentifier;
-  }): Promise<FoundOrNot<{ nonce: number }>>;
+  }): Promise<FoundOrNot<{ lastExecutedTxNonce: number | null; possibleNextNonce: number }>>;
 
   getAddressNonces(args: {
     stxAddress: string;

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -573,7 +573,7 @@ export class MemoryDataStore
   getAddressNonceAtBlock(args: {
     stxAddress: string;
     blockIdentifier: BlockIdentifier;
-  }): Promise<FoundOrNot<{ nonce: number }>> {
+  }): Promise<FoundOrNot<{ lastExecutedTxNonce: number | null; possibleNextNonce: number }>> {
     throw new Error('not yet implemented');
   }
 

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -4016,6 +4016,7 @@ describe('api tests', () => {
 
   test('address nonce', async () => {
     const testAddr1 = 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C';
+    const testAddr2 = 'ST5F760KN84TZK3VTZCTVFYCVXQBEVKNV9M7H2CW';
 
     const block1 = new TestBlockBuilder({
       block_height: 1,
@@ -4116,6 +4117,34 @@ describe('api tests', () => {
     expect(nonceResults4.status).toBe(200);
     expect(nonceResults4.type).toBe('application/json');
     expect(nonceResults4.body).toEqual(expectedNonceResults4);
+
+    // Get nonce for account with no transactions
+    const expectedNonceResultsNoTxs1 = {
+      detected_missing_nonces: [],
+      last_executed_tx_nonce: null,
+      last_mempool_tx_nonce: null,
+      possible_next_nonce: 0,
+    };
+    const nonceResultsNoTxs1 = await supertest(api.server).get(
+      `/extended/v1/address/${testAddr2}/nonces`
+    );
+    expect(nonceResultsNoTxs1.status).toBe(200);
+    expect(nonceResultsNoTxs1.type).toBe('application/json');
+    expect(nonceResultsNoTxs1.body).toEqual(expectedNonceResultsNoTxs1);
+
+    // Get nonce for account with no transactions
+    const expectedNonceResultsNoTxs2 = {
+      detected_missing_nonces: [],
+      last_executed_tx_nonce: null,
+      last_mempool_tx_nonce: null,
+      possible_next_nonce: 0,
+    };
+    const nonceResultsNoTxs2 = await supertest(api.server).get(
+      `/extended/v1/address/${testAddr2}/nonces?block_height=${block2.block.block_height}`
+    );
+    expect(nonceResultsNoTxs2.status).toBe(200);
+    expect(nonceResultsNoTxs2.type).toBe('application/json');
+    expect(nonceResultsNoTxs2.body).toEqual(expectedNonceResultsNoTxs2);
 
     // Bad requests
     const nonceResults5 = await supertest(api.server).get(


### PR DESCRIPTION
Fixes https://github.com/hirosystems/stacks-blockchain-api/issues/961

The last used nonce was being returned as opposed to the next nonce.