### PR TITLE
fix: filter canonical txs correctly for account tx history

### DIFF
--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -5548,6 +5548,7 @@ export class PgDataStore
         SELECT ${txColumns()}, ${abiColumn()}, count
         FROM stx_txs
         INNER JOIN txs USING (tx_id)
+        WHERE canonical = TRUE AND microblock_canonical = TRUE
         `,
         [args.stxAddress, args.limit, args.offset, args.blockHeight]
       );

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -2072,6 +2072,7 @@ describe('api tests', () => {
     expect(result1.type).toBe('application/json');
     const json1 = JSON.parse(result1.text);
     expect(json1.total).toEqual(1);
+    expect(json1.results.length).toEqual(1);
     expect(json1.results[0].tx_id).toEqual('0x123123');
     expect(json1.results[0].block_height).toEqual(3);
 


### PR DESCRIPTION
This patch fixes a query statement when calculating the response for `/extended/v1/address/:addr/transactions` endpoint where even though the tx list and total was being calculated correctly, the `JOIN` with the `txs` table could bring a duplicate tx entry in the case of a re-org.