### PR TITLE
feat!: add mempool endpoint cache handlers

### DIFF
--- a/docker/docker-compose.dev.postgres.yml
+++ b/docker/docker-compose.dev.postgres.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   postgres:
-    image: "postgres:12.2"
+    image: "postgres:14"
     ports:
       - "5490:5432"
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   postgres:
-    image: "postgres:12.2"
+    image: "postgres:14"
     ports:
       - "5490:5432"
     environment:

--- a/readme.md
+++ b/readme.md
@@ -54,9 +54,10 @@ See [overview.md](overview.md) for architecture details.
 
 # Deployment
 
+For optimal performance, we recommend running the API database on PostgreSQL version 14 or newer.
 ## Upgrading
 
-If upgrading the API to a new major version (e.g. `3.0.0` to `4.0.0`) then the Postgres database from the previous version will not be compatible and the process will fail to start. 
+If upgrading the API to a new major version (e.g. `3.0.0` to `4.0.0`) then the Postgres database from the previous version will not be compatible and the process will fail to start.
 
 [Event Replay](#event-replay) must be used when upgrading major versions. Follow the event replay [instructions](#event-replay-instructions) below. Failure to do so will require wiping both the Stacks Blockchain chainstate data and the API Postgres database, and re-syncing from scratch.
 
@@ -116,7 +117,7 @@ event's to be re-played, the following steps could be ran:
    ```
 1. Update to the new stacks-blockchain-api version.
 1. Perform the event playback using the `import-events` command:
-   
+
    **WARNING**: This will **drop _all_ tables** from the configured Postgres database, including any tables not automatically added by the API.
 
    ```shell

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,7 @@ See [overview.md](overview.md) for architecture details.
 # Deployment
 
 For optimal performance, we recommend running the API database on PostgreSQL version 14 or newer.
+
 ## Upgrading
 
 If upgrading the API to a new major version (e.g. `3.0.0` to `4.0.0`) then the Postgres database from the previous version will not be compatible and the process will fail to start.

--- a/src/api/controllers/cache-controller.ts
+++ b/src/api/controllers/cache-controller.ts
@@ -1,17 +1,27 @@
 import { RequestHandler, Request, Response } from 'express';
 import * as prom from 'prom-client';
-import { FoundOrNot, logger } from '../../helpers';
-import { DataStore, DbChainTip } from '../../datastore/common';
+import { logger } from '../../helpers';
+import { DataStore } from '../../datastore/common';
 import { asyncHandler } from '../async-handler';
 
 const CACHE_OK = Symbol('cache_ok');
-const CHAIN_TIP_LOCAL = 'chain_tip';
 
 // A `Cache-Control` header used for re-validation based caching.
 // `public` == allow proxies/CDNs to cache as opposed to only local browsers.
 // `no-cache` == clients can cache a resource but should revalidate each time before using it.
 // `must-revalidate` == somewhat redundant directive to assert that cache must be revalidated, required by some CDNs
 const CACHE_CONTROL_MUST_REVALIDATE = 'public, no-cache, must-revalidate';
+
+/**
+ * Describes a key-value to be saved into request locals which represents the current
+ * entity tag for an API endpoint.
+ */
+enum ETagType {
+  /** ETag based on the latest `index_block_hash` or `microblock_hash`. */
+  chainTip = 'chain_tip',
+  /** ETag based on a digest of all pending mempool `tx_id`s. */
+  mempool = 'mempool',
+}
 
 interface ChainTipCacheMetrics {
   chainTipCacheHits: prom.Counter<string>;
@@ -48,31 +58,26 @@ export function setResponseNonCacheable(res: Response) {
 }
 
 /**
- * Sets the response `Cache-Control` and `ETag` headers using the chain tip previously added
+ * Sets the response `Cache-Control` and `ETag` headers using the etag previously added
  * to the response locals.
- * Uses the latest unanchored microblock hash if available, otherwise uses the anchor
- * block index hash.
  */
-export function setChainTipCacheHeaders(res: Response) {
-  const chainTip: FoundOrNot<DbChainTip> | undefined = res.locals[CHAIN_TIP_LOCAL];
-  if (!chainTip) {
+export function setETagCacheHeaders(res: Response, etagType: ETagType = ETagType.chainTip) {
+  const etag: string | undefined = res.locals[etagType];
+  if (!etag) {
     logger.error(
-      `Cannot set cache control headers, no chain tip was set on \`Response.locals[CHAIN_TIP_LOCAL]\`.`
+      `Cannot set cache control headers, no etag was set on \`Response.locals[${etagType}]\`.`
     );
     return;
   }
-  if (!chainTip.found) {
-    return;
-  }
-  const chainTipTag = chainTip.result.microblockHash ?? chainTip.result.indexBlockHash;
   res.set({
     'Cache-Control': CACHE_CONTROL_MUST_REVALIDATE,
-    // Use the current chain tip `indexBlockHash` as the etag so that cache is invalidated on new blocks.
+    // Use the current chain tip or mempool state as the etag so that cache is invalidated on new blocks or
+    // new mempool events.
     // This value will be provided in the `If-None-Match` request header in subsequent requests.
     // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
     // > Entity tag that uniquely represents the requested resource.
     // > It is a string of ASCII characters placed between double quotes..
-    ETag: `"${chainTipTag}"`,
+    ETag: `"${etag}"`,
   });
 }
 
@@ -123,21 +128,37 @@ export function parseIfNoneMatchHeader(
 }
 
 /**
- * Parse the `ETag` from the given request's `If-None-Match` header which represents the chain tip associated
- * with the client's cached response. Query the current chain tip from the db, and compare the two.
+ * Parse the `ETag` from the given request's `If-None-Match` header which represents the chain tip or
+ * mempool state associated with the client's cached response. Query the current state from the db, and
+ * compare the two.
  * This function is also responsible for tracking the prometheus metrics associated with cache hits/misses.
- * @returns `CACHE_OK` if the client's cached response is up-to-date with the current chain tip, otherwise,
- * returns the current chain tip which can be used later for setting the cache control etag response header.
+ * @returns `CACHE_OK` if the client's cached response is up-to-date with the current state, otherwise,
+ * returns a string which can be used later for setting the cache control `ETag` response header.
  */
-async function checkChainTipCacheOK(
+async function checkETagCacheOK(
   db: DataStore,
-  req: Request
-): Promise<FoundOrNot<DbChainTip> | typeof CACHE_OK> {
+  req: Request,
+  etagType: ETagType
+): Promise<string | undefined | typeof CACHE_OK> {
   const metrics = getChainTipMetrics();
-  const chainTip = await db.getUnanchoredChainTip();
-  if (!chainTip.found) {
-    // This should never happen unless the API is serving requests before it has synced any blocks.
-    return chainTip;
+  let etag: string;
+  switch (etagType) {
+    case ETagType.chainTip:
+      const chainTip = await db.getUnanchoredChainTip();
+      if (!chainTip.found) {
+        // This should never happen unless the API is serving requests before it has synced any blocks.
+        return;
+      }
+      etag = chainTip.result.microblockHash ?? chainTip.result.indexBlockHash;
+      break;
+    case ETagType.mempool:
+      const digest = await db.getMempoolTxDigest();
+      if (!digest.found) {
+        // This would only happen if the `mempool_digest` materialized view hasn't been refreshed.
+        return;
+      }
+      etag = digest.result.digest;
+      break;
   }
   // Parse ETag values from the request's `If-None-Match` header, if any.
   // Note: node.js normalizes `IncomingMessage.headers` to lowercase.
@@ -145,10 +166,9 @@ async function checkChainTipCacheOK(
   if (ifNoneMatch === undefined || ifNoneMatch.length === 0) {
     // No if-none-match header specified.
     metrics.chainTipCacheNoHeader.inc();
-    return chainTip;
+    return etag;
   }
-  const chainTipTag = chainTip.result.microblockHash ?? chainTip.result.indexBlockHash;
-  if (ifNoneMatch.includes(chainTipTag)) {
+  if (ifNoneMatch.includes(etag)) {
     // The client cache's ETag matches the current chain tip, so no need to re-process the request
     // server-side as there will be no change in response. Record this as a "cache hit" and return CACHE_OK.
     metrics.chainTipCacheHits.inc();
@@ -158,14 +178,14 @@ async function checkChainTipCacheOK(
     // an older block or a forked block, so the client's cached response is stale and should not be used.
     // Record this as a "cache miss" and return the current chain tip.
     metrics.chainTipCacheMisses.inc();
-    return chainTip;
+    return etag;
   }
 }
 
 /**
  * Check if the request has an up-to-date cached response by comparing the `If-None-Match` request header to the
- * current chain tip. If the cache is valid then a `304 Not Modified` response is sent and the route handling for
- * this request is completed. If the cache is outdated, the current chain tip is added to the `Request.locals` for
+ * current state. If the cache is valid then a `304 Not Modified` response is sent and the route handling for
+ * this request is completed. If the cache is outdated, the current state is added to the `Request.locals` for
  * later use in setting response cache headers.
  * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#freshness
  * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match
@@ -176,19 +196,22 @@ async function checkChainTipCacheOK(
  * doesn't match any of the values listed.
  * ```
  */
-export function getChainTipCacheHandler(db: DataStore): RequestHandler {
+export function getETagCacheHandler(
+  db: DataStore,
+  etagType: ETagType = ETagType.chainTip
+): RequestHandler {
   const requestHandler = asyncHandler(async (req, res, next) => {
-    const result = await checkChainTipCacheOK(db, req);
+    const result = await checkETagCacheOK(db, req, etagType);
     if (result === CACHE_OK) {
       // Instruct the client to use the cached response via a `304 Not Modified` response header.
       // This completes the handling for this request, do not call `next()` in order to skip the
       // router handler used for non-cached responses.
       res.set('Cache-Control', CACHE_CONTROL_MUST_REVALIDATE).status(304).send();
     } else {
-      // Request does not have a valid cache. Store the chainTip for later
+      // Request does not have a valid cache. Store the etag for later
       // use in setting response cache headers.
-      const chainTip: FoundOrNot<DbChainTip> = result;
-      res.locals[CHAIN_TIP_LOCAL] = chainTip;
+      const etag: string | undefined = result;
+      res.locals[etagType] = etag;
       next();
     }
   });

--- a/src/api/controllers/cache-controller.ts
+++ b/src/api/controllers/cache-controller.ts
@@ -16,7 +16,7 @@ const CACHE_CONTROL_MUST_REVALIDATE = 'public, no-cache, must-revalidate';
  * Describes a key-value to be saved into request locals which represents the current
  * entity tag for an API endpoint.
  */
-enum ETagType {
+export enum ETagType {
   /** ETag based on the latest `index_block_hash` or `microblock_hash`. */
   chainTip = 'chain_tip',
   /** ETag based on a digest of all pending mempool `tx_id`s. */

--- a/src/api/controllers/cache-controller.ts
+++ b/src/api/controllers/cache-controller.ts
@@ -65,9 +65,13 @@ export function setResponseNonCacheable(res: Response) {
 export function setETagCacheHeaders(res: Response, etagType: ETagType = ETagType.chainTip) {
   const etag: string | undefined = res.locals[etagType];
   if (!etag) {
-    logger.error(
-      `Cannot set cache control headers, no etag was set on \`Response.locals[${etagType}]\`.`
-    );
+    // An empty mempool ETag means either no pending mempool txs or that the API is running
+    // on old pg versions. No error reporting is necessary in that case.
+    if (etagType === ETagType.chainTip) {
+      logger.error(
+        `Cannot set cache control headers, no etag was set on \`Response.locals[${etagType}]\`.`
+      );
+    }
     return;
   }
   res.set({

--- a/src/api/controllers/cache-controller.ts
+++ b/src/api/controllers/cache-controller.ts
@@ -13,8 +13,9 @@ const CACHE_OK = Symbol('cache_ok');
 const CACHE_CONTROL_MUST_REVALIDATE = 'public, no-cache, must-revalidate';
 
 /**
- * Describes a key-value to be saved into request locals which represents the current
- * entity tag for an API endpoint.
+ * Describes a key-value to be saved into a request's locals, representing the current
+ * state of the chain depending on the type of information being requested by the endpoint.
+ * This entry will have an `ETag` string as the value.
  */
 export enum ETagType {
   /** ETag based on the latest `index_block_hash` or `microblock_hash`. */

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -42,7 +42,7 @@ import {
 import { ChainID, cvToString, deserializeCV } from '@stacks/transactions';
 import { validate } from '../validate';
 import { NextFunction, Request, Response } from 'express';
-import { getChainTipCacheHandler, setChainTipCacheHeaders } from '../controllers/cache-controller';
+import { getETagCacheHandler, setETagCacheHeaders } from '../controllers/cache-controller';
 
 const MAX_TX_PER_REQUEST = 50;
 const MAX_ASSETS_PER_REQUEST = 50;
@@ -107,7 +107,7 @@ interface AddressAssetEvents {
 
 export function createAddressRouter(db: DataStore, chainId: ChainID): express.Router {
   const router = express.Router();
-  const cacheHandler = getChainTipCacheHandler(db);
+  const cacheHandler = getETagCacheHandler(db);
 
   router.get(
     '/:stx_address/stx',
@@ -245,7 +245,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): express.Ro
       });
       const results = txResults.map(dbTx => parseDbTx(dbTx));
       const response: TransactionResults = { limit, offset, total, results };
-      setChainTipCacheHeaders(res);
+      setETagCacheHeaders(res);
       res.json(response);
     })
   );

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -42,7 +42,11 @@ import {
 import { ChainID, cvToString, deserializeCV } from '@stacks/transactions';
 import { validate } from '../validate';
 import { NextFunction, Request, Response } from 'express';
-import { getETagCacheHandler, setETagCacheHeaders } from '../controllers/cache-controller';
+import {
+  ETagType,
+  getETagCacheHandler,
+  setETagCacheHeaders,
+} from '../controllers/cache-controller';
 
 const MAX_TX_PER_REQUEST = 50;
 const MAX_ASSETS_PER_REQUEST = 50;
@@ -108,9 +112,11 @@ interface AddressAssetEvents {
 export function createAddressRouter(db: DataStore, chainId: ChainID): express.Router {
   const router = express.Router();
   const cacheHandler = getETagCacheHandler(db);
+  const mempoolCacheHandler = getETagCacheHandler(db, ETagType.mempool);
 
   router.get(
     '/:stx_address/stx',
+    cacheHandler,
     asyncHandler(async (req, res, next) => {
       const stxAddress = req.params['stx_address'];
       validatePrincipal(stxAddress);
@@ -137,6 +143,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): express.Ro
       if (tokenOfferingLocked.found) {
         result.token_offering_locked = tokenOfferingLocked.result;
       }
+      setETagCacheHeaders(res);
       res.json(result);
     })
   );
@@ -144,6 +151,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): express.Ro
   // get balances for STX, FTs, and counts for NFTs
   router.get(
     '/:stx_address/balances',
+    cacheHandler,
     asyncHandler(async (req, res, next) => {
       const stxAddress = req.params['stx_address'];
       validatePrincipal(stxAddress);
@@ -202,6 +210,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): express.Ro
         result.token_offering_locked = tokenOfferingLocked.result;
       }
 
+      setETagCacheHeaders(res);
       res.json(result);
     })
   );
@@ -252,6 +261,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): express.Ro
 
   router.get(
     '/:stx_address/:tx_id/with_transfers',
+    cacheHandler,
     asyncHandler(async (req, res) => {
       const stxAddress = req.params['stx_address'];
       let tx_id = req.params['tx_id'];
@@ -279,6 +289,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): express.Ro
             recipient: transfer.recipient,
           })),
         };
+        setETagCacheHeaders(res);
         res.json(result);
       } else res.status(404).json({ error: 'No matching transaction found' });
     })
@@ -286,6 +297,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): express.Ro
 
   router.get(
     '/:stx_address/transactions_with_transfers',
+    cacheHandler,
     asyncHandler(async (req, res, next) => {
       const stxAddress = req.params['stx_address'];
       validatePrincipal(stxAddress);
@@ -365,12 +377,14 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): express.Ro
         total,
         results,
       };
+      setETagCacheHeaders(res);
       res.json(response);
     })
   );
 
   router.get(
     '/:stx_address/assets',
+    cacheHandler,
     asyncHandler(async (req, res, next) => {
       // get recent asset event associated with address
       const stxAddress = req.params['stx_address'];
@@ -388,12 +402,14 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): express.Ro
       });
       const results = assetEvents.map(event => parseDbEvent(event));
       const response: AddressAssetEvents = { limit, offset, total, results };
+      setETagCacheHeaders(res);
       res.json(response);
     })
   );
 
   router.get(
     '/:stx_address/stx_inbound',
+    cacheHandler,
     asyncHandler(async (req, res, next) => {
       // get recent inbound STX transfers with memos
       const stxAddress = req.params['stx_address'];
@@ -448,6 +464,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): express.Ro
           limit,
           offset,
         };
+        setETagCacheHeaders(res);
         res.json(response);
       } catch (error) {
         logger.error(`Unable to get inbound transfers for ${stxAddress}`, error);
@@ -461,6 +478,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): express.Ro
    */
   router.get(
     '/:stx_address/nft_events',
+    cacheHandler,
     asyncHandler(async (req, res, next) => {
       // get recent asset event associated with address
       const stxAddress = req.params['stx_address'];
@@ -496,12 +514,14 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): express.Ro
         limit: limit,
         offset: offset,
       };
+      setETagCacheHeaders(res);
       res.json(nftListResponse);
     })
   );
 
   router.get(
     '/:address/mempool',
+    mempoolCacheHandler,
     asyncHandler(async (req, res, next) => {
       const limit = parseTxQueryLimit(req.query.limit ?? MAX_TX_PER_REQUEST);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
@@ -529,12 +549,14 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): express.Ro
           '@stacks/stacks-blockchain-api-types/api/transaction/get-mempool-transactions.schema.json';
         await validate(schemaPath, response);
       }
+      setETagCacheHeaders(res, ETagType.mempool);
       res.json(response);
     })
   );
 
   router.get(
     '/:stx_address/nonces',
+    cacheHandler,
     asyncHandler(async (req, res) => {
       // get recent asset event associated with address
       const stxAddress = req.params['stx_address'];
@@ -579,6 +601,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): express.Ro
           last_mempool_tx_nonce: (null as unknown) as number,
           detected_missing_nonces: [],
         };
+        setETagCacheHeaders(res);
         res.json(results);
       } else {
         const nonces = await db.getAddressNonces({
@@ -590,6 +613,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): express.Ro
           possible_next_nonce: nonces.possibleNextNonce,
           detected_missing_nonces: nonces.detectedMissingNonces,
         };
+        setETagCacheHeaders(res);
         res.json(results);
       }
     })

--- a/src/api/routes/block.ts
+++ b/src/api/routes/block.ts
@@ -8,7 +8,7 @@ import { timeout, waiter, has0xPrefix } from '../../helpers';
 import { InvalidRequestError, InvalidRequestErrorType } from '../../errors';
 import { parseLimitQuery, parsePagingQueryInput } from '../pagination';
 import { getBlockHeightPathParam, validateRequestHexInput } from '../query-helpers';
-import { getChainTipCacheHandler, setChainTipCacheHeaders } from '../controllers/cache-controller';
+import { getETagCacheHandler, setETagCacheHeaders } from '../controllers/cache-controller';
 import { asyncHandler } from '../async-handler';
 
 const MAX_BLOCKS_PER_REQUEST = 30;
@@ -20,7 +20,7 @@ const parseBlockQueryLimit = parseLimitQuery({
 
 export function createBlockRouter(db: DataStore): express.Router {
   const router = express.Router();
-  const cacheHandler = getChainTipCacheHandler(db);
+  const cacheHandler = getETagCacheHandler(db);
   router.get(
     '/',
     cacheHandler,
@@ -41,7 +41,7 @@ export function createBlockRouter(db: DataStore): express.Router {
         }
         return blockQuery.result;
       });
-      setChainTipCacheHeaders(res);
+      setETagCacheHeaders(res);
       // TODO: block schema validation
       const response: BlockListResponse = { limit, offset, total, results };
       res.json(response);
@@ -58,7 +58,7 @@ export function createBlockRouter(db: DataStore): express.Router {
         res.status(404).json({ error: `cannot find block by height ${height}` });
         return;
       }
-      setChainTipCacheHeaders(res);
+      setETagCacheHeaders(res);
       // TODO: block schema validation
       res.json(block.result);
     })
@@ -86,7 +86,7 @@ export function createBlockRouter(db: DataStore): express.Router {
         res.status(404).json({ error: `cannot find block by height ${burnBlockHeight}` });
         return;
       }
-      setChainTipCacheHeaders(res);
+      setETagCacheHeaders(res);
       // TODO: block schema validation
       res.json(block.result);
     })
@@ -108,7 +108,7 @@ export function createBlockRouter(db: DataStore): express.Router {
         res.status(404).json({ error: `cannot find block by hash ${hash}` });
         return;
       }
-      setChainTipCacheHeaders(res);
+      setETagCacheHeaders(res);
       // TODO: block schema validation
       res.json(block.result);
     })
@@ -129,7 +129,7 @@ export function createBlockRouter(db: DataStore): express.Router {
         res.status(404).json({ error: `cannot find block by burn block hash ${burnBlockHash}` });
         return;
       }
-      setChainTipCacheHeaders(res);
+      setETagCacheHeaders(res);
       // TODO: block schema validation
       res.json(block.result);
     })

--- a/src/api/routes/status.ts
+++ b/src/api/routes/status.ts
@@ -3,11 +3,11 @@ import * as fs from 'fs';
 import { DataStore } from '../../datastore/common';
 import { ServerStatusResponse } from '@stacks/stacks-blockchain-api-types';
 import { logger } from '../../helpers';
-import { getChainTipCacheHandler, setChainTipCacheHeaders } from '../controllers/cache-controller';
+import { getETagCacheHandler, setETagCacheHeaders } from '../controllers/cache-controller';
 
 export function createStatusRouter(db: DataStore): express.Router {
   const router = express.Router();
-  const cacheHandler = getChainTipCacheHandler(db);
+  const cacheHandler = getETagCacheHandler(db);
   const statusHandler = async (_: Request, res: any) => {
     try {
       const [branch, commit, tag] = fs.readFileSync('.git-info', 'utf-8').split('\n');
@@ -25,7 +25,7 @@ export function createStatusRouter(db: DataStore): express.Router {
           microblock_sequence: chainTip.result.microblockSequence,
         };
       }
-      setChainTipCacheHeaders(res);
+      setETagCacheHeaders(res);
       res.json(response);
     } catch (error) {
       logger.error(`Unable to read git info`, error);

--- a/src/api/routes/tokens/tokens.ts
+++ b/src/api/routes/tokens/tokens.ts
@@ -22,10 +22,7 @@ import { bufferToHexPrefixString, has0xPrefix, isValidPrincipal } from '../../..
 import { booleanValueForParam, isUnanchoredRequest } from '../../../api/query-helpers';
 import { cvToString, deserializeCV } from '@stacks/transactions';
 import { getAssetEventTypeString, parseDbTx } from '../../controllers/db-controller';
-import {
-  getChainTipCacheHandler,
-  setChainTipCacheHeaders,
-} from '../../controllers/cache-controller';
+import { getETagCacheHandler, setETagCacheHeaders } from '../../controllers/cache-controller';
 
 const MAX_TOKENS_PER_REQUEST = 200;
 const parseTokenQueryLimit = parseLimitQuery({
@@ -35,7 +32,7 @@ const parseTokenQueryLimit = parseLimitQuery({
 
 export function createTokenRouter(db: DataStore): express.Router {
   const router = express.Router();
-  const cacheHandler = getChainTipCacheHandler(db);
+  const cacheHandler = getETagCacheHandler(db);
   router.use(express.json());
 
   router.get(
@@ -97,7 +94,7 @@ export function createTokenRouter(db: DataStore): express.Router {
         total: total,
         results: parsedResults,
       };
-      setChainTipCacheHeaders(res);
+      setETagCacheHeaders(res);
       res.status(200).json(response);
     })
   );
@@ -158,7 +155,7 @@ export function createTokenRouter(db: DataStore): express.Router {
         total: total,
         results: parsedResults,
       };
-      setChainTipCacheHeaders(res);
+      setETagCacheHeaders(res);
       res.status(200).json(response);
     })
   );
@@ -212,7 +209,7 @@ export function createTokenRouter(db: DataStore): express.Router {
         total: total,
         results: parsedResults,
       };
-      setChainTipCacheHeaders(res);
+      setETagCacheHeaders(res);
       res.status(200).json(response);
     })
   );

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -34,7 +34,7 @@ import {
   GetRawTransactionResult,
   Transaction,
 } from '@stacks/stacks-blockchain-api-types';
-import { getChainTipCacheHandler, setChainTipCacheHeaders } from '../controllers/cache-controller';
+import { getETagCacheHandler, setETagCacheHeaders } from '../controllers/cache-controller';
 
 const MAX_TXS_PER_REQUEST = 200;
 const parseTxQueryLimit = parseLimitQuery({
@@ -57,7 +57,7 @@ const parseTxQueryEventsLimit = parseLimitQuery({
 export function createTxRouter(db: DataStore): express.Router {
   const router = express.Router();
 
-  const cacheHandler = getChainTipCacheHandler(db);
+  const cacheHandler = getETagCacheHandler(db);
 
   router.get(
     '/',
@@ -92,7 +92,7 @@ export function createTxRouter(db: DataStore): express.Router {
           '@stacks/stacks-blockchain-api-types/api/transaction/get-transactions.schema.json';
         await validate(schemaPath, response);
       }
-      setChainTipCacheHeaders(res);
+      setETagCacheHeaders(res);
       res.json(response);
     })
   );

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -655,9 +655,8 @@ export interface DataStore extends DataStoreEventEmitter {
   }): Promise<{ results: DbMempoolTx[]; total: number }>;
 
   /**
-   * Returns a string that represents a digest of all the current pending and valid
-   * transactions in the mempool. This digest can be used to calculate an `ETag` for
-   * mempool endpoint cache handlers.
+   * Returns a string that represents a digest of all the current pending transactions
+   * in the mempool. This digest can be used to calculate an `ETag` for mempool endpoint cache handlers.
    * @returns `FoundOrNot` object with a possible `digest` string.
    */
   getMempoolTxDigest(): Promise<FoundOrNot<{ digest: string }>>;

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -653,6 +653,15 @@ export interface DataStore extends DataStoreEventEmitter {
     recipientAddress?: string;
     address?: string;
   }): Promise<{ results: DbMempoolTx[]; total: number }>;
+
+  /**
+   * Returns a string that represents a digest of all the current pending and valid
+   * transactions in the mempool. This digest can be used to calculate an `ETag` for
+   * mempool endpoint cache handlers.
+   * @returns `FoundOrNot` object with a possible `digest` string.
+   */
+  getMempoolTxDigest(): Promise<FoundOrNot<{ digest: string }>>;
+
   getDroppedTxs(args: {
     limit: number;
     offset: number;

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -362,6 +362,10 @@ export class MemoryDataStore
     throw new Error('not yet implemented');
   }
 
+  getMempoolTxDigest(): Promise<FoundOrNot<{ digest: string }>> {
+    throw new Error('not yet implemented');
+  }
+
   getTxStrict(args: { txId: string; indexBlockHash: string }): Promise<FoundOrNot<DbTx>> {
     throw new Error('not implemented');
   }

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -2132,6 +2132,7 @@ export class PgDataStore
       `,
       [txIdBuffers]
     );
+    await this.refreshMaterializedView(client, 'mempool_digest');
     const restoredTxs = updateResults.rows.map(r => bufferToHexPrefixString(r.tx_id));
     return { restoredTxs: restoredTxs };
   }
@@ -2159,6 +2160,7 @@ export class PgDataStore
       `,
       [txIdBuffers]
     );
+    await this.refreshMaterializedView(client, 'mempool_digest');
     const removedTxs = updateResults.rows.map(r => bufferToHexPrefixString(r.tx_id));
     return { removedTxs: removedTxs };
   }
@@ -2188,6 +2190,7 @@ export class PgDataStore
       RETURNING tx_id`,
       [cutoffBlockHeight, DbTxStatus.DroppedApiGarbageCollect]
     );
+    await this.refreshMaterializedView(client, 'mempool_digest');
     const deletedTxs = deletedTxResults.rows.map(r => bufferToHexPrefixString(r.tx_id));
     return { deletedTxs: deletedTxs };
   }
@@ -3487,6 +3490,7 @@ export class PgDataStore
           updatedTxs.push(tx);
         }
       }
+      await this.refreshMaterializedView(client, 'mempool_digest');
     });
     for (const tx of updatedTxs) {
       await this.notifier?.sendTx({ txId: tx.tx_id });
@@ -3507,6 +3511,7 @@ export class PgDataStore
         [txIdBuffers, status]
       );
       updatedTxs = updateResults.rows.map(r => this.parseMempoolTxQueryResult(r));
+      await this.refreshMaterializedView(client, 'mempool_digest');
     });
     for (const tx of updatedTxs) {
       await this.notifier?.sendTx({ txId: tx.tx_id });

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -3875,6 +3875,16 @@ export class PgDataStore
     return { results: parsed, total: queryResult.total };
   }
 
+  async getMempoolTxDigest(): Promise<FoundOrNot<{ digest: string }>> {
+    return await this.query(async client => {
+      const result = await client.query<{ digest: string }>(`SELECT digest FROM mempool_digest`);
+      if (result.rowCount === 0) {
+        return { found: false } as const;
+      }
+      return { found: true, result: { digest: result.rows[0].digest } };
+    });
+  }
+
   async getTxStrict(args: { txId: string; indexBlockHash: string }): Promise<FoundOrNot<DbTx>> {
     return this.query(async client => {
       const result = await client.query<ContractTxQueryResult>(

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -7435,6 +7435,7 @@ export class PgDataStore
       await this.refreshMaterializedView(client, 'nft_custody', false);
       await this.refreshMaterializedView(client, 'nft_custody_unanchored', false);
       await this.refreshMaterializedView(client, 'chain_tip', false);
+      await this.refreshMaterializedView(client, 'mempool_digest', false);
     });
   }
 

--- a/src/migrations/1647573802137_mempool_digest.ts
+++ b/src/migrations/1647573802137_mempool_digest.ts
@@ -3,10 +3,21 @@ import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
 
 export const shorthands: ColumnDefinitions | undefined = undefined;
 
+async function pgServerMajorVersion(pgm: MigrationBuilder): Promise<number | undefined> {
+  const result = await pgm.db.query(`SHOW server_version`);
+  if (result.rowCount === 0) {
+    return;
+  }
+  return parseInt(result.rows[0].server_version
+    .split(' ')[0] // Remove additional info e.g. "(Debian 11.12-1.pgdg100+1)"
+    .split('.')[0] // Take only the major version e.g. "14" from "14.2"
+  );
+}
+
 export async function up(pgm: MigrationBuilder): Promise<void> {
-  const serverVersion = await pgm.db.query(`SHOW server_version`);
-  const majorVersion = parseInt(serverVersion.rows[0].server_version.split(' ')[0].split('.')[0]);
-  if (majorVersion >= 14) {
+  const serverVersion = await pgServerMajorVersion(pgm);
+  // The `bit_xor` function is available starting at PostgreSQL 14.
+  if (serverVersion && serverVersion >= 14) {
     pgm.createMaterializedView('mempool_digest', {}, `
       SELECT to_hex(bit_xor(tx_short_id)) AS digest
       FROM (
@@ -16,6 +27,9 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       ) m
     `);
   } else {
+    // TODO: Create a backwards-compatible view.
+    // We could use postgres' `digest` function here, but that requires enabling the `pgcrypto`
+    // extension, which might not be possible for some users.
     pgm.createMaterializedView('mempool_digest', {}, `
       SELECT NULL AS digest
     `);

--- a/src/migrations/1647573802137_mempool_digest.ts
+++ b/src/migrations/1647573802137_mempool_digest.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  const serverVersion = await pgm.db.query(`SHOW server_version`);
+  const majorVersion = parseInt(serverVersion.rows[0].server_version.split(' ')[0].split('.')[0]);
+  if (majorVersion >= 14) {
+    pgm.createMaterializedView('mempool_digest', {}, `
+      SELECT to_hex(bit_xor(tx_short_id)) AS digest
+      FROM (
+          SELECT ('x' || encode(tx_id, 'hex'))::bit(64)::bigint tx_short_id
+          FROM mempool_txs
+          WHERE pruned = false
+      ) m
+    `);
+  } else {
+    pgm.createMaterializedView('mempool_digest', {}, `
+      SELECT NULL AS digest
+    `);
+  }
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropMaterializedView('mempool_digest');
+}

--- a/src/migrations/1647573802137_mempool_digest.ts
+++ b/src/migrations/1647573802137_mempool_digest.ts
@@ -29,10 +29,8 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   } else {
     // TODO: Create a backwards-compatible view.
     // We could use postgres' `digest` function here, but that requires enabling the `pgcrypto`
-    // extension, which might not be possible for some users.
-    pgm.createMaterializedView('mempool_digest', {}, `
-      SELECT NULL AS digest
-    `);
+    // extension which might not be possible for some users.
+    pgm.createMaterializedView('mempool_digest', {}, `SELECT NULL AS digest`);
   }
 }
 

--- a/src/migrations/1647573802137_mempool_digest.ts
+++ b/src/migrations/1647573802137_mempool_digest.ts
@@ -3,31 +3,30 @@ import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
 
 export const shorthands: ColumnDefinitions | undefined = undefined;
 
-async function pgServerMajorVersion(pgm: MigrationBuilder): Promise<number | undefined> {
-  const result = await pgm.db.query(`SHOW server_version`);
-  if (result.rowCount === 0) {
-    return;
+async function isBitXorAvailable(pgm: MigrationBuilder) {
+  try {
+    await pgm.db.query('SELECT bit_xor(1)');
+    return true;
+  } catch (error: any) {
+    if (error.code === '42883' /* UNDEFINED_FUNCTION */) {
+      return false;
+    }
+    throw error;
   }
-  return parseInt(result.rows[0].server_version
-    .split(' ')[0] // Remove additional info e.g. "(Debian 11.12-1.pgdg100+1)"
-    .split('.')[0] // Take only the major version e.g. "14" from "14.2"
-  );
 }
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
-  const serverVersion = await pgServerMajorVersion(pgm);
-  // The `bit_xor` function is available starting at PostgreSQL 14.
-  if (serverVersion && serverVersion >= 14) {
+  if (await isBitXorAvailable(pgm)) {
     pgm.createMaterializedView('mempool_digest', {}, `
       SELECT to_hex(bit_xor(tx_short_id)) AS digest
       FROM (
-          SELECT ('x' || encode(tx_id, 'hex'))::bit(64)::bigint tx_short_id
-          FROM mempool_txs
-          WHERE pruned = false
+        SELECT ('x' || encode(tx_id, 'hex'))::bit(64)::bigint tx_short_id
+        FROM mempool_txs
+        WHERE pruned = false
       ) m
     `);
   } else {
-    // TODO: Create a backwards-compatible view.
+    // Assume mempool cache is always invalid.
     // We could use postgres' `digest` function here, but that requires enabling the `pgcrypto`
     // extension which might not be possible for some users.
     pgm.createMaterializedView('mempool_digest', {}, `SELECT NULL AS digest`);

--- a/src/migrations/1647573802137_mempool_digest.ts
+++ b/src/migrations/1647573802137_mempool_digest.ts
@@ -18,7 +18,7 @@ async function isBitXorAvailable(pgm: MigrationBuilder) {
 export async function up(pgm: MigrationBuilder): Promise<void> {
   if (await isBitXorAvailable(pgm)) {
     pgm.createMaterializedView('mempool_digest', {}, `
-      SELECT to_hex(bit_xor(tx_short_id)) AS digest
+      SELECT COALESCE(to_hex(bit_xor(tx_short_id)), '0') AS digest
       FROM (
         SELECT ('x' || encode(tx_id, 'hex'))::bit(64)::bigint tx_short_id
         FROM mempool_txs

--- a/src/tests/cache-control-tests.ts
+++ b/src/tests/cache-control-tests.ts
@@ -336,11 +336,11 @@ describe('cache-control tests', () => {
       .build();
     await db.update(block1);
 
-    // No ETag yet.
+    // Empty ETag.
     const request1 = await supertest(api.server).get('/extended/v1/tx/mempool');
     expect(request1.status).toBe(200);
     expect(request1.type).toBe('application/json');
-    expect(request1.headers['etag']).toBeUndefined();
+    expect(request1.headers['etag']).toEqual('"-1"');
 
     // Add mempool txs.
     const mempoolTx1 = testMempoolTx({ tx_id: '0x1101' });
@@ -410,7 +410,7 @@ describe('cache-control tests', () => {
     const request7 = await supertest(api.server).get('/extended/v1/tx/mempool');
     expect(request7.status).toBe(200);
     expect(request7.type).toBe('application/json');
-    expect(request7.headers['etag']).toBeUndefined();
+    expect(request7.headers['etag']).toEqual('"-1"');
   });
 
   afterEach(async () => {

--- a/src/tests/cache-control-tests.ts
+++ b/src/tests/cache-control-tests.ts
@@ -1,12 +1,13 @@
 import * as supertest from 'supertest';
 import { ChainID } from '@stacks/transactions';
 import { getBlockFromDataStore } from '../api/controllers/db-controller';
-import { DbBlock, DbMicroblockPartial, DbTx, DbTxTypeId } from '../datastore/common';
+import { DbBlock, DbMicroblockPartial, DbTx, DbTxStatus, DbTxTypeId } from '../datastore/common';
 import { startApiServer, ApiServer } from '../api/init';
 import { PgDataStore, cycleMigrations, runMigrations } from '../datastore/postgres-store';
 import { PoolClient } from 'pg';
 import { I32_MAX } from '../helpers';
 import { parseIfNoneMatchHeader } from '../api/controllers/cache-controller';
+import { TestBlockBuilder, testMempoolTx } from '../test-utils/test-builders';
 
 describe('cache-control tests', () => {
   let db: PgDataStore;
@@ -324,6 +325,92 @@ describe('cache-control tests', () => {
       .set('If-None-Match', `"${mb1.microblock_hash}"`);
     expect(fetchBlockByHashCached2.status).toBe(304);
     expect(fetchBlockByHashCached2.text).toBe('');
+  });
+
+  test('mempool digest cache control', async () => {
+    const block1 = new TestBlockBuilder({
+      block_height: 1,
+      index_block_hash: '0x01',
+    })
+      .addTx()
+      .build();
+    await db.update(block1);
+
+    // No ETag yet.
+    const request1 = await supertest(api.server).get('/extended/v1/tx/mempool');
+    expect(request1.status).toBe(200);
+    expect(request1.type).toBe('application/json');
+    expect(request1.headers['etag']).toBeUndefined();
+
+    // Add mempool txs.
+    const mempoolTx1 = testMempoolTx({ tx_id: '0x1101' });
+    const mempoolTx2 = testMempoolTx({ tx_id: '0x1102' });
+    await db.updateMempoolTxs({ mempoolTxs: [mempoolTx1, mempoolTx2] });
+
+    // Valid ETag.
+    const request2 = await supertest(api.server).get('/extended/v1/tx/mempool');
+    expect(request2.status).toBe(200);
+    expect(request2.type).toBe('application/json');
+    expect(request2.headers['etag']).toBeTruthy();
+    const etag1 = request2.headers['etag'];
+
+    // Cache works with valid ETag.
+    const request3 = await supertest(api.server)
+      .get('/extended/v1/tx/mempool')
+      .set('If-None-Match', etag1);
+    expect(request3.status).toBe(304);
+    expect(request3.text).toBe('');
+
+    // Drop one tx.
+    await db.dropMempoolTxs({ status: DbTxStatus.DroppedReplaceByFee, txIds: ['0x1101'] });
+
+    // Cache is now a miss.
+    const request4 = await supertest(api.server)
+      .get('/extended/v1/tx/mempool')
+      .set('If-None-Match', etag1);
+    expect(request4.status).toBe(200);
+    expect(request4.type).toBe('application/json');
+    expect(request4.headers['etag'] !== etag1).toEqual(true);
+    const etag2 = request4.headers['etag'];
+
+    // Restore dropped tx.
+    await db.restoreMempoolTxs(client, ['0x1101']);
+
+    // Cache with new ETag now a miss, new ETag is the same as the original.
+    const request5 = await supertest(api.server)
+      .get('/extended/v1/tx/mempool')
+      .set('If-None-Match', etag2);
+    expect(request5.status).toBe(200);
+    expect(request5.type).toBe('application/json');
+    expect(request5.headers['etag']).toEqual(etag1);
+
+    // Prune same tx.
+    await db.pruneMempoolTxs(client, ['0x1101']);
+
+    // ETag is now the same as when dropped.
+    const request6 = await supertest(api.server)
+      .get('/extended/v1/tx/mempool')
+      .set('If-None-Match', etag1);
+    expect(request6.status).toBe(200);
+    expect(request6.type).toBe('application/json');
+    expect(request6.headers['etag']).toEqual(etag2);
+
+    // Garbage collect all txs.
+    process.env.STACKS_MEMPOOL_TX_GARBAGE_COLLECTION_THRESHOLD = '0';
+    const block2 = new TestBlockBuilder({
+      block_height: 2,
+      index_block_hash: '0x02',
+      parent_index_block_hash: '0x01',
+    })
+      .addTx()
+      .build();
+    await db.update(block2);
+
+    // No ETag once again.
+    const request7 = await supertest(api.server).get('/extended/v1/tx/mempool');
+    expect(request7.status).toBe(200);
+    expect(request7.type).toBe('application/json');
+    expect(request7.headers['etag']).toBeUndefined();
   });
 
   afterEach(async () => {


### PR DESCRIPTION
This PR adds `ETag` cache support for mempool endpoints.
- Creates a new `mempool_digest` materialized view that calculates a pending mempool tx digest string only for pg14+. A version check is added to disable this string for earlier pg versions.
- Adds a new `mempool` entry to response locals to keep and validate this `ETag`.
- Installs the new cache handler in all mempool-sensitive endpoints, and adds chain tip handlers to endpoints that didn't have them before.
- Upgrade the postgres version used in our docker compose files to 14

Closes #879 