### PR TITLE
feat: add `chain_tip` materialized view to track chain tip stats

### DIFF
--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -1192,6 +1192,7 @@ export class PgDataStore
       }
 
       await this.refreshNftCustody(client, txs, true);
+      // `chain_tip` needs to be refreshed during replay as some UPDATE queries depend on it.
       await this.refreshMaterializedView(client, 'chain_tip', false);
 
       if (this.notifier) {
@@ -1384,6 +1385,7 @@ export class PgDataStore
           }
         }
         await this.refreshNftCustody(client, batchedTxData);
+        // `chain_tip` needs to be refreshed during replay as some UPDATE queries depend on it.
         await this.refreshMaterializedView(client, 'chain_tip', false);
 
         const tokenContractDeployments = data.txs
@@ -7334,6 +7336,7 @@ export class PgDataStore
     }
     await this.queryTx(async client => {
       await this.refreshMaterializedView(client, 'nft_custody', false);
+      await this.refreshMaterializedView(client, 'chain_tip', false);
     });
   }
 

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -1198,6 +1198,7 @@ export class PgDataStore
       }
 
       await this.refreshNftCustody(client, txs, true);
+      await this.refreshMaterializedView(client, 'chain_tip');
 
       if (this.notifier) {
         dbMicroblocks.forEach(async microblock => {
@@ -1389,6 +1390,7 @@ export class PgDataStore
           }
         }
         await this.refreshNftCustody(client, batchedTxData);
+        await this.refreshMaterializedView(client, 'chain_tip');
 
         const tokenContractDeployments = data.txs
           .filter(entry => entry.tx.type_id === DbTxTypeId.SmartContract)
@@ -5024,6 +5026,7 @@ export class PgDataStore
     }
     await client.query(`REFRESH MATERIALIZED VIEW ${viewName}`);
   }
+
   async getSmartContractByTrait(args: {
     trait: ClarityAbi;
     limit: number;

--- a/src/migrations/1643755236533_chain_tip.ts
+++ b/src/migrations/1643755236533_chain_tip.ts
@@ -9,31 +9,35 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       SELECT block_height, block_hash, index_block_hash
         FROM blocks
         WHERE block_height = (SELECT MAX(block_height) FROM blocks WHERE canonical = TRUE)
-    ), microblock_stats AS (
+    ),
+    microblock_stats AS (
       SELECT microblock_hash
       FROM microblocks
       WHERE canonical = TRUE AND microblock_canonical = TRUE
       ORDER BY block_height DESC
       LIMIT 1
-    ), microblock_count AS (
+    ),
+    microblock_count AS (
       SELECT COUNT(*)::INTEGER AS microblock_count
       FROM microblocks
       WHERE canonical = TRUE AND microblock_canonical = TRUE
-    ), tx_count AS (
+    ),
+    tx_count AS (
       SELECT COUNT(*)::INTEGER AS tx_count
       FROM txs
       WHERE canonical = TRUE AND microblock_canonical = TRUE
         AND block_height <= (SELECT MAX(block_height) FROM blocks WHERE canonical = TRUE)
-    ), tx_count_unanchored AS (
+    ),
+    tx_count_unanchored AS (
       SELECT COUNT(*)::INTEGER AS tx_count_unanchored
       FROM txs
       WHERE canonical = TRUE AND microblock_canonical = TRUE
     )
     SELECT *, block_stats.block_height AS block_count
     FROM block_stats
-    CROSS JOIN microblock_stats
-    CROSS JOIN microblock_count
-    CROSS JOIN tx_count
-    CROSS JOIN tx_count_unanchored
+    LEFT JOIN microblock_stats ON TRUE
+    LEFT JOIN microblock_count ON TRUE
+    LEFT JOIN tx_count ON TRUE
+    LEFT JOIN tx_count_unanchored ON TRUE
   `);
 }

--- a/src/migrations/1643755236533_chain_tip.ts
+++ b/src/migrations/1643755236533_chain_tip.ts
@@ -5,28 +5,35 @@ export const shorthands: ColumnDefinitions | undefined = undefined;
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createMaterializedView('chain_tip', {}, `
-    WITH block_s AS (
-      SELECT MAX(block_height) AS blocks
-      FROM blocks
-      WHERE canonical = TRUE
-    ), microblock_s AS (
-      SELECT COUNT(*)::INTEGER AS microblocks
+    WITH block_stats AS (
+      SELECT block_height, block_hash, index_block_hash
+        FROM blocks
+        WHERE block_height = (SELECT MAX(block_height) FROM blocks WHERE canonical = TRUE)
+    ), microblock_stats AS (
+      SELECT microblock_hash
       FROM microblocks
       WHERE canonical = TRUE AND microblock_canonical = TRUE
-    ), tx_s AS (
-      SELECT COUNT(*)::INTEGER AS txs
+      ORDER BY block_height DESC
+      LIMIT 1
+    ), microblock_count AS (
+      SELECT COUNT(*)::INTEGER AS microblock_count
+      FROM microblocks
+      WHERE canonical = TRUE AND microblock_canonical = TRUE
+    ), tx_count AS (
+      SELECT COUNT(*)::INTEGER AS tx_count
       FROM txs
       WHERE canonical = TRUE AND microblock_canonical = TRUE
         AND block_height <= (SELECT MAX(block_height) FROM blocks WHERE canonical = TRUE)
-    ), tx_s_unanchored AS (
-      SELECT COUNT(*)::INTEGER AS txs_unanchored
+    ), tx_count_unanchored AS (
+      SELECT COUNT(*)::INTEGER AS tx_count_unanchored
       FROM txs
       WHERE canonical = TRUE AND microblock_canonical = TRUE
     )
-    SELECT block_s.blocks AS block_height, *
-    FROM block_s
-    CROSS JOIN microblock_s
-    CROSS JOIN tx_s
-    CROSS JOIN tx_s_unanchored
+    SELECT *, block_stats.block_height AS block_count
+    FROM block_stats
+    CROSS JOIN microblock_stats
+    CROSS JOIN microblock_count
+    CROSS JOIN tx_count
+    CROSS JOIN tx_count_unanchored
   `);
 }

--- a/src/migrations/1643755236533_chain_tip.ts
+++ b/src/migrations/1643755236533_chain_tip.ts
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createMaterializedView('chain_tip', {}, `
+    WITH block_s AS (
+      SELECT MAX(block_height) AS blocks
+      FROM blocks
+      WHERE canonical = TRUE
+    ), microblock_s AS (
+      SELECT COUNT(*)::INTEGER AS microblocks
+      FROM microblocks
+      WHERE canonical = TRUE AND microblock_canonical = TRUE
+    ), tx_s AS (
+      SELECT COUNT(*)::INTEGER AS txs
+      FROM txs
+      WHERE canonical = TRUE AND microblock_canonical = TRUE
+        AND block_height <= (SELECT MAX(block_height) FROM blocks WHERE canonical = TRUE)
+    ), tx_s_unanchored AS (
+      SELECT COUNT(*)::INTEGER AS txs_unanchored
+      FROM txs
+      WHERE canonical = TRUE AND microblock_canonical = TRUE
+    )
+    SELECT block_s.blocks AS block_height, *
+    FROM block_s
+    CROSS JOIN microblock_s
+    CROSS JOIN tx_s
+    CROSS JOIN tx_s_unanchored
+  `);
+}

--- a/src/tests-bns/api.ts
+++ b/src/tests-bns/api.ts
@@ -73,7 +73,12 @@ describe('BNS API tests', () => {
     client = await db.pool.connect();
     api = await startApiServer({ datastore: db, chainId: ChainID.Testnet, httpLogLevel: 'silly' });
 
-    await db.updateBlock(client, dbBlock);
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [],
+    });
 
     const namespace: DbBnsNamespace = {
       namespace_id: 'abc',

--- a/src/tests-bns/bns-integration-tests.ts
+++ b/src/tests-bns/bns-integration-tests.ts
@@ -8,7 +8,7 @@ import * as supertest from 'supertest';
 import { startEventServer } from '../event-stream/event-server';
 import { Server } from 'net';
 import { createHash } from 'crypto';
-import { DbMempoolTx, DbTx, DbTxStatus } from '../datastore/common';
+import { DbTx, DbTxStatus } from '../datastore/common';
 import { AnchorMode, ChainID, PostConditionMode, someCV } from '@stacks/transactions';
 import { StacksMocknet } from '@stacks/network';
 
@@ -28,6 +28,7 @@ import { logger } from '../helpers';
 import { testnetKeys } from '../api/routes/debug';
 import { importV1BnsData } from '../import-v1';
 import * as assert from 'assert';
+import { TestBlockBuilder } from '../test-utils/test-builders';
 
 function hash160(bfr: Buffer): Buffer {
   const hash160 = createHash('ripemd160')
@@ -340,6 +341,9 @@ describe('BNS integration tests', () => {
     client = await db.pool.connect();
     eventServer = await startEventServer({ datastore: db, chainId: ChainID.Testnet, httpLogLevel: 'silly' });
     api = await startApiServer({ datastore: db, chainId: ChainID.Testnet, httpLogLevel: 'silly' });
+
+    const block = new TestBlockBuilder().build();
+    await db.update(block);
   });
 
   test('name-import/ready/update contract call', async () => {

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -172,10 +172,24 @@ describe('api tests', () => {
       ...stxMintEvent1,
       amount: 5_000_000_000_000n,
     };
-    await db.updateBlock(client, dbBlock1);
-    await db.updateTx(client, tx);
-    await db.updateStxEvent(client, tx, stxMintEvent1);
-    await db.updateStxEvent(client, tx, stxMintEvent2);
+    await db.update({
+      block: dbBlock1,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: tx,
+          stxEvents: [stxMintEvent1, stxMintEvent2],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [],
+        },
+      ],
+    });
 
     const expectedTotalStx1 = stxMintEvent1.amount + stxMintEvent2.amount;
     const result1 = await supertest(api.server).get(`/extended/v1/stx_supply`);
@@ -772,7 +786,6 @@ describe('api tests', () => {
       contract_call_contract_id: 'SP3YK7KWMYRCDMV5M4792T0T7DERQXHJJGGEPV1N8.pg-mdomains-v1',
       contract_call_function_name: 'bns-name-preorder',
     };
-
     const contractCall: DbSmartContract = {
       tx_id: '0x668142abbcabb846e3f83183325325071a8b4882dcf5476a38148cb5b738fc83',
       canonical: true,
@@ -800,9 +813,6 @@ describe('api tests', () => {
       execution_cost_write_count: 138,
       execution_cost_write_length: 91116,
     };
-    await db.updateBlock(client, dbBlock);
-    await db.updateTx(client, tx1);
-    await db.updateSmartContract(client, tx1, contractCall);
     const dbTx2: DbTx = {
       tx_id: '0x8915000000000000000000000000000000000000000000000000000000000000',
       anchor_mode: 3,
@@ -837,7 +847,35 @@ describe('api tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateTx(client, dbTx2);
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: tx1,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [contractCall],
+        },
+        {
+          tx: dbTx2,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [],
+        },
+      ],
+    });
     const notFoundTxId = '0x8914000000000000000000000000000000000000000000000000000000000000';
     const txsListDetail = await supertest(api.server).get(
       `/extended/v1/tx/multiple?tx_id=${mempoolTx.tx_id}&tx_id=${tx1.tx_id}&tx_id=${notFoundTxId}&tx_id=${dbTx2.tx_id}`
@@ -853,6 +891,8 @@ describe('api tests', () => {
   });
 
   test('fetch mempool-tx', async () => {
+    const block = new TestBlockBuilder().addTx().build();
+    await db.update(block);
     const mempoolTx: DbMempoolTx = {
       pruned: false,
       tx_id: '0x8912000000000000000000000000000000000000000000000000000000000000',
@@ -895,26 +935,8 @@ describe('api tests', () => {
   });
 
   test('fetch mempool-tx - sponsored', async () => {
-    const dbBlock: DbBlock = {
-      block_hash: '0xff',
-      index_block_hash: '0x1234',
-      parent_index_block_hash: '0x5678',
-      parent_block_hash: '0x5678',
-      parent_microblock_hash: '',
-      parent_microblock_sequence: 0,
-      block_height: 1,
-      burn_block_time: 1594647995,
-      burn_block_hash: '0x1234',
-      burn_block_height: 123,
-      miner_txid: '0x4321',
-      canonical: true,
-      execution_cost_read_count: 0,
-      execution_cost_read_length: 0,
-      execution_cost_runtime: 0,
-      execution_cost_write_count: 0,
-      execution_cost_write_length: 0,
-    };
-    await db.updateBlock(client, dbBlock);
+    const block = new TestBlockBuilder().addTx().build();
+    await db.update(block);
     const mempoolTx: DbMempoolTx = {
       pruned: false,
       tx_id: '0x8912000000000000000000000000000000000000000000000000000000000000',
@@ -958,6 +980,8 @@ describe('api tests', () => {
   });
 
   test('fetch mempool-tx - dropped', async () => {
+    const block = new TestBlockBuilder({ index_block_hash: '0x5678' }).addTx().build();
+    await db.update(block);
     const mempoolTx1: DbMempoolTx = {
       pruned: false,
       tx_id: '0x8912000000000000000000000000000000000000000000000000000000000000',
@@ -994,11 +1018,6 @@ describe('api tests', () => {
       ...mempoolTx1,
       tx_id: '0x8912000000000000000000000000000000000000000000000000000000000005',
       receipt_time: 1594307705,
-    };
-    const mempoolTx6: DbMempoolTx = {
-      ...mempoolTx1,
-      tx_id: '0x8912000000000000000000000000000000000000000000000000000000000006',
-      receipt_time: 1594307706,
     };
 
     await db.updateMempoolTxs({
@@ -1162,11 +1181,11 @@ describe('api tests', () => {
     const dbBlock1: DbBlock = {
       block_hash: '0x0123',
       index_block_hash: '0x1234',
-      parent_index_block_hash: '0x00',
+      parent_index_block_hash: '0x5678',
       parent_block_hash: '0x5678',
       parent_microblock_hash: '',
       parent_microblock_sequence: 0,
-      block_height: 1,
+      block_height: 2,
       burn_block_time: 39486,
       burn_block_hash: '0x1234',
       burn_block_height: 123,
@@ -1248,6 +1267,8 @@ describe('api tests', () => {
   });
 
   test('fetch mempool-tx list', async () => {
+    const block = new TestBlockBuilder().addTx().build();
+    await db.update(block);
     for (let i = 0; i < 10; i++) {
       const mempoolTx: DbMempoolTx = {
         pruned: false,
@@ -1333,6 +1354,9 @@ describe('api tests', () => {
     const recvAddr = 'SP10EZK56MB87JYF5A704K7N18YAT6G6M09HY22GC';
     const contractAddr = 'SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27';
     const contractCallId = 'SP32AEEF6WW5Y0NMJ1S8SBSZDAY8R5J32NBZFPKKZ.free-punks-v0';
+
+    const block = new TestBlockBuilder().addTx().build();
+    await db.update(block);
     const stxTransfers: {
       sender: string;
       receiver: string;
@@ -3426,7 +3450,7 @@ describe('api tests', () => {
       parent_block_hash: '0x5678',
       parent_microblock_hash: '',
       parent_microblock_sequence: 0,
-      block_height: 100123123,
+      block_height: 1,
       burn_block_time: 39486,
       burn_block_hash: '0x1234',
       burn_block_height: 100123123,
@@ -3438,8 +3462,6 @@ describe('api tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, block);
-
     let indexIdIndex = 0;
     const createStxTx = (
       sender: string,
@@ -3456,9 +3478,9 @@ describe('api tests', () => {
         anchor_mode: 3,
         nonce: 0,
         raw_tx: Buffer.alloc(0),
-        index_block_hash: '0x5432',
-        block_hash: '0x9876',
-        block_height: 68456,
+        index_block_hash: block.index_block_hash,
+        block_hash: block.block_hash,
+        block_height: block.block_height,
         burn_block_time: 1594647994,
         parent_burn_block_time: 1626122935,
         type_id: DbTxTypeId.TokenTransfer,
@@ -3538,7 +3560,6 @@ describe('api tests', () => {
       }
       return [tx, stxEvents, ftEvents, nftEvents];
     };
-
     const txs = [
       createStxTx(testAddr1, testAddr2, 100_000, true, 1, 1, 1),
       createStxTx(testAddr2, testContractAddr, 100, true, 1, 2, 1),
@@ -3547,18 +3568,22 @@ describe('api tests', () => {
       createStxTx(testContractAddr, testAddr4, 15, true, 1, 1, 0),
       createStxTx(testAddr2, testAddr4, 35, true, 3, 1, 2),
     ];
-    for (const [tx, stxEvents, ftEvents, nftEvents] of txs) {
-      await db.updateTx(client, tx);
-      for (const event of stxEvents) {
-        await db.updateStxEvent(client, tx, event);
-      }
-      for (const event of ftEvents) {
-        await db.updateFtEvent(client, tx, event);
-      }
-      for (const event of nftEvents) {
-        await db.updateNftEvent(client, tx, event);
-      }
-    }
+    await db.update({
+      block: block,
+      microblocks: [],
+      minerRewards: [],
+      txs: txs.map(data => ({
+        tx: data[0],
+        stxEvents: data[1],
+        ftEvents: data[2],
+        nftEvents: data[3],
+        stxLockEvents: [],
+        contractLogEvents: [],
+        names: [],
+        namespaces: [],
+        smartContracts: [],
+      })),
+    });
 
     const fetch1 = await supertest(api.server).get(
       `/extended/v1/address/${testAddr2}/transactions_with_transfers?limit=3&offset=0`
@@ -3583,8 +3608,8 @@ describe('api tests', () => {
             post_condition_mode: 'allow',
             post_conditions: [],
             tx_status: 'success',
-            block_hash: '0x9876',
-            block_height: 68456,
+            block_hash: '0x1234',
+            block_height: 1,
             burn_block_time: 1594647994,
             burn_block_time_iso: '2020-07-13T13:46:34.000Z',
             canonical: true,
@@ -3670,8 +3695,8 @@ describe('api tests', () => {
             post_condition_mode: 'allow',
             post_conditions: [],
             tx_status: 'success',
-            block_hash: '0x9876',
-            block_height: 68456,
+            block_hash: '0x1234',
+            block_height: 1,
             burn_block_time: 1594647994,
             burn_block_time_iso: '2020-07-13T13:46:34.000Z',
             canonical: true,
@@ -3731,8 +3756,8 @@ describe('api tests', () => {
             post_condition_mode: 'allow',
             post_conditions: [],
             tx_status: 'success',
-            block_hash: '0x9876',
-            block_height: 68456,
+            block_hash: '0x1234',
+            block_height: 1,
             burn_block_time: 1594647994,
             burn_block_time_iso: '2020-07-13T13:46:34.000Z',
             canonical: true,
@@ -3815,8 +3840,8 @@ describe('api tests', () => {
         post_condition_mode: 'allow',
         post_conditions: [],
         tx_status: 'success',
-        block_hash: '0x9876',
-        block_height: 68456,
+        block_hash: '0x1234',
+        block_height: 1,
         burn_block_time: 1594647994,
         burn_block_time_iso: '2020-07-13T13:46:34.000Z',
         canonical: true,
@@ -3887,8 +3912,8 @@ describe('api tests', () => {
             post_condition_mode: 'allow',
             post_conditions: [],
             tx_status: 'success',
-            block_hash: '0x9876',
-            block_height: 68456,
+            block_hash: '0x1234',
+            block_height: 1,
             burn_block_time: 1594647994,
             burn_block_time_iso: '2020-07-13T13:46:34.000Z',
             canonical: true,
@@ -3974,8 +3999,8 @@ describe('api tests', () => {
             post_condition_mode: 'allow',
             post_conditions: [],
             tx_status: 'success',
-            block_hash: '0x9876',
-            block_height: 68456,
+            block_hash: '0x1234',
+            block_height: 1,
             burn_block_time: 1594647994,
             burn_block_time_iso: '2020-07-13T13:46:34.000Z',
             canonical: true,
@@ -6995,6 +7020,8 @@ describe('api tests', () => {
   });
 
   test('getTxList() returns object', async () => {
+    const block = new TestBlockBuilder().build();
+    await db.update(block);
     const expectedResp = {
       limit: 96,
       offset: 0,
@@ -7285,7 +7312,6 @@ describe('api tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, dbBlock);
     const txBuilder = await makeContractCall({
       contractAddress: 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y',
       contractName: 'hello-world',
@@ -7340,7 +7366,6 @@ describe('api tests', () => {
       parent_burn_block_hash: '0xaa',
       parent_burn_block_time: 1626122935,
     });
-    await db.updateTx(client, dbTx);
     const contractAbi: ClarityAbi = {
       functions: [
         {
@@ -7355,14 +7380,33 @@ describe('api tests', () => {
       fungible_tokens: [],
       non_fungible_tokens: [],
     };
-    await db.updateSmartContract(client, dbTx, {
+    const smartContract: DbSmartContract = {
       tx_id: dbTx.tx_id,
       canonical: true,
       contract_id: 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y.hello-world',
       block_height: dbBlock.block_height,
       source_code: '()',
       abi: JSON.stringify(contractAbi),
+    };
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: dbTx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [smartContract],
+        },
+      ],
     });
+
     const txQuery = await getTxFromDataStore(db, { txId: dbTx.tx_id, includeUnanchored: false });
     expect(txQuery.found).toBe(true);
     if (!txQuery.found) {
@@ -7435,7 +7479,7 @@ describe('api tests', () => {
       parent_block_hash: '0x5678nb',
       parent_microblock_hash: '',
       parent_microblock_sequence: 0,
-      block_height: 2,
+      block_height: 1,
       burn_block_time: 1594647997,
       burn_block_hash: '0x1234nb',
       burn_block_height: 124,
@@ -7447,7 +7491,12 @@ describe('api tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, dbBlock);
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [],
+    });
 
     const expectedSponsoredRespBefore = {
       balance: '0',
@@ -7631,7 +7680,6 @@ describe('api tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, dbBlock);
 
     const pc1 = createNonFungiblePostCondition(
       'ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR',
@@ -7701,7 +7749,6 @@ describe('api tests', () => {
       parent_burn_block_hash: '0xaa',
       parent_burn_block_time: 1626122935,
     });
-    await db.updateTx(client, dbTx);
     const contractAbi: ClarityAbi = {
       functions: [
         {
@@ -7716,13 +7763,31 @@ describe('api tests', () => {
       fungible_tokens: [],
       non_fungible_tokens: [],
     };
-    await db.updateSmartContract(client, dbTx, {
+    const smartContract: DbSmartContract = {
       tx_id: dbTx.tx_id,
       canonical: true,
       contract_id: 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y.hello-world',
       block_height: 123,
       source_code: '()',
       abi: JSON.stringify(contractAbi),
+    };
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: dbTx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [smartContract],
+        },
+      ],
     });
     const txQuery = await getTxFromDataStore(db, { txId: dbTx.tx_id, includeUnanchored: false });
     expect(txQuery.found).toBe(true);
@@ -7855,7 +7920,6 @@ describe('api tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, dbBlock);
     const txBuilder = await makeContractDeploy({
       contractName: 'hello-world',
       codeBody: '()',
@@ -7902,7 +7966,24 @@ describe('api tests', () => {
       parent_burn_block_hash: '0xaa',
       parent_burn_block_time: 1626122935,
     });
-    await db.updateTx(client, dbTx);
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: dbTx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [],
+        },
+      ],
+    });
 
     const txQuery = await getTxFromDataStore(db, { txId: dbTx.tx_id, includeUnanchored: false });
     expect(txQuery.found).toBe(true);
@@ -7979,7 +8060,6 @@ describe('api tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, dbBlock);
     const txBuilder = await makeContractDeploy({
       contractName: 'hello-world',
       codeBody: '()',
@@ -8026,7 +8106,24 @@ describe('api tests', () => {
       parent_burn_block_hash: '0xaa',
       parent_burn_block_time: 1626122935,
     });
-    await db.updateTx(client, dbTx);
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: dbTx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [],
+        },
+      ],
+    });
 
     const txQuery = await getTxFromDataStore(db, { txId: dbTx.tx_id, includeUnanchored: false });
     expect(txQuery.found).toBe(true);
@@ -8554,7 +8651,6 @@ describe('api tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, block);
     const tx: DbTx = {
       tx_id: '0x1234',
       tx_index: 4,
@@ -8589,8 +8685,6 @@ describe('api tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateTx(client, tx);
-
     const nftEvent: DbNftEvent = {
       canonical: true,
       event_type: DbEventTypeId.NonFungibleTokenAsset,
@@ -8604,8 +8698,24 @@ describe('api tests', () => {
       recipient: testAddr1,
       sender: testAddr2,
     };
-
-    await db.updateNftEvent(client, tx, nftEvent);
+    await db.update({
+      block: block,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: tx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [nftEvent],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [],
+        },
+      ],
+    });
 
     const expectedResponse = {
       tx_id: '0x1234',

--- a/src/tests/cache-control-tests.ts
+++ b/src/tests/cache-control-tests.ts
@@ -73,7 +73,7 @@ describe('cache-control tests', () => {
       parent_block_hash: '0xff0011',
       parent_microblock_hash: '',
       parent_microblock_sequence: 0,
-      block_height: 1235,
+      block_height: 1,
       burn_block_time: 1594647996,
       burn_block_hash: '0x1234',
       burn_block_height: 123,
@@ -85,7 +85,6 @@ describe('cache-control tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, block1);
     const tx: DbTx = {
       tx_id: '0x1234',
       anchor_mode: 3,
@@ -120,7 +119,24 @@ describe('cache-control tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateTx(client, tx);
+    await db.update({
+      block: block1,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: tx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [],
+        },
+      ],
+    });
 
     const blockQuery = await getBlockFromDataStore({
       blockIdentifer: { hash: block1.block_hash },
@@ -138,7 +154,7 @@ describe('cache-control tests', () => {
       miner_txid: '0x4321',
       canonical: true,
       hash: '0x1234',
-      height: 1235,
+      height: 1,
       parent_block_hash: '0xff0011',
       parent_microblock_hash: '',
       parent_microblock_sequence: 0,
@@ -281,7 +297,7 @@ describe('cache-control tests', () => {
       miner_txid: '0x4321',
       canonical: true,
       hash: '0x1234',
-      height: 1235,
+      height: 1,
       parent_block_hash: '0xff0011',
       parent_microblock_hash: '',
       parent_microblock_sequence: 0,

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -449,7 +449,6 @@ describe('postgres datastore', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
       tx_id: '0x1234',
       tx_index: 4,
@@ -522,7 +521,6 @@ describe('postgres datastore', () => {
       createFtEvent('none', 'addrA', 'cash', 500_000),
       createFtEvent('addrA', 'none', 'tendies', 1_000_000),
     ];
-
     const ftBurnEvent: DbFtEvent = {
       canonical: true,
       event_type: DbEventTypeId.FungibleTokenAsset,
@@ -537,10 +535,24 @@ describe('postgres datastore', () => {
       sender: 'addrA',
     };
     events.push(ftBurnEvent);
-
-    for (const event of events) {
-      await db.updateFtEvent(client, tx, event);
-    }
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: tx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: events,
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [],
+        },
+      ],
+    });
 
     const blockHeight = await db.getMaxBlockHeight(client, { includeUnanchored: false });
     const addrAResult = await db.getFungibleTokenBalances({
@@ -597,7 +609,6 @@ describe('postgres datastore', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
       tx_id: '0x1234',
       tx_index: 4,
@@ -674,7 +685,6 @@ describe('postgres datastore', () => {
       createNFtEvents('none', 'addrA', 'cash', 500),
       createNFtEvents('addrA', 'none', 'tendies', 100),
     ];
-
     const nftBurnEvent: DbNftEvent = {
       canonical: true,
       event_type: DbEventTypeId.NonFungibleTokenAsset,
@@ -690,9 +700,24 @@ describe('postgres datastore', () => {
     };
     events.push([nftBurnEvent]);
 
-    for (const event of events.flat()) {
-      await db.updateNftEvent(client, tx, event);
-    }
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: tx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: events.flat(),
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [],
+        },
+      ],
+    });
 
     const blockHeight = await db.getMaxBlockHeight(client, { includeUnanchored: false });
 
@@ -2096,7 +2121,6 @@ describe('postgres datastore', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
       tx_id: '0x1234',
       tx_index: 4,
@@ -2131,7 +2155,24 @@ describe('postgres datastore', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateTx(client, tx);
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: tx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [],
+        },
+      ],
+    });
     const txQuery = await db.getTx({ txId: tx.tx_id, includeUnanchored: false });
     assert(txQuery.found);
     expect(txQuery.result).toEqual(tx);
@@ -2157,7 +2198,6 @@ describe('postgres datastore', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
       tx_id: '0x421234',
       tx_index: 4,
@@ -2197,7 +2237,24 @@ describe('postgres datastore', () => {
     tx.token_transfer_amount = 34n;
     tx.token_transfer_memo = Buffer.from('thx');
     tx.token_transfer_recipient_address = 'recipient-addr';
-    await db.updateTx(client, tx);
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: tx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [],
+        },
+      ],
+    });
     const txQuery = await db.getTx({ txId: tx.tx_id, includeUnanchored: false });
     assert(txQuery.found);
     expect(txQuery.result).toEqual(tx);
@@ -2223,7 +2280,6 @@ describe('postgres datastore', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
       tx_id: '0x421234',
       tx_index: 4,
@@ -2262,7 +2318,32 @@ describe('postgres datastore', () => {
     );
     tx.smart_contract_contract_id = 'my-contract';
     tx.smart_contract_source_code = '(src)';
-    await db.updateTx(client, tx);
+    const contract: DbSmartContract = {
+      tx_id: tx.tx_id,
+      canonical: true,
+      block_height: dbBlock.block_height,
+      contract_id: 'my-contract',
+      source_code: '(src)',
+      abi: '{"some":"abi"}',
+    };
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: tx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [contract],
+        },
+      ],
+    });
     const txQuery = await db.getTx({ txId: tx.tx_id, includeUnanchored: false });
     assert(txQuery.found);
     expect(txQuery.result).toEqual(tx);
@@ -2288,7 +2369,6 @@ describe('postgres datastore', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
       tx_id: '0x421234',
       tx_index: 4,
@@ -2328,7 +2408,24 @@ describe('postgres datastore', () => {
     tx.contract_call_contract_id = 'my-contract';
     tx.contract_call_function_name = 'my-fn';
     tx.contract_call_function_args = Buffer.from('test');
-    await db.updateTx(client, tx);
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: tx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [],
+        },
+      ],
+    });
     const txQuery = await db.getTx({ txId: tx.tx_id, includeUnanchored: false });
     assert(txQuery.found);
     expect(txQuery.result).toEqual(tx);
@@ -2354,7 +2451,6 @@ describe('postgres datastore', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
       tx_id: '0x421234',
       tx_index: 4,
@@ -2393,7 +2489,24 @@ describe('postgres datastore', () => {
     );
     tx.poison_microblock_header_1 = Buffer.from('poison A');
     tx.poison_microblock_header_2 = Buffer.from('poison B');
-    await db.updateTx(client, tx);
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: tx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [],
+        },
+      ],
+    });
     const txQuery = await db.getTx({ txId: tx.tx_id, includeUnanchored: false });
     assert(txQuery.found);
     expect(txQuery.result).toEqual(tx);
@@ -2419,7 +2532,6 @@ describe('postgres datastore', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
       tx_id: '0x421234',
       tx_index: 4,
@@ -2457,7 +2569,24 @@ describe('postgres datastore', () => {
       new Error('new row for relation "txs" violates check constraint "valid_coinbase"')
     );
     tx.coinbase_payload = Buffer.from('coinbase hi');
-    await db.updateTx(client, tx);
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: tx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [],
+        },
+      ],
+    });
     const txQuery = await db.getTx({ txId: tx.tx_id, includeUnanchored: false });
     assert(txQuery.found);
     expect(txQuery.result).toEqual(tx);
@@ -4340,8 +4469,12 @@ describe('postgres datastore', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, dbBlock);
-
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [],
+    });
     const namespace: DbBnsNamespace = {
       namespace_id: 'abc',
       address: 'ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH',
@@ -4395,8 +4528,12 @@ describe('postgres datastore', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, dbBlock);
-
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [],
+    });
     const name: DbBnsName = {
       name: 'xyz',
       address: 'ST5RRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1ZA',
@@ -4450,8 +4587,12 @@ describe('postgres datastore', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
-    await db.updateBlock(client, dbBlock);
-
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [],
+    });
     const subdomain: DbBnsSubdomain = {
       namespace_id: 'test',
       name: 'nametest',


### PR DESCRIPTION
* Calculate block height, leading block hashes, leading microblock hash, and transaction counts in a materialized view
* Substitute all `block_height` calculations for a SELECT against the new view
* Substitute all `COUNT(*)` queries for their respective stats in the view