### PR TITLE
Return 400 on invalid pagination query

### DIFF
--- a/src/api/pagination.ts
+++ b/src/api/pagination.ts
@@ -1,15 +1,27 @@
+import { InvalidRequestError, InvalidRequestErrorType } from 'src/errors';
+
 export function parsePagingQueryInput(val: any) {
   if (typeof val === 'number') {
     return val;
   }
   if (typeof val !== 'string') {
-    throw new Error('Input must be either typeof `string` or `number`');
+    throw new InvalidRequestError(
+      'Input must be either typeof `string` or `number`',
+      InvalidRequestErrorType.invalid_query
+    );
   }
   if (!/^\d+$/.test(val)) {
-    throw new Error('`limit` and `offset` must be integers');
+    throw new InvalidRequestError(
+      '`limit` and `offset` must be integers',
+      InvalidRequestErrorType.invalid_query
+    );
   }
   const parsedInput = parseInt(val, 10);
-  if (isNaN(parsedInput)) throw new Error('Pagination value parsed as NaN');
+  if (isNaN(parsedInput))
+    throw new InvalidRequestError(
+      'Pagination value parsed as NaN',
+      InvalidRequestErrorType.invalid_query
+    );
   return parsedInput;
 }
 
@@ -21,7 +33,8 @@ interface ParseLimitQueryParams {
 export function parseLimitQuery({ maxItems, errorMsg }: ParseLimitQueryParams) {
   return (val: any) => {
     const limit = parsePagingQueryInput(val);
-    if (limit > maxItems) throw new Error(errorMsg);
+    if (limit > maxItems)
+      throw new InvalidRequestError(errorMsg, InvalidRequestErrorType.invalid_query);
     return limit;
   };
 }

--- a/src/api/pagination.ts
+++ b/src/api/pagination.ts
@@ -1,4 +1,4 @@
-import { InvalidRequestError, InvalidRequestErrorType } from 'src/errors';
+import { InvalidRequestError, InvalidRequestErrorType } from '../errors';
 
 export function parsePagingQueryInput(val: any) {
   if (typeof val === 'number') {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -22,6 +22,7 @@ export enum InvalidRequestErrorType {
   bad_request = 'Bad request',
   invalid_param = 'Invalid param',
   invalid_address = 'Invalid address',
+  invalid_query = 'Invalid query',
 }
 export class InvalidRequestError extends Error {
   type: InvalidRequestErrorType;

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -9220,6 +9220,7 @@ describe('api tests', () => {
     };
     const metadata_error = { error: `Unexpected value for 'include_metadata' parameter: "bac"` };
     const principal_error = { error: 'invalid STX address "S.hello-world"' };
+    const pagination_error = { error: '`limit` must be equal to or less than 200' };
     // extended/v1/tx
     const searchResult1 = await supertest(api.server).get(`/extended/v1/tx/${tx_id}`);
     expect(JSON.parse(searchResult1.text)).toEqual(odd_tx_error);
@@ -9251,14 +9252,21 @@ describe('api tests', () => {
       `/extended/v1/search/${block_hash}?include_metadata=bac`
     );
     expect(JSON.parse(searchResult7.text)).toEqual(metadata_error);
-    expect(searchResult6.status).toBe(400);
+    expect(searchResult7.status).toBe(400);
 
     // extended/v1/address
     const searchResult8 = await supertest(api.server).get(
       `/extended/v1/address/${principal_addr}/stx`
     );
     expect(JSON.parse(searchResult8.text)).toEqual(principal_error);
-    expect(searchResult6.status).toBe(400);
+    expect(searchResult8.status).toBe(400);
+
+    // pagination queries
+    const searchResult9 = await supertest(api.server).get(
+      '/extended/v1/tx/mempool?limit=201&offset=2'
+    );
+    expect(JSON.parse(searchResult9.text)).toEqual(pagination_error);
+    expect(searchResult9.status).toBe(400);
   });
 
   test('empty abi', async () => {


### PR DESCRIPTION
## Description

This PR updates the errors in pagination queries to the custom error created in PR #864. It sends 400 status code and does not spam the log messages.

For details refer to issue #854 

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @rafaelcr or @zone117x for review
