### PR TITLE
fix: nft event sorting

### DIFF
--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -6171,7 +6171,7 @@ export class PgDataStore
           AND txs.canonical = TRUE AND txs.microblock_canonical = TRUE
           AND nft.canonical = TRUE AND nft.microblock_canonical = TRUE
           AND nft.block_height <= $3
-        ORDER BY txs.block_height DESC, txs.microblock_sequence DESC, txs.tx_index DESC
+        ORDER BY nft.block_height DESC, txs.microblock_sequence DESC, txs.tx_index DESC
         LIMIT $4
         OFFSET $5
         `,
@@ -6229,7 +6229,7 @@ export class PgDataStore
           AND nft.canonical = TRUE AND nft.microblock_canonical = TRUE
           AND txs.canonical = TRUE AND txs.microblock_canonical = TRUE
           AND nft.block_height <= $2
-        ORDER BY nft.block_height DESC
+        ORDER BY nft.block_height DESC, txs.microblock_sequence DESC, txs.tx_index DESC
         LIMIT $3
         OFFSET $4
         `,

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -6171,7 +6171,7 @@ export class PgDataStore
           AND txs.canonical = TRUE AND txs.microblock_canonical = TRUE
           AND nft.canonical = TRUE AND nft.microblock_canonical = TRUE
           AND nft.block_height <= $3
-        ORDER BY nft.block_height DESC
+        ORDER BY txs.block_height DESC, txs.microblock_sequence DESC, txs.tx_index DESC
         LIMIT $4
         OFFSET $5
         `,

--- a/src/migrations/1588261750265_nft_events.ts
+++ b/src/migrations/1588261750265_nft_events.ts
@@ -62,6 +62,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     recipient: 'string',
   });
 
+  pgm.createIndex('nft_events', 'asset_identifier', { where: 'asset_event_type_id = 2' }); // Mints
   pgm.createIndex('nft_events', 'tx_id');
   pgm.createIndex('nft_events', [
     { name: 'block_height', sort: 'DESC'}
@@ -70,12 +71,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createIndex('nft_events', 'parent_index_block_hash');
   pgm.createIndex('nft_events', 'microblock_hash');
   pgm.createIndex('nft_events', 'microblock_sequence');
-  pgm.createIndex('nft_events', 'microblock_canonical');
   pgm.createIndex('nft_events', 'sender');
   pgm.createIndex('nft_events', 'recipient');
   pgm.createIndex('nft_events', 'event_index');
   pgm.createIndex('nft_events', ['asset_identifier', 'value']);
-  pgm.createIndex('nft_events', ['canonical', 'microblock_canonical']);
 
   pgm.addConstraint('nft_events', 'valid_asset_transfer', `CHECK (asset_event_type_id != 1 OR (
     NOT (sender, recipient) IS NULL

--- a/src/migrations/1636130197558_nft_custody.ts
+++ b/src/migrations/1636130197558_nft_custody.ts
@@ -12,16 +12,17 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     INNER JOIN
       txs USING (tx_id)
     WHERE
-      txs.canonical = true AND txs.microblock_canonical = true
+      txs.canonical = true
+      AND txs.microblock_canonical = true
+      AND nft.canonical = true
+      AND nft.microblock_canonical = true
     ORDER BY
       asset_identifier,
       value,
-      nft.block_height DESC
+      txs.block_height DESC,
+      txs.microblock_sequence DESC,
+      txs.tx_index DESC
   `);
 
-  pgm.createIndex('nft_custody', ['asset_identifier', 'value']);
-  pgm.createIndex('nft_custody', 'recipient');
-  pgm.createIndex('nft_custody', [
-    { name: 'block_height', sort: 'DESC' }
-  ]);
+  pgm.createIndex('nft_custody', ['recipient', 'asset_identifier']);
 }

--- a/src/migrations/1640037852136_nft_custody_unanchored.ts
+++ b/src/migrations/1640037852136_nft_custody_unanchored.ts
@@ -16,16 +16,17 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     INNER JOIN
       txs USING (tx_id)
     WHERE
-      txs.canonical = true AND txs.microblock_canonical = true
+      txs.canonical = true
+      AND txs.microblock_canonical = true
+      AND nft.canonical = true
+      AND nft.microblock_canonical = true
     ORDER BY
       asset_identifier,
       value,
-      nft.block_height DESC
+      txs.block_height DESC,
+      txs.microblock_sequence DESC,
+      txs.tx_index DESC
   `);
 
-  pgm.createIndex('nft_custody_unanchored', ['asset_identifier', 'value']);
-  pgm.createIndex('nft_custody_unanchored', 'recipient');
-  pgm.createIndex('nft_custody_unanchored', [
-    { name: 'block_height', sort: 'DESC' }
-  ]);
+  pgm.createIndex('nft_custody_unanchored', ['recipient', 'asset_identifier']);
 }

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -7244,7 +7244,7 @@ describe('api tests', () => {
       parent_microblock_hash: microblock1.microblocks[0].microblock_hash,
       parent_microblock_sequence: microblock1.microblocks[0].microblock_sequence,
       // Ensure micro-orphaned tx `0x1002` is not included
-      txs: ['0x1001', '0x0002'],
+      txs: ['0x0002', '0x1001'],
     };
     expect(fetch2.status).toBe(200);
     expect(fetch2.type).toBe('application/json');

--- a/src/tests/token-tests.ts
+++ b/src/tests/token-tests.ts
@@ -273,7 +273,6 @@ describe('/extended/v1/tokens tests', () => {
       })
       .addTx({ tx_id: '0x1009' })
       .addTxStxEvent({ event_index: 0 })
-      // Transfer #1
       .addTxNftEvent({
         asset_identifier: assetId2,
         asset_event_type_id: DbAssetEventTypeId.Transfer,
@@ -287,7 +286,6 @@ describe('/extended/v1/tokens tests', () => {
         microblock_sequence: 1,
       })
       .addTx({ tx_id: '0x100a' })
-      // Mint #2
       .addTxNftEvent({
         asset_identifier: assetId2,
         asset_event_type_id: DbAssetEventTypeId.Transfer,


### PR DESCRIPTION
* Fixes an edge case in which an NFT could have several sequential events all in the same `block_height` (i.e. in different microblocks for the same block) and events would be returned in the wrong order for that block
* Optimizes some indexes on `nft_events` including the addition of a "mint events" index
* Optimizes indexes on the `nft_custody` materialized views
* Fixes `tx_index` and `event_index` on test block builders