### PR TITLE
feat: use primary pg server for notifier

### DIFF
--- a/.env
+++ b/.env
@@ -5,14 +5,28 @@ PG_PASSWORD=postgres
 PG_DATABASE=stacks_blockchain_api
 PG_SCHEMA=public
 PG_SSL=false
+# The connection URI below can be used in place of the PG variables above,
+# but if enabled it must be defined without others or omitted.
+# PG_CONNECTION_URI=
+
+# If your PG deployment implements a combination of primary server and read replicas, you should
+# specify the values below to point to the primary server. The API will use primary when
+# implementing LISTEN/NOTIFY postgres messages for websocket/socket.io support.
+# Any value not provided here will fall back to the default equivalent above.
+# PG_PRIMARY_HOST=
+# PG_PRIMARY_PORT=
+# PG_PRIMARY_USER=
+# PG_PRIMARY_PASSWORD=
+# PG_PRIMARY_DATABASE=
+# PG_PRIMARY_SCHEMA=
+# PG_PRIMARY_SSL=
+# The connection URI below can be used in place of the PG variables above,
+# but if enabled it must be defined without others or omitted.
+# PG_PRIMARY_CONNECTION_URI=
 
 # Limit to how many concurrent connections can be created, defaults to 10
 # See https://node-postgres.com/api/pool
 # PG_CONNECTION_POOL_MAX=10
-
-# The connection URI below can be used in place of the PG variables above,
-# but if enabled it must be defined without others or omitted.
-# PG_CONNECTION_URI=
 
 # Enable to have stacks-node events streamed to a file while the application is running
 # STACKS_EXPORT_EVENTS_FILE=/tmp/stacks-events.tsv

--- a/.env
+++ b/.env
@@ -12,6 +12,9 @@ PG_SSL=false
 # If your PG deployment implements a combination of primary server and read replicas, you should
 # specify the values below to point to the primary server. The API will use primary when
 # implementing LISTEN/NOTIFY postgres messages for websocket/socket.io support.
+# To avoid any data inconsistencies across replicas, make sure to set `synchronous_commit` to
+# `on` or `remote_apply` on the primary database's configuration.
+# See https://www.postgresql.org/docs/12/runtime-config-wal.html
 # Any value not provided here will fall back to the default equivalent above.
 # PG_PRIMARY_HOST=
 # PG_PRIMARY_PORT=


### PR DESCRIPTION
Adds primary pg server .env vars for `PgNotifier` to use.
Related to #990 