### PR TITLE
fix: add token metadata modes to warn on missing rosetta FT metadata

### DIFF
--- a/.env
+++ b/.env
@@ -96,6 +96,12 @@ MAINNET_SEND_MANY_CONTRACT_ID=SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-man
 # STACKS_API_ENABLE_FT_METADATA=1
 # STACKS_API_ENABLE_NFT_METADATA=1
 
+# Controls the token metadata processing mode. The possible values are:
+# * `warning`: If required metadata is not found, the API will issue a warning and not display data for that token.
+# * `error`: If required metadata is not found, the API will throw an error.
+# If not specified or any other value is provided, the mode will be set to `warning`.
+# STACKS_API_TOKEN_METADATA_MODE=
+
 # Configure a script to handle image URLs during token metadata processing.
 # This example script uses the `imgix.net` service to create CDN URLs.
 # Must be an executable script that accepts the URL as the first program argument

--- a/src/event-stream/tokens-contract-handler.ts
+++ b/src/event-stream/tokens-contract-handler.ts
@@ -48,6 +48,17 @@ const METADATA_MAX_PAYLOAD_BYTE_SIZE = 1_000_000; // 1 megabyte
 
 const PUBLIC_IPFS = 'https://ipfs.io';
 
+export enum TokenMetadataMode {
+  /**
+   * Default mode. If a required token metadata is not found, the API will issue a warning.
+   */
+  warning,
+  /**
+   * If a required token metadata is not found, the API will throw an error.
+   */
+  error,
+}
+
 export function isFtMetadataEnabled() {
   const opt = process.env['STACKS_API_ENABLE_FT_METADATA']?.toLowerCase().trim();
   return opt === '1' || opt === 'true';
@@ -56,6 +67,19 @@ export function isFtMetadataEnabled() {
 export function isNftMetadataEnabled() {
   const opt = process.env['STACKS_API_ENABLE_NFT_METADATA']?.toLowerCase().trim();
   return opt === '1' || opt === 'true';
+}
+
+/**
+ * Determines the token metadata mode based on .env values.
+ * @returns TokenMetadataMode
+ */
+export function tokenMetadataMode(): TokenMetadataMode {
+  switch (process.env['STACKS_API_TOKEN_METADATA_MODE']) {
+    case 'warning':
+      return TokenMetadataMode.warning;
+    default:
+      return TokenMetadataMode.error;
+  }
 }
 
 const FT_FUNCTIONS: ClarityAbiFunction[] = [


### PR DESCRIPTION
Adds a `STACKS_API_TOKEN_METADATA_MODE` .env value so users can control how the API should handle missing token metadata (warn or error). In the future, #1007 would add a `strict` mode to this value.

TODO: Add unit tests