### PR TITLE
ci: update gh-pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,7 +3,7 @@ name: gh-pages
 on:
   workflow_run:
     workflows:
-      - "stacks-blockchain-api"
+      - CI
     branches:
       - master
     types:


### PR DESCRIPTION
## Description

Updates the name of the referenced CI workflow to kick off the gh-pages workflow.
This should fix the problem where the gh-pages aren't updated after a release.