### PR TITLE
chore: configure dependabot to only open PRs for security issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Disable version updates for npm dependencies
+    # https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#open-pull-requests-limit
+    open-pull-requests-limit: 0
 
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
@@ -14,3 +17,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Disable version updates for npm dependencies
+    open-pull-requests-limit: 0


### PR DESCRIPTION
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#open-pull-requests-limit
> By default, Dependabot opens a maximum of five pull requests for version updates. Once there are five open pull requests, new requests are blocked until you merge or close some of the open requests, after which new pull requests can be opened on subsequent updates. Use open-pull-requests-limit to change this limit. This also provides a simple way to temporarily disable version updates for a package manager.
> 
> This option has no impact on security updates, which have a separate, internal limit of ten open pull requests.