### PR TITLE
fix: deactivate bns table indices before subdomain import

### DIFF
--- a/src/import-v1/index.ts
+++ b/src/import-v1/index.ts
@@ -430,6 +430,15 @@ export async function importV1BnsData(db: PgDataStore, importDir: string) {
   const client = await db.pool.connect();
   try {
     await client.query('BEGIN');
+    // Temporarily disable BNS table indices to speed up INSERTs.
+    await client.query(`
+      UPDATE pg_index
+      SET indisready = false, indisvalid = false
+      WHERE indrelid = ANY (
+        SELECT oid FROM pg_class
+        WHERE relname IN ('subdomains', 'zonefiles', 'namespaces', 'names')
+      )
+    `);
     const zhashes = await readZones(path.join(importDir, 'name_zonefiles.txt'));
     await pipeline(
       fs.createReadStream(path.join(importDir, 'chainstate.txt')),
@@ -458,6 +467,7 @@ export async function importV1BnsData(db: PgDataStore, importDir: string) {
         logger.info(`Subdomains imported: ${subdomainsImported}`);
       }
     }
+    logger.info(`Subdomains imported: ${subdomainsImported}`);
 
     const updatedConfigState: DbConfigState = {
       ...configState,
@@ -465,6 +475,12 @@ export async function importV1BnsData(db: PgDataStore, importDir: string) {
       bns_subdomains_imported: true,
     };
     await db.updateConfigState(updatedConfigState, client);
+
+    // Re-enable indices
+    await client.query(`REINDEX TABLE subdomains`);
+    await client.query(`REINDEX TABLE zonefiles`);
+    await client.query(`REINDEX TABLE namespaces`);
+    await client.query(`REINDEX TABLE names`);
     await client.query('COMMIT');
   } catch (error) {
     await client.query('ROLLBACK');

--- a/src/migrations/1608030374841_namespaces.ts
+++ b/src/migrations/1608030374841_namespaces.ts
@@ -92,11 +92,5 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   });
 
   pgm.createIndex('namespaces', 'namespace_id', { method: 'hash' });
-  pgm.createIndex('namespaces', 'microblock_hash', { method: 'hash' });
   pgm.createIndex('namespaces', [{ name: 'ready_block', sort: 'DESC' }]);
-  pgm.createIndex('namespaces', [
-    { name: 'namespace_id' },
-    { name: 'ready_block', sort: 'DESC' },
-    { name: 'tx_index', sort: 'DESC' },
-  ]);
 }

--- a/src/migrations/1608030374842_names.ts
+++ b/src/migrations/1608030374842_names.ts
@@ -87,12 +87,5 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createIndex('names', 'name', { method: 'hash' });
   pgm.createIndex('names', 'namespace_id', { method: 'hash' });
   pgm.createIndex('names', 'zonefile_hash', { method: 'hash' });
-  pgm.createIndex('names', 'index_block_hash', { method: 'hash' });
-  pgm.createIndex('names', 'microblock_hash', { method: 'hash' });
   pgm.createIndex('names', [{ name: 'registered_at', sort: 'DESC' }]);
-  pgm.createIndex('names', [
-    { name: 'name' },
-    { name: 'registered_at', sort: 'DESC' },
-    { name: 'tx_index', sort: 'DESC' },
-  ]);
 }

--- a/src/migrations/1610030345948_subdomains.ts
+++ b/src/migrations/1610030345948_subdomains.ts
@@ -85,14 +85,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   });
 
   pgm.createIndex('subdomains', 'owner', { method: 'hash' });
-  pgm.createIndex('subdomains', 'tx_id', { method: 'hash' });
-  pgm.createIndex('subdomains', 'index_block_hash', { method: 'hash' });
-  pgm.createIndex('subdomains', 'microblock_hash', { method: 'hash' });
-  pgm.createIndex('subdomains', 'name', { method: 'hash' });
+  pgm.createIndex('subdomains', 'zonefile_hash', { method: 'hash' });
   pgm.createIndex('subdomains', 'fully_qualified_subdomain', { method: 'hash' });
-  pgm.createIndex('subdomains', [
-    { name: 'fully_qualified_subdomain' },
-    { name: 'block_height', sort: 'DESC' },
-    { name: 'tx_index', sort: 'DESC' },
-  ]);
+  pgm.createIndex('subdomains', [{ name: 'block_height', sort: 'DESC' }]);
 }


### PR DESCRIPTION
This patch temporarily disables indices on the `subdomains`, `zonefiles`, `namespaces`, and `names` tables before subdomain import, and also removes unused indices from these tables.

From postgres docs on [populating a database](https://www.postgresql.org/docs/current/populate.html#POPULATE-RM-INDEXES):

> If you are adding large amounts of data to an existing table, it might be a win to drop the indexes, load the table, and then recreate the indexes.

Instead of dropping and re-creating, this code just disables and reindexes them after import is complete via the use of the `indisready` and `indisvalid` [index state flags](https://www.postgresql.org/docs/current/catalog-pg-index.html).

On local tests, it now takes ~2 seconds to import 10,000 subdomains when before this change it took ~30 seconds per 10,000.

Fixes #1081 