### PR TITLE
fix: send address tx updates correctly on microblocks

### DIFF
--- a/src/api/routes/ws/ws-rpc.ts
+++ b/src/api/routes/ws/ws-rpc.ts
@@ -431,10 +431,10 @@ export function createWsRpcRouter(db: DataStore, server: http.Server): WebSocket
   // Queue to process balance update notifications
   const addrBalanceProcessorQueue = new PQueue({ concurrency: 1 });
 
-  function processAddressBalanceUpdate(address: string) {
+  async function processAddressBalanceUpdate(address: string) {
     const subscribers = addressBalanceUpdateSubscriptions.subscriptions.get(address);
     if (subscribers) {
-      void addrBalanceProcessorQueue.add(async () => {
+      await addrBalanceProcessorQueue.add(async () => {
         try {
           const balance = await db.getStxBalance({
             stxAddress: address,
@@ -521,7 +521,7 @@ export function createWsRpcRouter(db: DataStore, server: http.Server): WebSocket
 
   db.addListener('addressUpdate', async (address, blockHeight) => {
     await processAddressUpdate(address, blockHeight);
-    processAddressBalanceUpdate(address);
+    await processAddressBalanceUpdate(address);
   });
 
   db.addListener('blockUpdate', async blockHash => {
@@ -539,7 +539,7 @@ export function createWsRpcRouter(db: DataStore, server: http.Server): WebSocket
       prometheus?.connect(req.socket.remoteAddress);
     }
     clientSocket.on('message', data => {
-      void handleClientMessage(clientSocket, data);
+      handleClientMessage(clientSocket, data);
     });
     clientSocket.on('close', (_: WebSocket) => {
       prometheus?.disconnect(clientSocket);

--- a/src/tests/socket-io-tests.ts
+++ b/src/tests/socket-io-tests.ts
@@ -157,22 +157,28 @@ describe('socket-io', () => {
     socket.on(`address-transaction:${addr1}`, (_, tx) => {
       updateWaiters[waiterIndex++].finish(tx);
     });
-    const block = new TestBlockBuilder()
+    const block = new TestBlockBuilder({
+      block_height: 1,
+      block_hash: '0x01',
+      index_block_hash: '0x01',
+    })
       .addTx({ tx_id: '0x8912', sender_address: addr1, token_transfer_amount: 100n, fee_rate: 50n })
       .addTxStxEvent({ sender: addr1, amount: 100n })
       .build();
     await db.update(block);
 
     const microblock = new TestMicroblockStreamBuilder()
-      .addMicroblock()
+      .addMicroblock({
+        microblock_hash: '0x11',
+        parent_index_block_hash: '0x01',
+      })
       .addTx({
         tx_id: '0x8913',
         sender_address: addr1,
         token_transfer_amount: 150n,
         fee_rate: 50n,
-        block_height: 2,
       })
-      .addTxStxEvent({ sender: addr1, amount: 150n, block_height: 2 })
+      .addTxStxEvent({ sender: addr1, amount: 150n })
       .build();
     await db.updateMicroblocks(microblock);
 

--- a/src/tests/socket-io-tests.ts
+++ b/src/tests/socket-io-tests.ts
@@ -64,8 +64,7 @@ describe('socket-io', () => {
   });
 
   test('socket-io > microblock updates', async () => {
-    const address = apiServer.address;
-    const socket = io(`http://${address}`, {
+    const socket = io(`http://${apiServer.address}`, {
       reconnection: false,
       query: { subscriptions: 'microblock' },
     });
@@ -81,7 +80,6 @@ describe('socket-io', () => {
     const microblocks = new TestMicroblockStreamBuilder()
       .addMicroblock({
         microblock_hash: '0xff01',
-        microblock_parent_hash: '0x1212',
         parent_index_block_hash: '0x4343',
       })
       .addTx({ tx_id: '0xf6f6' })
@@ -91,7 +89,7 @@ describe('socket-io', () => {
     const result = await updateWaiter;
     try {
       expect(result.microblock_hash).toEqual('0xff01');
-      expect(result.microblock_parent_hash).toEqual('0x1212');
+      expect(result.parent_block_hash).toEqual('0x1212');
       expect(result.txs[0]).toEqual('0xf6f6');
     } finally {
       socket.emit('unsubscribe', 'microblock');

--- a/src/tests/websocket-tests.ts
+++ b/src/tests/websocket-tests.ts
@@ -256,7 +256,11 @@ describe('websocket notifications', () => {
         }
       });
 
-      const block = new TestBlockBuilder()
+      const block = new TestBlockBuilder({
+        block_height: 1,
+        block_hash: '0x01',
+        index_block_hash: '0x01',
+      })
         .addTx({
           tx_id: '0x8912000000000000000000000000000000000000000000000000000000000000',
           sender_address: addr,
@@ -268,16 +272,18 @@ describe('websocket notifications', () => {
       await db.update(block);
 
       const microblock = new TestMicroblockStreamBuilder()
-        .addMicroblock()
+        .addMicroblock({
+          microblock_hash: '0x11',
+          parent_index_block_hash: '0x01',
+        })
         .addTx({
           tx_id: '0x8913',
           sender_address: addr,
           token_transfer_amount: 150n,
           fee_rate: 50n,
-          block_height: 2,
           type_id: DbTxTypeId.TokenTransfer,
         })
-        .addTxStxEvent({ sender: addr, amount: 150n, block_height: 2 })
+        .addTxStxEvent({ sender: addr, amount: 150n })
         .build();
       await db.updateMicroblocks(microblock);
 


### PR DESCRIPTION
`block_height` was being sent incorrectly to the ws/socket.io handlers when a transaction was confirmed in a microblock, causing the call to `getAddressTxsWithAssetTransfers` to return empty results.

This patch also fixes some race conditions and flaky tests that happened from socket messages not being awaited correctly.

Fixes #1085 