### PR TITLE
feat: select default/primary pg server for all queries

### DIFF
--- a/.env
+++ b/.env
@@ -10,8 +10,8 @@ PG_SSL=false
 # PG_CONNECTION_URI=
 
 # If your PG deployment implements a combination of primary server and read replicas, you should
-# specify the values below to point to the primary server. The API will use primary when
-# implementing LISTEN/NOTIFY postgres messages for websocket/socket.io support.
+# specify the values below to point to the primary server. The API will use primary for
+# UPDATEs and INSERTs, and to support LISTEN/NOTIFY for websocket/socket.io messages.
 # To avoid any data inconsistencies across replicas, make sure to set `synchronous_commit` to
 # `on` or `remote_apply` on the primary database's configuration.
 # See https://www.postgresql.org/docs/12/runtime-config-wal.html

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -691,10 +691,11 @@ function getSqlQueryString(query: QueryConfig | string): string {
 export class PgDataStore
   extends (EventEmitter as { new (): DataStoreEventEmitter })
   implements DataStore {
-  readonly primaryPool: Pool;
   readonly pool: Pool;
+  readonly primaryPool: Pool;
   readonly notifier?: PgNotifier;
   readonly isEventReplay: boolean;
+
   private constructor(
     pool: Pool,
     primaryPool: Pool,
@@ -2590,7 +2591,7 @@ export class PgDataStore
       return pool;
     };
 
-    const clientConfig = getPgClientConfig();
+    const clientConfig = getPgClientConfig(PgServer.default);
     await testClientConnection(clientConfig);
     const primaryClientConfig = getPgClientConfig(PgServer.primary);
     await testClientConnection(primaryClientConfig);


### PR DESCRIPTION
Maintains two postgres pools (default and primary) and selects the appropriate one depending on each query's purpose: `INSERT` and `UPDATE` operations go to primary, `SELECT` goes to default.