### PR TITLE
ci: add step to send discord notif on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,4 +518,4 @@ jobs:
               "url": "https://github.com/hirosystems/stacks-blockchain-api/releases/tag/v${{ steps.semantic.outputs.new_release_version }}"
             }]
         with:
-          args: ":rocket: A new version (${{ steps.semantic.outputs.new_release_version }}) of the Hiro Wallet is available on the Firefox Web Store!"
+          args: ":rocket: A new version (${{ steps.semantic.outputs.new_release_version }}) of the Stacks Blockchain API is available on Github!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,3 +504,18 @@ jobs:
           cache-to: type=gha,mode=max
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
           push: ${{ (github.ref != 'refs/heads/master' || steps.semantic.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+
+      - name: API Discord notification
+        if: steps.semantic.outputs.new_release_version != ''
+        uses: Ilshidur/action-discord@f1ed8844d9b33c17221fab0f36672cde39800eed
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_API_WEBHOOK }}
+          DISCORD_USERNAME: Hiro Team
+          DISCORD_AVATAR: 'https://i.imgur.com/z9Iy6ug.png'
+          DISCORD_EMBEDS: |
+            [{
+              "title": "API Release: ${{ steps.semantic.outputs.new_release_version }}",
+              "url": "https://github.com/hirosystems/stacks-blockchain-api/releases/tag/v${{ steps.semantic.outputs.new_release_version }}"
+            }]
+        with:
+          args: ":rocket: A new version (${{ steps.semantic.outputs.new_release_version }}) of the Hiro Wallet is available on the Firefox Web Store!"


### PR DESCRIPTION
## Description

Adds a step to the CI workflow to send a Github notification upon release.