### PR TITLE
Add the missing "routes" path to the overview guide for completeness

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -16,7 +16,7 @@
     * See: https://www.rosetta-api.org/
   * The API also implements the BNS (Blockchain Naming System) endpoints.
     * See https://docs.stacks.co/build-apps/references/bns
-  * See `/src/api` for the Express.js routes.
+  * See `/src/api/routes` for the Express.js routes.
 
 
 * The API creates an "event observer" http server which listens for events from a `stacks-node` "event emitter"


### PR DESCRIPTION
## Description
As a user, while reviewing the architecture overview, I noticed the missing reference to the path in which the Express.js route may have been residing, so I wanted to make it more explicit as to where they are living in this doc-change.

Please disregard and close this PR if I misinterpreted the intent. Perhaps the correct directory reference would still be helpful for the general audience.

## Type of Change
- [X] API reference/documentation update
