### PR TITLE
fix: sort NFT events by event_index too

### DIFF
--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -6231,7 +6231,11 @@ export class PgDataStore
           AND txs.canonical = TRUE AND txs.microblock_canonical = TRUE
           AND nft.canonical = TRUE AND nft.microblock_canonical = TRUE
           AND nft.block_height <= $3
-        ORDER BY nft.block_height DESC, txs.microblock_sequence DESC, txs.tx_index DESC
+        ORDER BY
+          nft.block_height DESC,
+          txs.microblock_sequence DESC,
+          txs.tx_index DESC,
+          nft.event_index DESC
         LIMIT $4
         OFFSET $5
         `,

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -6293,7 +6293,11 @@ export class PgDataStore
           AND nft.canonical = TRUE AND nft.microblock_canonical = TRUE
           AND txs.canonical = TRUE AND txs.microblock_canonical = TRUE
           AND nft.block_height <= $2
-        ORDER BY nft.block_height DESC, txs.microblock_sequence DESC, txs.tx_index DESC
+        ORDER BY
+          nft.block_height DESC,
+          txs.microblock_sequence DESC,
+          txs.tx_index DESC,
+          nft.event_index DESC
         LIMIT $3
         OFFSET $4
         `,

--- a/src/migrations/1636130197558_nft_custody.ts
+++ b/src/migrations/1636130197558_nft_custody.ts
@@ -21,7 +21,8 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       value,
       txs.block_height DESC,
       txs.microblock_sequence DESC,
-      txs.tx_index DESC
+      txs.tx_index DESC,
+      nft.event_index DESC
   `);
 
   pgm.createIndex('nft_custody', ['recipient', 'asset_identifier']);

--- a/src/migrations/1640037852136_nft_custody_unanchored.ts
+++ b/src/migrations/1640037852136_nft_custody_unanchored.ts
@@ -25,7 +25,8 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       value,
       txs.block_height DESC,
       txs.microblock_sequence DESC,
-      txs.tx_index DESC
+      txs.tx_index DESC,
+      nft.event_index DESC
   `);
 
   pgm.createIndex('nft_custody_unanchored', ['recipient', 'asset_identifier']);

--- a/src/tests/token-tests.ts
+++ b/src/tests/token-tests.ts
@@ -967,19 +967,20 @@ describe('/extended/v1/tokens tests', () => {
       parent_index_block_hash: '0x07',
     })
       .addTx({ tx_id: '0x100c' })
-      .addTxNftEvent({
-        asset_identifier: assetId,
-        asset_event_type_id: DbAssetEventTypeId.Mint,
-        recipient: addr1,
-        value: hexToBuffer('0x01000000000000000000000000000009ca'),
-        event_index: 1,
-      })
+      // Reversed events but correct event_index
       .addTxNftEvent({
         asset_identifier: assetId,
         asset_event_type_id: DbAssetEventTypeId.Mint,
         recipient: addr1,
         value: hexToBuffer('0x01000000000000000000000000000009cb'),
         event_index: 2,
+      })
+      .addTxNftEvent({
+        asset_identifier: assetId,
+        asset_event_type_id: DbAssetEventTypeId.Mint,
+        recipient: addr1,
+        value: hexToBuffer('0x01000000000000000000000000000009ca'),
+        event_index: 1,
       })
       .build();
     await db.update(block8);


### PR DESCRIPTION
Consider `event_index` too for sorting in all NFT endpoint queries, in case different events for the same NFT come by in the same transaction.
Closes #1060 