### PR TITLE
feat: add write-only mode

### DIFF
--- a/.env
+++ b/.env
@@ -17,9 +17,18 @@ PG_SSL=false
 # Enable to have stacks-node events streamed to a file while the application is running
 # STACKS_EXPORT_EVENTS_FILE=/tmp/stacks-events.tsv
 
-# Initializes the API in read-only mode i.e. without an event server that listens to events from a node and writes them
-# to the local database. The API will only read data from the PG database specified above to respond to requests.
-# STACKS_READ_ONLY_MODE=true
+# If specified, controls the Stacks Blockchain API mode. The possible values are:
+# * `readonly`: Runs the API endpoints without an Event Server that listens to events from a node and
+#       writes them to the local database. The API will only read data from the PG database
+#       specified above to respond to requests.
+# * `writeonly`: Runs the Event Server without API endpoints. Useful when looking to query the postgres
+#       database containing blockchain data exclusively without the overhead of a web server.
+# * `offline`: Run the API endpoints without a stacks-node or postgres connection. In this mode,
+#       only the given Rosetta endpoints are supported:
+#       https://www.rosetta-api.org/docs/node_deployment.html#offline-mode-endpoints
+# If not specified or any other value is provided, the API will run in the default `read-write` mode
+# (with both Event Server and API endpoints).
+# STACKS_API_MODE=
 
 # If specified, an http server providing profiling capability endpoints will be opened on the given port.
 # This port should not be publicly exposed.
@@ -62,11 +71,6 @@ MAINNET_SEND_MANY_CONTRACT_ID=SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-man
 
 # Directory containing Stacks 1.0 BNS data extracted from https://storage.googleapis.com/blockstack-v1-migration-data/export-data.tar.gz
 # BNS_IMPORT_DIR=/extracted/export-data-dir/
-
-# Used to run the API without a stacks-node or postgres connection.
-# In this mode, only the given rosetta endpoints are supported:
-# https://www.rosetta-api.org/docs/node_deployment.html#offline-mode-endpoints .
-# STACKS_API_OFFLINE_MODE=1
 
 # Override the default file path for the proxy cache control file
 # STACKS_API_PROXY_CACHE_CONTROL_FILE=/path/to/.proxy-cache-control.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,6 +52,28 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Launch: mocknet write-only",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only", "-r", "tsconfig-paths/register"],
+      "args": ["${workspaceFolder}/src/index.ts"],
+      "outputCapture": "std",
+      "internalConsoleOptions": "openOnSessionStart",
+      "preLaunchTask": "stacks-node:deploy-dev",
+      "postDebugTask": "stacks-node:stop-dev",
+      "env": {
+        "STACKS_API_MODE": "writeonly",
+        "STACKS_BLOCKCHAIN_API_DB": "pg",
+        "STACKS_CHAIN_ID": "0x80000000",
+        "NODE_ENV": "development",
+        "TS_NODE_SKIP_IGNORE": "true"
+      },
+      "killBehavior": "polite",
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Launch: read-only",
       "skipFiles": [
         "<node_internals>/**"
@@ -69,7 +91,7 @@
       "internalConsoleOptions": "openOnSessionStart",
       "env": {
         "STACKS_BLOCKCHAIN_API_PORT": "3998",
-        "STACKS_READ_ONLY_MODE": "true",
+        "STACKS_API_MODE": "readonly",
         "STACKS_BLOCKCHAIN_API_DB": "pg",
         "STACKS_CHAIN_ID": "0x80000000",
         "NODE_ENV": "development",

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 ## Quick start
 
-A self-contained Docker image is provided which starts a Stacks 2.0 blockchain and API instance.
+A self-contained Docker image is provided which starts a Stacks 2.05 blockchain and API instance.
 
 Ensure Docker is installed, then run the command:
 
@@ -59,23 +59,39 @@ If upgrading the API to a new major version (e.g. `3.0.0` to `4.0.0`) then the P
 
 [Event Replay](#event-replay) must be used when upgrading major versions. Follow the event replay [instructions](#event-replay-instructions) below. Failure to do so will require wiping both the Stacks Blockchain chainstate data and the API Postgres database, and re-syncing from scratch.
 
-### Offline mode
+## API Run Modes
 
-In Offline mode app runs without a stacks-node or postgres connection. In this mode, only the given rosetta endpoints are supported:
-https://www.rosetta-api.org/docs/node_deployment.html#offline-mode-endpoints .
+The API supports a series of run modes, each accomodating different use cases for scaling and data access by toggling [architecture](#architecture) components on or off depending on its objective.
 
-For running offline mode set an environment variable `STACKS_API_OFFLINE_MODE=1`
+### Default mode (Read-write)
+
+The default mode runs with all components enabled. It consumes events from a Stacks node, writes them to a postgres database, and serves API endpoints.
+
+### Write-only mode
+
+During Write-only mode, the API only runs the Stacks node events server to populate the postgres database but it does not serve any API endpoints.
+
+This mode is very useful when you need to consume blockchain data from the postgres database directly and you're not interested in taking on the overhead of running an API web server.
+
+For write-only mode, set the environment variable `STACKS_API_MODE=writeonly`.
 
 ### Read-only mode
 
-During Read-only mode, the API runs without an internal event server that listens to events from a stacks-node.
+During Read-only mode, the API runs without an internal event server that listens to events from a Stacks node.
 The API only reads data from the connected postgres database when building endpoint responses.
 In order to keep serving updated blockchain data, this mode requires the presence of another API instance that keeps writing stacks-node events to the same database.
 
 This mode is very useful when building an environment that load-balances incoming HTTP requests between multiple API instances that can be scaled up and down very quickly.
 Read-only instances support websockets and socket.io clients.
 
-For read-only mode, set the environment variable `STACKS_READ_ONLY_MODE=1`.
+For read-only mode, set the environment variable `STACKS_API_MODE=readonly`.
+
+### Offline mode
+
+In Offline mode app runs without a stacks-node or postgres connection. In this mode, only the given rosetta endpoints are supported:
+https://www.rosetta-api.org/docs/node_deployment.html#offline-mode-endpoints.
+
+For running offline mode set an environment variable `STACKS_API_MODE=offline`
 
 ## Event Replay
 
@@ -112,7 +128,6 @@ events should be appended. Example:
 ```
 STACKS_EXPORT_EVENTS_FILE=/tmp/stacks-node-events.tsv
 ```
-
 
 # Client library
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -25,7 +25,6 @@ export const isProdEnv =
   process.env.NODE_ENV === 'prod' ||
   !process.env.NODE_ENV ||
   (!isTestEnv && !isDevEnv);
-export const isReadOnlyMode = parseArgBoolean(process.env['STACKS_READ_ONLY_MODE']);
 
 export const APP_DIR = __dirname;
 export const REPO_DIR = path.dirname(__dirname);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
   isProdEnv,
   numberToHex,
   httpPostRequest,
-  isReadOnlyMode,
+  parseArgBoolean,
 } from './helpers';
 import * as sourceMapSupport from 'source-map-support';
 import { DataStore } from './datastore/common';
@@ -30,8 +30,52 @@ import { Socket } from 'net';
 import * as getopts from 'getopts';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as net from 'net';
 import { injectC32addressEncodeCache } from './c32-addr-cache';
+
+enum StacksApiMode {
+  /**
+   * Default mode. Runs both the Event Server and API endpoints. AKA read-write mode.
+   */
+  default,
+  /**
+   * Runs the API endpoints without an Event Server. A connection to a `default`
+   * or `writeOnly` API's postgres DB is required.
+   */
+  readOnly,
+  /**
+   * Runs the Event Server only.
+   */
+  writeOnly,
+  /**
+   * Runs without an Event Server or API endpoints. Used for Rosetta only.
+   */
+  offline,
+}
+
+/**
+ * Determines the current API execution mode based on .env values.
+ * @returns detected StacksApiMode
+ */
+function getApiMode(): StacksApiMode {
+  switch (process.env['STACKS_API_MODE']) {
+    case 'readonly':
+      return StacksApiMode.readOnly;
+    case 'writeonly':
+      return StacksApiMode.writeOnly;
+    case 'offline':
+      return StacksApiMode.offline;
+    default:
+      break;
+  }
+  // Make sure we're backwards compatible if `STACKS_API_MODE` is not specified.
+  if (parseArgBoolean(process.env['STACKS_READ_ONLY_MODE'])) {
+    return StacksApiMode.readOnly;
+  }
+  if (parseArgBoolean(process.env['STACKS_API_OFFLINE_MODE'])) {
+    return StacksApiMode.offline;
+  }
+  return StacksApiMode.default;
+}
 
 loadDotEnv();
 
@@ -90,9 +134,10 @@ async function init(): Promise<void> {
         '`/extended/v1/status` endpoint. Please execute `npm run build` to regenerate it.'
     );
   }
+  const apiMode = getApiMode();
 
   let db: DataStore;
-  if ('STACKS_API_OFFLINE_MODE' in process.env) {
+  if (apiMode === StacksApiMode.offline) {
     db = OfflineDummyStore;
   } else {
     switch (process.env['STACKS_BLOCKCHAIN_API_DB']) {
@@ -103,7 +148,7 @@ async function init(): Promise<void> {
       }
       case 'pg':
       case undefined: {
-        const skipMigrations = isReadOnlyMode;
+        const skipMigrations = apiMode === StacksApiMode.readOnly;
         db = await PgDataStore.connect(skipMigrations);
         break;
       }
@@ -114,7 +159,7 @@ async function init(): Promise<void> {
       }
     }
 
-    if (!isReadOnlyMode) {
+    if (apiMode !== StacksApiMode.readOnly) {
       if (db instanceof PgDataStore) {
         if (isProdEnv) {
           await importV1TokenOfferingData(db);
@@ -169,14 +214,16 @@ async function init(): Promise<void> {
     }
   }
 
-  const apiServer = await startApiServer({ datastore: db, chainId: getConfiguredChainID() });
-  logger.info(`API server listening on: http://${apiServer.address}`);
-  registerShutdownConfig({
-    name: 'API Server',
-    handler: () => apiServer.terminate(),
-    forceKillable: true,
-    forceKillHandler: () => apiServer.forceKill(),
-  });
+  if (apiMode !== StacksApiMode.writeOnly) {
+    const apiServer = await startApiServer({ datastore: db, chainId: getConfiguredChainID() });
+    logger.info(`API server listening on: http://${apiServer.address}`);
+    registerShutdownConfig({
+      name: 'API Server',
+      handler: () => apiServer.terminate(),
+      forceKillable: true,
+      forceKillHandler: () => apiServer.forceKill(),
+    });
+  }
 
   const profilerHttpServerPort = process.env['STACKS_PROFILER_PORT'];
   if (profilerHttpServerPort) {


### PR DESCRIPTION
- Add `writeonly` API mode
- Unify `readonly` and `offline` modes into a single ENV setting alongside `writeonly`
- Update README

Closes #965 

TODO: Test in a dedicated deployment to measure performance and any other considerations that could've been missed cc @CharlieC3 