### PR TITLE
fix: principal_stx_txs sorting

### DIFF
--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -4414,25 +4414,34 @@ export class PgDataStore
     }
     const insertPrincipalStxTxs = async (principals: string[]) => {
       principals = [...new Set(principals)]; // Remove duplicates
-      const columnCount = 3;
+      const columnCount = 5;
       const insertParams = this.generateParameterizedInsertString({
         rowCount: principals.length,
         columnCount,
       });
       const values: any[] = [];
       for (const principal of principals) {
-        values.push(principal, hexToBuffer(tx.tx_id), tx.block_height);
+        values.push(
+          principal,
+          hexToBuffer(tx.tx_id),
+          tx.block_height,
+          tx.microblock_sequence,
+          tx.tx_index
+        );
       }
       // If there was already an existing (`tx_id`, `principal`) pair in the table, we will update
       // the entry's `block_height` to reflect the newer block.
       const insertQuery = `
-        INSERT INTO principal_stx_txs (principal, tx_id, block_height)
+        INSERT INTO principal_stx_txs (principal, tx_id, block_height, microblock_sequence, tx_index)
         VALUES ${insertParams}
-        ON CONFLICT
-          ON CONSTRAINT unique_principal_tx_id
+        ON CONFLICT ON CONSTRAINT unique_principal_tx_id
           DO UPDATE
-            SET block_height = EXCLUDED.block_height
-            WHERE EXCLUDED.block_height > principal_stx_txs.block_height
+            SET block_height = EXCLUDED.block_height,
+              microblock_sequence = EXCLUDED.microblock_sequence,
+              tx_index = EXCLUDED.tx_index
+            WHERE (EXCLUDED.block_height > principal_stx_txs.block_height
+              OR EXCLUDED.microblock_sequence > principal_stx_txs.microblock_sequence
+              OR EXCLUDED.tx_index > principal_stx_txs.tx_index)
         `;
       const insertQueryName = `insert-batch-principal_stx_txs_${columnCount}x${principals.length}`;
       const insertQueryConfig: QueryConfig = {
@@ -5504,25 +5513,18 @@ export class PgDataStore
         // Query the `principal_stx_txs` table first to get the results page we want and then
         // join against `txs` to get the full transaction objects only for that page.
         `
-        WITH
-        -- getAddressTxs
-        stx_txs AS (
-          SELECT tx_id
+        WITH stx_txs AS (
+          SELECT tx_id, ${COUNT_COLUMN}
           FROM principal_stx_txs AS s
           WHERE principal = $1 AND ${blockCond}
-        ` +
-          // TODO: this also needs to sort by microblock_sequence DESC, tx_index DESC, but the
-          // columns don't currently exist on the table. this will be a breaking change to fix
-          `
-          ORDER BY block_height DESC
+          ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC
+          LIMIT $2
+          OFFSET $3
         )
-        SELECT ${TX_COLUMNS}, ${abiColumn()}, ${COUNT_COLUMN}
+        SELECT ${txColumns()}, ${abiColumn()}, count
         FROM stx_txs
         INNER JOIN txs USING (tx_id)
         WHERE canonical = TRUE AND microblock_canonical = TRUE
-        ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC
-        LIMIT $2
-        OFFSET $3
         `,
         [args.stxAddress, args.limit, args.offset, args.blockHeight]
       );

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -4439,9 +4439,9 @@ export class PgDataStore
             SET block_height = EXCLUDED.block_height,
               microblock_sequence = EXCLUDED.microblock_sequence,
               tx_index = EXCLUDED.tx_index
-            WHERE (EXCLUDED.block_height > principal_stx_txs.block_height
+            WHERE EXCLUDED.block_height > principal_stx_txs.block_height
               OR EXCLUDED.microblock_sequence > principal_stx_txs.microblock_sequence
-              OR EXCLUDED.tx_index > principal_stx_txs.tx_index)
+              OR EXCLUDED.tx_index > principal_stx_txs.tx_index
         `;
       const insertQueryName = `insert-batch-principal_stx_txs_${columnCount}x${principals.length}`;
       const insertQueryConfig: QueryConfig = {

--- a/src/migrations/1640651533899_principal_stx_txs.ts
+++ b/src/migrations/1640651533899_principal_stx_txs.ts
@@ -25,6 +25,14 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       type: 'integer',
       notNull: true,
     },
+    microblock_sequence: {
+      type: 'integer',
+      notNull: true,
+    },
+    tx_index: {
+      type: 'smallint',
+      notNull: true,
+    },
   });
 
   pgm.createIndex('principal_stx_txs', [

--- a/src/migrations/1640651533899_principal_stx_txs.ts
+++ b/src/migrations/1640651533899_principal_stx_txs.ts
@@ -35,9 +35,11 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     },
   });
 
+  pgm.createIndex('principal_stx_txs', 'principal', { method: 'hash' });
   pgm.createIndex('principal_stx_txs', [
-    { name: 'principal' },
     { name: 'block_height', sort: 'DESC' },
+    { name: 'microblock_sequence', sort: 'DESC' },
+    { name: 'tx_index', sort: 'DESC' }
   ]);
 
   pgm.addConstraint('principal_stx_txs', 'unique_principal_tx_id', `UNIQUE(principal, tx_id)`);


### PR DESCRIPTION
* Add `microblock_sequence` and `tx_index` columns to `principal_stx_txs`
* Sort via these columns when querying for `/transactions`

Closes #1050 