### PR TITLE
ci: update CI workflow and remove slack notifs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: stacks-blockchain-api
+name: CI
 
 on:
   push:
@@ -13,23 +13,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  notify-start:
-    runs-on: ubuntu-latest
-    # Only run on non-PR events or only PRs that aren't from forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    outputs:
-      slack_message_id: ${{ steps.slack.outputs.message_id }}
-    steps:
-      - name: Notify slack start
-        if: success()
-        id: slack
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1.1.2
-        with:
-          channel: devops-notify
-          status: STARTING
-          color: warning
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -447,13 +430,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SEMANTIC_RELEASE_PACKAGE: ${{ github.workflow }}
+          SEMANTIC_RELEASE_PACKAGE: ${{ github.event.repository.name }}
         with:
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git
-            semantic-release-slack-bot
             @semantic-release/exec
 
       - name: Set up Docker Buildx
@@ -464,8 +445,8 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            blockstack/${{ github.workflow }}
-            hirosystems/${{ github.workflow }}
+            blockstack/${{ github.event.repository.name }}
+            hirosystems/${{ github.event.repository.name }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -477,8 +458,8 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            blockstack/${{ github.workflow }}-standalone
-            hirosystems/${{ github.workflow }}-standalone
+            blockstack/${{ github.event.repository.name }}-standalone
+            hirosystems/${{ github.event.repository.name }}-standalone
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -511,37 +492,3 @@ jobs:
           cache-to: type=gha,mode=max
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
           push: ${{ (github.ref != 'refs/heads/master' || steps.semantic.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-
-  notify-end:
-    runs-on: ubuntu-latest
-    needs:
-      - notify-start
-      - lint
-      - lint-docs
-      - test
-      - test-rosetta
-      - build-publish
-    # Only run on non-PR events or only PRs that aren't from forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    steps:
-      - name: Notify slack success
-        if: needs.notify-start.result != 'failure' && needs.lint.result != 'failure' && needs.lint-docs.result != 'failure' && needs.test.result != 'failure' && needs.build-publish.result != 'failure'
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1.1.2
-        with:
-          message_id: ${{ needs.notify-start.outputs.slack_message_id }}
-          channel: devops-notify
-          status: SUCCESS
-          color: good
-
-      - name: Notify slack fail
-        if: needs.notify-start.result == 'failure' || needs.lint.result == 'failure' || needs.lint-docs.result == 'failure' || needs.test.result == 'failure' || needs.build-publish.result == 'failure'
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1.1.2
-        with:
-          message_id: ${{ needs.notify-start.outputs.slack_message_id }}
-          channel: devops-notify
-          status: FAILED
-          color: danger

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: CI
 on:
   push:
     branches:
-      - '**'
+      - master
+      - develop
     tags-ignore:
       - '**'
     paths-ignore:

--- a/package.json
+++ b/package.json
@@ -79,15 +79,7 @@
       ],
       "@semantic-release/github",
       "@semantic-release/changelog",
-      "@semantic-release/git",
-      [
-        "semantic-release-slack-bot",
-        {
-          "notifyOnSuccess": true,
-          "notifyOnFail": true,
-          "markdownReleaseNotes": true
-        }
-      ]
+      "@semantic-release/git"
     ]
   },
   "commitlint": {


### PR DESCRIPTION
## Description
* Changed the name of the main workflow to just "CI". It was originally given the same name as the repository when GH Actions was much newer, and was a requirement for something hacky we were doing back then. It's not necessary anymore.
* Removed the Slack notify jobs from the CI workflow.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No
