### PR TITLE
feat: add usage details for each pg connection via application_name

### DIFF
--- a/.env
+++ b/.env
@@ -5,6 +5,10 @@ PG_PASSWORD=postgres
 PG_DATABASE=stacks_blockchain_api
 PG_SCHEMA=public
 PG_SSL=false
+
+# Can be any string, use to specify a use case specific to a deployment
+PG_APPLICATION_NAME=stacks_api_app
+
 # The connection URI below can be used in place of the PG variables above,
 # but if enabled it must be defined without others or omitted.
 # PG_CONNECTION_URI=

--- a/.env
+++ b/.env
@@ -7,7 +7,7 @@ PG_SCHEMA=public
 PG_SSL=false
 
 # Can be any string, use to specify a use case specific to a deployment
-PG_APPLICATION_NAME=stacks_api_app
+PG_APPLICATION_NAME=stacks-blockchain-api
 
 # The connection URI below can be used in place of the PG variables above,
 # but if enabled it must be defined without others or omitted.

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -119,7 +119,20 @@ const MIGRATIONS_TABLE = 'pgmigrations';
 const MIGRATIONS_DIR = path.join(APP_DIR, 'migrations');
 
 type PgClientConfig = ClientConfig & { schema?: string };
-export function getPgClientConfig(primary: boolean = false): PgClientConfig {
+type PgPoolConfig = PoolConfig & { schema?: string };
+
+/**
+ * @typeParam TGetPoolConfig - If specified as true, returns a PoolConfig object where max connections are configured. Otherwise, returns a regular ClientConfig.
+ */
+export function getPgClientConfig<TGetPoolConfig extends boolean = false>({
+  usageName,
+  primary = false,
+  getPoolConfig,
+}: {
+  usageName: string;
+  primary?: boolean;
+  getPoolConfig?: TGetPoolConfig;
+}): TGetPoolConfig extends true ? PgPoolConfig : PgClientConfig {
   // Retrieve a postgres ENV value depending on the target database server (read-replica/default or primary).
   // We will fall back to read-replica values if a primary value was not given.
   // See the `.env` file for more information on these options.
@@ -135,7 +148,9 @@ export function getPgClientConfig(primary: boolean = false): PgClientConfig {
     port: pgEnvValue('PORT'),
     ssl: pgEnvValue('SSL'),
     schema: pgEnvValue('SCHEMA'),
+    applicationName: pgEnvValue('APPLICATION_NAME'),
   };
+  const defaultAppName = 'stacks-blockchain-api';
   const pgConnectionUri = pgEnvValue('CONNECTION_URI');
   const pgConfigEnvVar = Object.entries(pgEnvVars).find(([, v]) => typeof v === 'string')?.[0];
   if (pgConfigEnvVar && pgConnectionUri) {
@@ -143,6 +158,7 @@ export function getPgClientConfig(primary: boolean = false): PgClientConfig {
       `Both PG_CONNECTION_URI and ${pgConfigEnvVar} environmental variables are defined. PG_CONNECTION_URI must be defined without others or omitted.`
     );
   }
+  let clientConfig: PgClientConfig;
   if (pgConnectionUri) {
     const uri = new URL(pgConnectionUri);
     const searchParams = Object.fromEntries(
@@ -155,13 +171,15 @@ export function getPgClientConfig(primary: boolean = false): PgClientConfig {
       searchParams['searchpath'] ??
       searchParams['search_path'] ??
       searchParams['schema'];
-    const config: PgClientConfig = {
-      connectionString: pgConnectionUri,
+    const appName = `${uri.searchParams.get('application_name') ?? defaultAppName}:${usageName}`;
+    uri.searchParams.set('application_name', appName);
+    clientConfig = {
+      connectionString: uri.toString(),
       schema,
     };
-    return config;
   } else {
-    const config: PgClientConfig = {
+    const appName = `${pgEnvVars.applicationName ?? defaultAppName}:${usageName}`;
+    clientConfig = {
       database: pgEnvVars.database,
       user: pgEnvVars.user,
       password: pgEnvVars.password,
@@ -169,13 +187,23 @@ export function getPgClientConfig(primary: boolean = false): PgClientConfig {
       port: parsePort(pgEnvVars.port),
       ssl: parseArgBoolean(pgEnvVars.ssl),
       schema: pgEnvVars.schema,
+      application_name: appName,
     };
-    return config;
+  }
+  if (getPoolConfig) {
+    const poolConfig: PgPoolConfig = { ...clientConfig };
+    const pgConnectionPoolMaxEnv = process.env['PG_CONNECTION_POOL_MAX'];
+    if (pgConnectionPoolMaxEnv) {
+      poolConfig.max = Number.parseInt(pgConnectionPoolMaxEnv);
+    }
+    return poolConfig;
+  } else {
+    return clientConfig;
   }
 }
 
 export async function runMigrations(
-  clientConfig: PgClientConfig = getPgClientConfig(),
+  clientConfig: PgClientConfig = getPgClientConfig({ usageName: 'schema-migrations' }),
   direction: 'up' | 'down' = 'up',
   opts?: {
     // Bypass the NODE_ENV check when performing a "down" migration which irreversibly drops data.
@@ -188,7 +216,6 @@ export async function runMigrations(
         'Set NODE_ENV to "test" or "development" to enable migration testing.'
     );
   }
-  clientConfig = clientConfig ?? getPgClientConfig();
   const client = new Client(clientConfig);
   try {
     await client.connect();
@@ -221,7 +248,7 @@ export async function cycleMigrations(opts?: {
   // Bypass the NODE_ENV check when performing a "down" migration which irreversibly drops data.
   dangerousAllowDataLoss?: boolean;
 }): Promise<void> {
-  const clientConfig = getPgClientConfig();
+  const clientConfig = getPgClientConfig({ usageName: 'cycle-migrations' });
 
   await runMigrations(clientConfig, 'down', opts);
   await runMigrations(clientConfig, 'up', opts);
@@ -233,7 +260,7 @@ export async function dangerousDropAllTables(opts?: {
   if (opts?.acknowledgePotentialCatastrophicConsequences !== 'yes') {
     throw new Error('Dangerous usage error.');
   }
-  const clientConfig = getPgClientConfig();
+  const clientConfig = getPgClientConfig({ usageName: 'dangerous-drop-all-tables' });
   const client = new Client(clientConfig);
   try {
     await client.connect();
@@ -864,7 +891,7 @@ export class PgDataStore
   }
 
   static async exportRawEventRequests(targetStream: Writable): Promise<void> {
-    const pg = await this.connect(true);
+    const pg = await this.connect({ usageName: 'export-raw-events', skipMigrations: true });
     try {
       await pg.query(async client => {
         const copyQuery = pgCopyStreams.to(
@@ -889,7 +916,7 @@ export class PgDataStore
     // 2. Use `pg-cursor` to async read rows from temp table (order by `id` ASC)
     // 3. Drop temp table
     // 4. Close db connection
-    const pg = await this.connect(true);
+    const pg = await this.connect({ usageName: 'get-raw-events', skipMigrations: true });
     try {
       const client = await pg.pool.connect();
       try {
@@ -960,7 +987,7 @@ export class PgDataStore
   }
 
   static async containsAnyRawEventRequests(): Promise<boolean> {
-    const pg = await this.connect(true);
+    const pg = await this.connect({ usageName: 'contains-raw-events-check', skipMigrations: true });
     try {
       return await pg.query(async client => {
         try {
@@ -976,6 +1003,17 @@ export class PgDataStore
     } finally {
       await pg.close();
     }
+  }
+
+  async getConnectionApplicationName(): Promise<string> {
+    const statResult = await this.query(async client => {
+      const result = await client.query<{ application_name: string }>(
+        // Get `application_name` for current connection (each connection has a unique PID)
+        'select application_name from pg_stat_activity WHERE pid = pg_backend_pid()'
+      );
+      return result.rows[0].application_name;
+    });
+    return statResult;
   }
 
   async getChainTip(
@@ -2521,18 +2559,23 @@ export class PgDataStore
     logger.verbose(`Entities marked as non-canonical: ${markedNonCanonical}`);
   }
 
-  static async connect(
+  static async connect({
     skipMigrations = false,
     withNotifier = true,
-    eventReplay = false
-  ): Promise<PgDataStore> {
-    const clientConfig = getPgClientConfig();
-
+    eventReplay = false,
+    usageName,
+  }: {
+    skipMigrations?: boolean;
+    withNotifier?: boolean;
+    eventReplay?: boolean;
+    usageName: string;
+  }): Promise<PgDataStore> {
     const initTimer = stopwatch();
     let connectionError: Error | undefined;
     let connectionOkay = false;
     let lastElapsedLog = 0;
     do {
+      const clientConfig = getPgClientConfig({ usageName: `${usageName};init-connection-poll` });
       const client = new Client(clientConfig);
       try {
         await client.connect();
@@ -2564,39 +2607,24 @@ export class PgDataStore
     }
 
     if (!skipMigrations) {
+      const clientConfig = getPgClientConfig({ usageName: `${usageName};schema-migrations` });
       await runMigrations(clientConfig);
     }
-    const poolConfig: PoolConfig = {
-      ...clientConfig,
-    };
-    const pgConnectionPoolMaxEnv = process.env['PG_CONNECTION_POOL_MAX'];
-    if (pgConnectionPoolMaxEnv) {
-      poolConfig.max = Number.parseInt(pgConnectionPoolMaxEnv);
+    let notifier: PgNotifier | undefined = undefined;
+    if (withNotifier) {
+      notifier = new PgNotifier(getPgClientConfig({ usageName: `${usageName}:notifier` }));
     }
+    const poolConfig: PoolConfig = getPgClientConfig({
+      usageName: `${usageName};datastore-crud`,
+      getPoolConfig: true,
+    });
     const pool = new Pool(poolConfig);
     pool.on('error', error => {
       logger.error(`Postgres connection pool error: ${error.message}`, error);
     });
-    let poolClient: PoolClient | undefined;
-    try {
-      poolClient = await pool.connect();
-      if (!withNotifier) {
-        return new PgDataStore(pool, undefined, eventReplay);
-      }
-      const primaryClientConfig = getPgClientConfig(true);
-      const notifier = new PgNotifier(primaryClientConfig);
-      const store = new PgDataStore(pool, notifier, eventReplay);
-      await store.connectPgNotifier();
-      return store;
-    } catch (error) {
-      logError(
-        `Error connecting to Postgres using ${JSON.stringify(clientConfig)}: ${error}`,
-        error
-      );
-      throw error;
-    } finally {
-      poolClient?.release();
-    }
+    const store = new PgDataStore(pool, notifier, eventReplay);
+    await store.connectPgNotifier();
+    return store;
   }
 
   async updateMinerReward(client: ClientBase, minerReward: DbMinerReward): Promise<number> {

--- a/src/tests-bns/api.ts
+++ b/src/tests-bns/api.ts
@@ -69,7 +69,7 @@ describe('BNS API tests', () => {
   beforeAll(async () => {
     process.env.PG_DATABASE = 'postgres';
     await cycleMigrations();
-    db = await PgDataStore.connect();
+    db = await PgDataStore.connect({ usageName: 'tests' });
     client = await db.pool.connect();
     api = await startApiServer({ datastore: db, chainId: ChainID.Testnet, httpLogLevel: 'silly' });
 

--- a/src/tests-bns/bns-integration-tests.ts
+++ b/src/tests-bns/bns-integration-tests.ts
@@ -336,7 +336,7 @@ describe('BNS integration tests', () => {
   beforeAll(async () => {
     process.env.PG_DATABASE = 'postgres';
     await cycleMigrations();
-    db = await PgDataStore.connect();
+    db = await PgDataStore.connect({ usageName: 'tests' });
     client = await db.pool.connect();
     eventServer = await startEventServer({ datastore: db, chainId: ChainID.Testnet, httpLogLevel: 'silly' });
     api = await startApiServer({ datastore: db, chainId: ChainID.Testnet, httpLogLevel: 'silly' });

--- a/src/tests-bns/setup.ts
+++ b/src/tests-bns/setup.ts
@@ -13,7 +13,7 @@ export default async (): Promise<void> => {
     process.env.NODE_ENV = 'test';
   }
   loadDotEnv();
-  const db = await PgDataStore.connect(true);
+  const db = await PgDataStore.connect({ skipMigrations: true, usageName: 'tests' });
   console.log('Waiting for RPC connection to core node..');
   await new StacksCoreRpcClient().waitForConnection(60000);
   const globalServices: GlobalServices = {

--- a/src/tests-rosetta-cli-construction/setup.ts
+++ b/src/tests-rosetta-cli-construction/setup.ts
@@ -12,7 +12,7 @@ export default async (): Promise<void> => {
     process.env.NODE_ENV = 'test';
   }
   loadDotEnv();
-  const db = await PgDataStore.connect(true);
+  const db = await PgDataStore.connect({ skipMigrations: true, usageName: 'tests' });
   console.log('Waiting for RPC connection to core node..');
   await new StacksCoreRpcClient().waitForConnection(60000);
   const globalServices: GlobalServices = {

--- a/src/tests-rosetta-cli-construction/validate-construction.ts
+++ b/src/tests-rosetta-cli-construction/validate-construction.ts
@@ -34,7 +34,7 @@ describe('Rosetta API', () => {
   beforeAll(async () => {
     process.env.PG_DATABASE = 'postgres';
     await cycleMigrations();
-    db = await PgDataStore.connect();
+    db = await PgDataStore.connect({ usageName: 'tests' });
     client = await db.pool.connect();
     eventServer = await startEventServer({ datastore: db, chainId: ChainID.Testnet });
     api = await startApiServer({ datastore: db, chainId: ChainID.Testnet });

--- a/src/tests-rosetta-cli-data/setup.ts
+++ b/src/tests-rosetta-cli-data/setup.ts
@@ -12,7 +12,7 @@ export default async (): Promise<void> => {
     process.env.NODE_ENV = 'test';
   }
   loadDotEnv();
-  const db = await PgDataStore.connect(true);
+  const db = await PgDataStore.connect({ skipMigrations: true, usageName: 'tests' });
   console.log('Waiting for RPC connection to core node..');
   await new StacksCoreRpcClient().waitForConnection(60000);
   const globalServices: GlobalServices = {

--- a/src/tests-rosetta-cli-data/validate-rosetta.ts
+++ b/src/tests-rosetta-cli-data/validate-rosetta.ts
@@ -104,7 +104,7 @@ describe('Rosetta API', () => {
   beforeAll(async () => {
     process.env.PG_DATABASE = 'postgres';
     await cycleMigrations();
-    db = await PgDataStore.connect();
+    db = await PgDataStore.connect({ usageName: 'tests' });
     client = await db.pool.connect();
     eventServer = await startEventServer({ datastore: db, chainId: ChainID.Testnet });
     api = await startApiServer({ datastore: db, chainId: ChainID.Testnet });

--- a/src/tests-rosetta/account-tests.ts
+++ b/src/tests-rosetta/account-tests.ts
@@ -14,7 +14,7 @@ describe('/account tests', () => {
   beforeEach(async () => {
     process.env.PG_DATABASE = 'postgres';
     await cycleMigrations();
-    db = await PgDataStore.connect();
+    db = await PgDataStore.connect({ usageName: 'tests' });
     client = await db.pool.connect();
     api = await startApiServer({ datastore: db, chainId: ChainID.Testnet, httpLogLevel: 'silly' });
   });

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -124,7 +124,7 @@ describe('Rosetta API', () => {
     process.env.PG_DATABASE = 'postgres';
     process.env.STACKS_CHAIN_ID = '0x80000000';
     await cycleMigrations();
-    db = await PgDataStore.connect();
+    db = await PgDataStore.connect({ usageName: 'tests' });
     client = await db.pool.connect();
     eventServer = await startEventServer({ datastore: db, chainId: ChainID.Testnet });
     api = await startApiServer({ datastore: db, chainId: ChainID.Testnet });

--- a/src/tests-rosetta/block-tests.ts
+++ b/src/tests-rosetta/block-tests.ts
@@ -15,7 +15,7 @@ describe('/block tests', () => {
   beforeEach(async () => {
     process.env.PG_DATABASE = 'postgres';
     await cycleMigrations();
-    db = await PgDataStore.connect();
+    db = await PgDataStore.connect({ usageName: 'tests' });
     client = await db.pool.connect();
     api = await startApiServer({ datastore: db, chainId: ChainID.Testnet, httpLogLevel: 'silly' });
   });

--- a/src/tests-rosetta/setup.ts
+++ b/src/tests-rosetta/setup.ts
@@ -13,7 +13,7 @@ export default async (): Promise<void> => {
     process.env.NODE_ENV = 'test';
   }
   loadDotEnv();
-  const db = await PgDataStore.connect(true);
+  const db = await PgDataStore.connect({skipMigrations: true, usageName: 'tests' });
   console.log('Waiting for RPC connection to core node..');
   await new StacksCoreRpcClient().waitForConnection(60000);
   const globalServices: GlobalServices = {

--- a/src/tests-tokens/setup.ts
+++ b/src/tests-tokens/setup.ts
@@ -13,7 +13,7 @@ export default async (): Promise<void> => {
     process.env.NODE_ENV = 'test';
   }
   loadDotEnv();
-  const db = await PgDataStore.connect(true);
+  const db = await PgDataStore.connect({ skipMigrations: true, usageName: 'tests' });
   console.log('Waiting for RPC connection to core node..');
   await new StacksCoreRpcClient().waitForConnection(60000);
   const globalServices: GlobalServices = {

--- a/src/tests-tokens/tokens-metadata-tests.ts
+++ b/src/tests-tokens/tokens-metadata-tests.ts
@@ -114,7 +114,7 @@ describe('api tests', () => {
   beforeAll(async () => {
     process.env.PG_DATABASE = 'postgres';
     await cycleMigrations();
-    db = await PgDataStore.connect();
+    db = await PgDataStore.connect({ usageName: 'tests' });
     client = await db.pool.connect();
     eventServer = await startEventServer({ datastore: db, chainId: ChainID.Testnet });
     api = await startApiServer({ datastore: db, chainId: ChainID.Testnet });

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -69,7 +69,7 @@ describe('api tests', () => {
   beforeEach(async () => {
     process.env.PG_DATABASE = 'postgres';
     await cycleMigrations();
-    db = await PgDataStore.connect();
+    db = await PgDataStore.connect({ usageName: 'tests' });
     client = await db.pool.connect();
     api = await startApiServer({ datastore: db, chainId: ChainID.Testnet, httpLogLevel: 'silly' });
   });

--- a/src/tests/cache-control-tests.ts
+++ b/src/tests/cache-control-tests.ts
@@ -16,7 +16,7 @@ describe('cache-control tests', () => {
   beforeEach(async () => {
     process.env.PG_DATABASE = 'postgres';
     await cycleMigrations();
-    db = await PgDataStore.connect();
+    db = await PgDataStore.connect({ usageName: 'tests' });
     client = await db.pool.connect();
     api = await startApiServer({ datastore: db, chainId: ChainID.Testnet, httpLogLevel: 'silly' });
   });

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -68,11 +68,11 @@ describe('in-memory datastore', () => {
   });
 });
 
-function testEnvVars(envVars: Record<string, string | undefined>, use: () => void): void;
 function testEnvVars(
   envVars: Record<string, string | undefined>,
   use: () => Promise<void>
 ): Promise<void>;
+function testEnvVars(envVars: Record<string, string | undefined>, use: () => void): void;
 function testEnvVars(
   envVars: Record<string, string | undefined>,
   use: () => void | Promise<void>
@@ -93,13 +93,16 @@ function testEnvVars(
     added.forEach(k => delete process.env[k]);
     Object.entries(existing).forEach(([k, v]) => (process.env[k] = v));
   };
+  let runFn: void | Promise<void>;
   try {
-    const runFn = use();
+    runFn = use();
     if (runFn instanceof Promise) {
       return runFn.finally(() => restoreEnvVars());
     }
   } finally {
-    restoreEnvVars();
+    if (!(runFn instanceof Promise)) {
+      restoreEnvVars();
+    }
   }
 }
 
@@ -110,13 +113,13 @@ describe('postgres datastore', () => {
   beforeEach(async () => {
     process.env.PG_DATABASE = 'postgres';
     await cycleMigrations();
-    db = await PgDataStore.connect();
+    db = await PgDataStore.connect({ usageName: 'tests' });
     client = await db.pool.connect();
   });
 
   test('postgres uri config', () => {
     const uri =
-      'postgresql://test_user:secret_password@database.server.com:3211/test_db?ssl=true&currentSchema=test_schema';
+      'postgresql://test_user:secret_password@database.server.com:3211/test_db?ssl=true&currentSchema=test_schema&application_name=test-conn-str';
     testEnvVars(
       {
         PG_CONNECTION_URI: uri,
@@ -127,10 +130,11 @@ describe('postgres datastore', () => {
         PG_PORT: undefined,
         PG_SSL: undefined,
         PG_SCHEMA: undefined,
+        PG_APPLICATION_NAME: undefined,
       },
       () => {
-        const config = getPgClientConfig();
-        const parsedUrl = pgConnectionString.parse(uri);
+        const config = getPgClientConfig({ usageName: 'tests' });
+        const parsedUrl = pgConnectionString.parse(config.connectionString ?? '');
         expect(parsedUrl.database).toBe('test_db');
         expect(parsedUrl.user).toBe('test_user');
         expect(parsedUrl.password).toBe('secret_password');
@@ -138,6 +142,7 @@ describe('postgres datastore', () => {
         expect(parsedUrl.port).toBe('3211');
         expect(parsedUrl.ssl).toBe(true);
         expect(config.schema).toBe('test_schema');
+        expect(parsedUrl.application_name).toBe('test-conn-str:tests');
       }
     );
   });
@@ -153,9 +158,10 @@ describe('postgres datastore', () => {
         PG_PORT: '9876',
         PG_SSL: 'true',
         PG_SCHEMA: 'pg_schema_schema1',
+        PG_APPLICATION_NAME: 'test-env-vars',
       },
       () => {
-        const config = getPgClientConfig();
+        const config = getPgClientConfig({ usageName: 'tests' });
         expect(config.database).toBe('pg_db_db1');
         expect(config.user).toBe('pg_user_user1');
         expect(config.password).toBe('pg_password_password1');
@@ -163,6 +169,27 @@ describe('postgres datastore', () => {
         expect(config.port).toBe(9876);
         expect(config.ssl).toBe(true);
         expect(config.schema).toBe('pg_schema_schema1');
+        expect(config.application_name).toBe('test-env-vars:tests');
+      }
+    );
+  });
+
+  test('postgres connection application_name', async () => {
+    await testEnvVars(
+      {
+        PG_APPLICATION_NAME: 'test-app-name',
+      },
+      async () => {
+        const testDb = await PgDataStore.connect({
+          usageName: 'test-usage-name',
+          skipMigrations: true,
+        });
+        try {
+          const name = await testDb.getConnectionApplicationName();
+          expect(name).toStrictEqual('test-app-name:test-usage-name;datastore-crud');
+        } finally {
+          await testDb.close();
+        }
       }
     );
   });
@@ -183,7 +210,7 @@ describe('postgres datastore', () => {
       },
       () => {
         expect(() => {
-          const config = getPgClientConfig();
+          const config = getPgClientConfig({ usageName: 'tests' });
         }).toThrowError();
       }
     );

--- a/src/tests/import-genesis-tests.ts
+++ b/src/tests/import-genesis-tests.ts
@@ -8,7 +8,7 @@ describe('import genesis data tests', () => {
   beforeEach(async () => {
     process.env.PG_DATABASE = 'postgres';
     await cycleMigrations();
-    db = await PgDataStore.connect();
+    db = await PgDataStore.connect({ usageName: 'tests' });
   });
 
   test('import token offering data', async () => {

--- a/src/tests/microblocks-tests.ts
+++ b/src/tests/microblocks-tests.ts
@@ -47,7 +47,7 @@ describe('microblock tests', () => {
   beforeEach(async () => {
     process.env.PG_DATABASE = 'postgres';
     await cycleMigrations();
-    db = await PgDataStore.connect();
+    db = await PgDataStore.connect({ usageName: 'tests' });
     client = await db.pool.connect();
   });
 

--- a/src/tests/socket-io-tests.ts
+++ b/src/tests/socket-io-tests.ts
@@ -27,7 +27,7 @@ describe('socket-io', () => {
   beforeEach(async () => {
     process.env.PG_DATABASE = 'postgres';
     await cycleMigrations();
-    db = await PgDataStore.connect();
+    db = await PgDataStore.connect({ usageName: 'tests' });
     dbClient = await db.pool.connect();
     apiServer = await startApiServer({
       datastore: db,

--- a/src/tests/token-tests.ts
+++ b/src/tests/token-tests.ts
@@ -15,7 +15,7 @@ describe('/extended/v1/tokens tests', () => {
   beforeEach(async () => {
     process.env.PG_DATABASE = 'postgres';
     await cycleMigrations();
-    db = await PgDataStore.connect();
+    db = await PgDataStore.connect({ usageName: 'tests' });
     client = await db.pool.connect();
     api = await startApiServer({ datastore: db, chainId: ChainID.Testnet, httpLogLevel: 'silly' });
   });

--- a/src/tests/v2-proxy-tests.ts
+++ b/src/tests/v2-proxy-tests.ts
@@ -17,7 +17,7 @@ describe('v2-proxy tests', () => {
   beforeEach(async () => {
     process.env.PG_DATABASE = 'postgres';
     await cycleMigrations();
-    db = await PgDataStore.connect();
+    db = await PgDataStore.connect({ usageName: 'tests' });
     client = await db.pool.connect();
   });
 

--- a/src/tests/websocket-tests.ts
+++ b/src/tests/websocket-tests.ts
@@ -39,7 +39,7 @@ describe('websocket notifications', () => {
   beforeEach(async () => {
     process.env.PG_DATABASE = 'postgres';
     await cycleMigrations();
-    db = await PgDataStore.connect();
+    db = await PgDataStore.connect({ usageName: 'tests' });
     dbClient = await db.pool.connect();
     apiServer = await startApiServer({
       datastore: db,


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/1046

Use the pg connection `application_name` string property to specify usage context. This was previously left undefined which makes it difficult to determine which API instances are using connections or what purpose a give connection is serving.

This is a free-form value, the PR uses the convention:
`<app instance name>:<optional datastore instance scope>;<connection instance scope>`

The app instance name is read from the env var `PG_APPLICATION_NAME` (or `PG_PRIMARY_APPLICATION_NAME` when applicable), which could be set to something like the pod name.

The usage scopes are specified in code, e.g. `event-replay`, `notifier`, `init-connection-poll`, the run-mode, etc.

Examples:
`api-pod-blue-3:import-events;datastore-crud`
`api-pod-blue-3:datastore-readonly;init-connection-poll`
`api-pod-blue-3:datastore-readonly;datastore-crud`
`api-pod-blue-3:datastore-readonly;notifier`