### PR TITLE
feat: exit immediately when stacks-node block desync detected

### DIFF
--- a/.github/workflows/stacks-blockchain-api.yml
+++ b/.github/workflows/stacks-blockchain-api.yml
@@ -438,6 +438,7 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2.7.0

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -110,6 +110,7 @@ import {
   PgTokensNotificationPayload,
   PgTxNotificationPayload,
 } from './postgres-notifier';
+import { ExitCode, panicShutdown } from '../shutdown-handler';
 
 const MIGRATIONS_TABLE = 'pgmigrations';
 const MIGRATIONS_DIR = path.join(APP_DIR, 'migrations');
@@ -2363,11 +2364,12 @@ export class PgDataStore
         );
       }
       if (parentResult.rowCount === 0) {
-        throw new Error(
+        const error = new Error(
           `DB does not contain a parent block at height ${block.block_height - 1} with index_hash ${
             block.parent_index_block_hash
           }`
         );
+        panicShutdown(error, ExitCode.EventEmitterDesync);
       }
 
       // This blocks builds off a previously orphaned chain. Restore canonical status for this chain.

--- a/src/shutdown-handler.ts
+++ b/src/shutdown-handler.ts
@@ -1,4 +1,4 @@
-import { logError, logger, resolveOrTimeout } from './helpers';
+import { getEnumDescription, logError, logger, resolveOrTimeout } from './helpers';
 
 const SHUTDOWN_SIGNALS = ['SIGINT', 'SIGTERM'] as const;
 
@@ -13,6 +13,22 @@ type ShutdownConfig = {
 const shutdownConfigs: ShutdownConfig[] = [];
 
 let isShuttingDown = false;
+
+export enum ExitCode {
+  OK = 0,
+  GenericError = 1,
+  EventEmitterDesync = 4,
+}
+
+/**
+ * Causes the application to exit immediately due to a fatal error.
+ */
+export function panicShutdown(error: Error, exitCode: ExitCode): never {
+  console.error(error);
+  console.error(`Panic shutdown from "${error.message}"`);
+  console.error(`Error code ${getEnumDescription(ExitCode, exitCode)}`);
+  return process.exit(exitCode);
+}
 
 async function startShutdown() {
   if (isShuttingDown) {


### PR DESCRIPTION
(Note: for now, this is primarily a testing PR for debugging desync issues)

This PR changes the behavior for when the API encounters a "desync" error with the `stacks-node` (event emitter). A desync being: when the stacks-node emits a `/new_block` event containing a pointer to a parent block that the API has _not_ received from any previous `/new_block` events. Typically this happens when some out-of-order or buggy shutdown sequence occurs between the API and `stacks-node`.

The API is unable to handle re-orgs and serve data in a "lossy" mode with missing blocks/txs. So prior to this PR, the API would return an http error response to the `stacks-node`, then the `stacks-node` would try to re-emit the same event, and this would just repeat indefinitely. This results in the db `event_observer_requests` table growing indefinitely, and a configured tsv output file growing indefinitely. 


With this PR, when a desync occurs, the program exits immediately with a specific error message and exit code.