### PR TITLE
fix: capture re-organized txs correctly in `/extended/v1/:address/transactions`

### DIFF
--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -1706,6 +1706,14 @@ export class PgDataStore
       );
     }
 
+    // Update `principal_stx_txs`
+    await client.query(
+      `UPDATE principal_stx_txs
+      SET canonical = $1, microblock_canonical = $2
+      WHERE tx_id = ANY ($3)`,
+      [args.isCanonical, args.isMicroCanonical, updatedMbTxs.map(tx => hexToBuffer(tx.tx_id))]
+    );
+
     return { updatedTxs: updatedMbTxs };
   }
 
@@ -2174,6 +2182,13 @@ export class PgDataStore
     for (const txId of txIds) {
       logger.verbose(`Marked tx as ${canonical ? 'canonical' : 'non-canonical'}: ${txId.tx_id}`);
     }
+    // Update `principal_stx_txs`
+    await client.query(
+      `UPDATE principal_stx_txs
+      SET canonical = $1
+      WHERE tx_id = ANY ($2)`,
+      [canonical, txIds.map(tx => hexToBuffer(tx.tx_id))]
+    );
 
     const minerRewardResults = await client.query(
       `
@@ -4410,18 +4425,15 @@ export class PgDataStore
   /**
    * Update the `principal_stx_tx` table with the latest `tx_id`s that resulted in a STX
    * transfer relevant to a principal (stx address or contract id).
-   * Only canonical transactions will be kept.
    * @param client - DB client
    * @param tx - Transaction
    * @param events - Transaction STX events
    */
   async updatePrincipalStxTxs(client: ClientBase, tx: DbTx, events: DbStxEvent[]) {
-    if (!tx.canonical || !tx.microblock_canonical) {
-      return;
-    }
+    const txIdBuffer = hexToBuffer(tx.tx_id);
     const insertPrincipalStxTxs = async (principals: string[]) => {
       principals = [...new Set(principals)]; // Remove duplicates
-      const columnCount = 5;
+      const columnCount = 7;
       const insertParams = this.generateParameterizedInsertString({
         rowCount: principals.length,
         columnCount,
@@ -4430,25 +4442,32 @@ export class PgDataStore
       for (const principal of principals) {
         values.push(
           principal,
-          hexToBuffer(tx.tx_id),
+          txIdBuffer,
           tx.block_height,
           tx.microblock_sequence,
-          tx.tx_index
+          tx.tx_index,
+          tx.canonical,
+          tx.microblock_canonical
         );
       }
       // If there was already an existing (`tx_id`, `principal`) pair in the table, we will update
-      // the entry's `block_height` to reflect the newer block.
+      // the entry's data to reflect the newer transaction state.
       const insertQuery = `
-        INSERT INTO principal_stx_txs (principal, tx_id, block_height, microblock_sequence, tx_index)
+        INSERT INTO principal_stx_txs
+          (principal, tx_id, block_height, microblock_sequence, tx_index, canonical, microblock_canonical)
         VALUES ${insertParams}
         ON CONFLICT ON CONSTRAINT unique_principal_tx_id
           DO UPDATE
             SET block_height = EXCLUDED.block_height,
               microblock_sequence = EXCLUDED.microblock_sequence,
-              tx_index = EXCLUDED.tx_index
+              tx_index = EXCLUDED.tx_index,
+              canonical = EXCLUDED.canonical,
+              microblock_canonical = EXCLUDED.microblock_canonical
             WHERE EXCLUDED.block_height > principal_stx_txs.block_height
               OR EXCLUDED.microblock_sequence > principal_stx_txs.microblock_sequence
               OR EXCLUDED.tx_index > principal_stx_txs.tx_index
+              OR EXCLUDED.canonical != principal_stx_txs.canonical
+              OR EXCLUDED.microblock_canonical != principal_stx_txs.microblock_canonical
         `;
       const insertQueryName = `insert-batch-principal_stx_txs_${columnCount}x${principals.length}`;
       const insertQueryConfig: QueryConfig = {
@@ -4458,9 +4477,10 @@ export class PgDataStore
       };
       await client.query(insertQueryConfig);
     };
+    const principals: string[] = [];
     // Insert tx data
-    await insertPrincipalStxTxs(
-      [
+    principals.push(
+      ...[
         tx.sender_address,
         tx.token_transfer_recipient_address,
         tx.contract_call_contract_id,
@@ -4470,16 +4490,12 @@ export class PgDataStore
     // Insert stx_event data
     const batchSize = 500;
     for (const eventBatch of batchIterate(events, batchSize)) {
-      const principals: string[] = [];
       for (const event of eventBatch) {
-        if (!event.canonical) {
-          continue;
-        }
         if (event.sender) principals.push(event.sender);
         if (event.recipient) principals.push(event.recipient);
       }
-      await insertPrincipalStxTxs(principals);
     }
+    await insertPrincipalStxTxs(principals);
   }
 
   async updateBatchSubdomains(
@@ -5522,7 +5538,7 @@ export class PgDataStore
         WITH stx_txs AS (
           SELECT tx_id, ${countOverColumn()}
           FROM principal_stx_txs AS s
-          WHERE principal = $1 AND ${blockCond}
+          WHERE principal = $1 AND ${blockCond} AND canonical = TRUE AND microblock_canonical = TRUE
           ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC
           LIMIT $2
           OFFSET $3
@@ -5530,7 +5546,6 @@ export class PgDataStore
         SELECT ${txColumns()}, ${abiColumn()}, count
         FROM stx_txs
         INNER JOIN txs USING (tx_id)
-        WHERE canonical = TRUE AND microblock_canonical = TRUE
         `,
         [args.stxAddress, args.limit, args.offset, args.blockHeight]
       );

--- a/src/migrations/1640651533899_principal_stx_txs.ts
+++ b/src/migrations/1640651533899_principal_stx_txs.ts
@@ -5,8 +5,8 @@ export const shorthands: ColumnDefinitions | undefined = undefined;
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
   /**
-   * Stores all `tx_id`s of **canonical** transactions that affect a principal's STX balance since
-   * that cannot be directly determined from the `txs` table (an expensive JOIN with `stx_events` is required).
+   * Stores all `tx_id`s of transactions that affect a principal's STX balance since that cannot be
+   * directly determined from the `txs` table (an expensive JOIN with `stx_events` is required).
    */
   pgm.createTable('principal_stx_txs', {
     id: {
@@ -31,6 +31,14 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     },
     tx_index: {
       type: 'smallint',
+      notNull: true,
+    },
+    canonical: {
+      type: 'boolean',
+      notNull: true,
+    },
+    microblock_canonical: {
+      type: 'boolean',
       notNull: true,
     },
   });

--- a/src/test-utils/test-builders.ts
+++ b/src/test-utils/test-builders.ts
@@ -76,6 +76,7 @@ interface TestBlockArgs {
   parent_block_hash?: string;
   parent_microblock_hash?: string;
   parent_microblock_sequence?: number;
+  canonical?: boolean;
 }
 
 /**
@@ -96,7 +97,7 @@ function testBlock(args?: TestBlockArgs): DbBlock {
     burn_block_hash: args?.burn_block_hash ?? BURN_BLOCK_HASH,
     burn_block_height: BURN_BLOCK_HEIGHT,
     miner_txid: '0x4321',
-    canonical: true,
+    canonical: args?.canonical ?? true,
     execution_cost_read_count: 0,
     execution_cost_read_length: 0,
     execution_cost_runtime: 0,


### PR DESCRIPTION
Add the `canonical` and `microblock_canonical` columns to the `principal_stx_txs` table in order to update them with block and microblock re-orgs correctly.

This has the added benefit of keeping all filtering done over the `principal_stx_txs` table and only using `txs` for the final JOIN to get additional transaction info, which in turn makes the `/transactions` query much faster.

This is an example output from EXPLAIN ANALYZE, showing only the indices `principal_stx_txs_principal_index` and `txs_tx_id_index` are needed to gather results in less than 1ms:
```
Nested Loop  (cost=403.76..805.93 rows=68 width=44) (actual time=0.035..0.048 rows=6 loops=1)
  ->  Limit  (cost=403.76..403.88 rows=50 width=47) (actual time=0.028..0.030 rows=6 loops=1)
        ->  Sort  (cost=403.76..403.99 rows=95 width=47) (actual time=0.028..0.029 rows=6 loops=1)
              Sort Key: s.block_height DESC, s.microblock_sequence DESC, s.tx_index DESC
              Sort Method: quicksort  Memory: 25kB
              ->  WindowAgg  (cost=4.78..400.63 rows=95 width=47) (actual time=0.022..0.024 rows=6 loops=1)
                    ->  Bitmap Heap Scan on principal_stx_txs s  (cost=4.78..399.21 rows=95 width=43) (actual time=0.014..0.018 rows=6 loops=1)
                          Recheck Cond: (principal = 'SPAV5PXNEZ44AH4RDP7JX7WEG9Y8N0BFY411VT51'::text)"
                          Filter: (canonical AND microblock_canonical AND (block_height <= 50000))
                          Heap Blocks: exact=5
                          ->  Bitmap Index Scan on principal_stx_txs_principal_index  (cost=0.00..4.76 rows=101 width=0) (actual time=0.010..0.010 rows=6 loops=1)
                                Index Cond: (principal = 'SPAV5PXNEZ44AH4RDP7JX7WEG9Y8N0BFY411VT51'::text)"
  ->  Index Scan using txs_tx_id_index on txs  (cost=0.00..8.02 rows=1 width=41) (actual time=0.002..0.002 rows=1 loops=6)
        Index Cond: (tx_id = s.tx_id)
Planning Time: 0.825 ms
Execution Time: 0.089 ms
```

Fixes #1058 