### PR TITLE
fix: reconnect broken pgnotify clients

### DIFF
--- a/src/datastore/postgres-notifier.ts
+++ b/src/datastore/postgres-notifier.ts
@@ -54,17 +54,27 @@ type PgNotificationCallback = (notification: PgNotification) => void;
  * https://www.postgresql.org/docs/12/sql-notify.html
  */
 export class PgNotifier {
-  readonly pgChannelName: string = 'pg-notifier';
-  subscriber: Subscriber;
+  private readonly pgChannelName: string = 'pg-notifier';
+  private readonly clientConfig: ClientConfig;
+  private eventCallback?: PgNotificationCallback;
+  private subscriber?: Subscriber;
 
   constructor(clientConfig: ClientConfig) {
-    this.subscriber = createPostgresSubscriber(clientConfig);
+    this.clientConfig = clientConfig;
   }
 
   public async connect(eventCallback: PgNotificationCallback) {
-    this.subscriber.notifications.on(this.pgChannelName, message =>
-      eventCallback(message.notification)
-    );
+    this.eventCallback = eventCallback;
+    await this.doConnect();
+  }
+
+  async doConnect() {
+    this.subscriber = createPostgresSubscriber(this.clientConfig);
+    this.subscriber.notifications.on(this.pgChannelName, message => {
+      if (this.eventCallback) {
+        this.eventCallback(message.notification);
+      }
+    });
     this.subscriber.events.on('error', error => logError('Fatal PgNotifier error', error));
     await this.subscriber.connect();
     await this.subscriber.listenTo(this.pgChannelName);
@@ -99,15 +109,30 @@ export class PgNotifier {
   }
 
   public async close() {
-    await this.subscriber.unlisten(this.pgChannelName);
-    await this.subscriber.close();
+    await this.subscriber?.unlisten(this.pgChannelName);
+    await this.subscriber?.close();
   }
 
   private async notify(notification: PgNotification) {
-    await this.subscriber
-      .notify(this.pgChannelName, { notification: notification })
-      .catch(error =>
-        logError(`Error sending PgNotifier notification of type: ${notification.type}`, error)
-      );
+    if (this.subscriber) {
+      await this.subscriber
+        .notify(this.pgChannelName, { notification: notification })
+        .catch(async error => {
+          if (
+            error instanceof Error &&
+            error.message === 'Client has encountered a connection error and is not queryable'
+          ) {
+            // The postgres client has lost the connection or has otherwise become corrupt. We will attempt to
+            // reconnect so we can continue sending events.
+            // There's no point in calling `unlisten` before closing the current client since it requires a query.
+            await this.subscriber?.close();
+            await this.doConnect();
+            // Try again now.
+            await this.subscriber?.notify(this.pgChannelName, { notification: notification });
+          } else {
+            logError(`Error sending PgNotifier notification of type: ${notification.type}`, error);
+          }
+        });
+    }
   }
 }

--- a/src/datastore/postgres-notifier.ts
+++ b/src/datastore/postgres-notifier.ts
@@ -118,10 +118,7 @@ export class PgNotifier {
       await this.subscriber
         .notify(this.pgChannelName, { notification: notification })
         .catch(async error => {
-          if (
-            error instanceof Error &&
-            error.message === 'Client has encountered a connection error and is not queryable'
-          ) {
+          if (error instanceof Error && error.message.includes('not queryable')) {
             // The postgres client has lost the connection or has otherwise become corrupt. We will attempt to
             // reconnect so we can continue sending events.
             // There's no point in calling `unlisten` before closing the current client since it requires a query.

--- a/src/datastore/postgres-notifier.ts
+++ b/src/datastore/postgres-notifier.ts
@@ -61,8 +61,8 @@ export class PgNotifier {
     this.subscriber = createPostgresSubscriber(clientConfig, {
       native: false,
       paranoidChecking: 30000, // 30s
-      retryLimit: undefined, // Keep trying until it works or the API shuts down
-      retryTimeout: undefined,
+      retryLimit: Infinity, // Keep trying until it works or the API shuts down
+      retryTimeout: Infinity,
       retryInterval: attempt => {
         const retryMs = 1000;
         logger.info(`PgNotifier reconnection attempt ${attempt}, trying again in ${retryMs}ms`);


### PR DESCRIPTION
Configure `pg-listen` reconnection settings to retry indefinitely while the database is restarting.

Fixes #960 