### PR TITLE
Fix: add link to client library documentation

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -12,6 +12,10 @@ This package provides the ability to:
 - Subscribe to WebSockets or Socket.io for real-time Stacks updates (see [Available Updates](#Available-Updates))
 - Full type safety for WebSocket and API requests and responses
 
+## Documentation
+
+The documentation for the client library is published as [github pages](https://hirosystems.github.io/stacks-blockchain-api/client/).
+
 ## Installation
 
 You can install this package using NPM:


### PR DESCRIPTION
This PR
* adds a link to the documentation of the client library in the README
* fixes #979 