### PR TITLE
fix: ensure `Cache-Control` is specified in 304 response

### DIFF
--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -156,6 +156,11 @@ export async function startApiServer(opts: {
     (() => {
       const router = addAsync(express.Router());
       router.use(cors());
+      router.use((req, res, next) => {
+        // Set caching on all routes to be disabled by default, individual routes can override
+        res.set('Cache-Control', 'no-store');
+        next();
+      });
       router.use('/tx', createTxRouter(datastore));
       router.use('/block', createBlockRouter(datastore));
       router.use('/microblock', createMicroblockRouter(datastore));


### PR DESCRIPTION
Fixes caching issue with certain CDNs (e.g. Cloudflare) where intermediate caching will only be performed if the `304 CACHE OK` response _also_ includes the `Cache-Control` headers.

Cloudflare will perform intermediate caching when the following page rules are applied for `/v1/extended/*`:
![image](https://user-images.githubusercontent.com/1447546/149184164-8799633b-56cf-4319-bdfa-0cbbde62be0b.png)
