### PR TITLE
Add NFT FT metadata flag

### DIFF
--- a/.env
+++ b/.env
@@ -128,3 +128,6 @@ MAINNET_SEND_MANY_CONTRACT_ID=SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-man
 # of openapi.yaml for test / development NODE_ENV. 
 # For production, /doc is not served if this env var is not provided.
 # API_DOCS_URL="https://docs.hiro.so/api" 
+
+# Enable to keep trying forever if the metadata retrieval error is recoverable. Disabled by default. 
+# STACKS_API_METADATA_STRICT_MODE=1

--- a/.env
+++ b/.env
@@ -131,3 +131,6 @@ MAINNET_SEND_MANY_CONTRACT_ID=SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-man
 
 # Enable to keep trying forever if the metadata retrieval error is recoverable. Disabled by default. 
 # STACKS_API_METADATA_STRICT_MODE=1
+
+# Specify a retrieval interval to fetch metadata for tokens in ms if STACKS_API_METADATA_STRICT_MODE is not enabled. Default value is 3000.
+# STACKS_API_METADATA_RETRIEVAL_INTERVAL=2000

--- a/src/event-stream/tokens-contract-handler.ts
+++ b/src/event-stream/tokens-contract-handler.ts
@@ -61,7 +61,7 @@ export enum TokenMetadataErrorMode {
 
 const MAX_RETRIES_METADATA_RETREIVAL = 3;
 
-export function isMetadataStrictModeEnabled() {
+function isMetadataStrictModeEnabled() {
   const opt = process.env['STACKS_API_ENABLE_FT_METADATA']?.toLowerCase().trim();
   return opt === '1' || opt === 'true';
 }

--- a/src/event-stream/tokens-contract-handler.ts
+++ b/src/event-stream/tokens-contract-handler.ts
@@ -21,7 +21,7 @@ import {
   UIntCV,
 } from '@stacks/transactions';
 import { GetStacksNetwork } from '../bns-helpers';
-import { logError, logger, parseDataUrl, REPO_DIR, stopwatch } from '../helpers';
+import { logError, logger, parseArgBoolean, parseDataUrl, REPO_DIR, stopwatch } from '../helpers';
 import { StacksNetwork } from '@stacks/network';
 import PQueue from 'p-queue';
 import * as querystring from 'querystring';
@@ -72,8 +72,7 @@ export function isFtMetadataEnabled() {
 }
 
 export function isNftMetadataEnabled() {
-  const opt = process.env['STACKS_API_ENABLE_NFT_METADATA']?.toLowerCase().trim();
-  return opt === '1' || opt === 'true';
+  return parseArgBoolean('STACKS_API_ENABLE_NFT_METADATA');
 }
 
 /**
@@ -638,12 +637,10 @@ export class TokensContractHandler {
     let retryCounter = 0;
     while (true) {
       retryCounter++;
-      console.log('retryCounter: ', retryCounter);
       try {
         const response = await this.makeReadOnlyContractCall(functionName, functionArgs);
         return response;
       } catch (error: any) {
-        console.log('failed with error ', error);
         if (!isMetadataStrictModeEnabled()) {
           throw error;
         } else if (

--- a/src/event-stream/tokens-contract-handler.ts
+++ b/src/event-stream/tokens-contract-handler.ts
@@ -62,17 +62,15 @@ export enum TokenMetadataErrorMode {
 const MAX_RETRIES_METADATA_RETREIVAL = 3;
 
 function isMetadataStrictModeEnabled() {
-  const opt = process.env['STACKS_API_ENABLE_FT_METADATA']?.toLowerCase().trim();
-  return opt === '1' || opt === 'true';
+  return parseArgBoolean(process.env['STACKS_API_METADATA_STRICT_MODE']);
 }
 
 export function isFtMetadataEnabled() {
-  const opt = process.env['STACKS_API_ENABLE_FT_METADATA']?.toLowerCase().trim();
-  return opt === '1' || opt === 'true';
+  return parseArgBoolean(process.env['STACKS_API_ENABLE_FT_METADATA']);
 }
 
 export function isNftMetadataEnabled() {
-  return parseArgBoolean('STACKS_API_ENABLE_NFT_METADATA');
+  return parseArgBoolean(process.env['STACKS_API_ENABLE_NFT_METADATA']);
 }
 
 /**

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -440,6 +440,17 @@ export function parseArgBoolean(val: string | undefined | null): boolean {
   }
 }
 
+export function parseArgNumber(val: string | undefined | null): number {
+  if (typeof val === 'undefined' || val === null) {
+    return 0;
+  }
+  const num = Number(val);
+  if (Number.isInteger(num)) {
+    return num;
+  }
+  throw new Error(`Cannot parse integer from "${val}"`);
+}
+
 export function parsePort(portVal: number | string | undefined): number | undefined {
   if (portVal === undefined) {
     return undefined;

--- a/src/tests-tokens/test-contracts/error-function.clar
+++ b/src/tests-tokens/test-contracts/error-function.clar
@@ -1,0 +1,61 @@
+;; (impl-trait 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6.nft-trait.nft-trait)
+(define-non-fungible-token beeple uint)
+
+;; Public functions
+(define-constant nft-not-owned-err (err u401)) ;; unauthorized
+(define-constant nft-not-found-err (err u404)) ;; not found
+(define-constant sender-equals-recipient-err (err u405)) ;; method not allowed
+
+(define-private (nft-transfer-err (code uint))
+  (if (is-eq u1 code)
+    nft-not-owned-err
+    (if (is-eq u2 code)
+      sender-equals-recipient-err
+      (if (is-eq u3 code)
+        nft-not-found-err
+        (err code)))))
+
+;; Transfers tokens to a specified principal.
+(define-public (transfer (token-id uint) (sender principal) (recipient principal))
+  (if (and
+        (is-eq tx-sender (unwrap! (nft-get-owner? beeple token-id) nft-not-found-err))
+        (is-eq tx-sender sender)
+        (not (is-eq recipient sender)))
+       (match (nft-transfer? beeple token-id sender recipient)
+        success (ok success)
+        error (nft-transfer-err error))
+      nft-not-owned-err))
+
+;; Gets the owner of the specified token ID.
+(define-read-only (get-owner (token-id uint))
+  (ok (nft-get-owner? beeple token-id)))
+
+;; Gets the owner of the specified token ID.
+(define-read-only (get-last-token-id)
+  (ok u1))
+
+(define-read-only (get-token-uri (token-id uint))
+  (ok (some "data:,%7B%22name%22%3A%22Heystack%22%2C%22description%22%3A%22Heystack%20is%20a%20SIP-010-compliant%20fungible%20token%22%2C%22imageUrl%22%3A%22https%3A%2F%2Fheystack.xyz%2Fassets%2FStacks128w.png%22%7D")))
+
+(define-read-only (get-meta (token-id uint))
+  (if (is-eq token-id u1)
+    (ok (some {name: "EVERYDAYS: THE FIRST 5000 DAYS", uri: "https://ipfsgateway.makersplace.com/ipfs/QmZ15eQX8FPjfrtdX3QYbrhZxJpbLpvDpsgb2p3VEH8Bqq", mime-type: "image/jpeg"}))
+    (ok none)))
+
+(define-read-only (get-nft-meta)
+  (ok (some {name: "beeple", uri: "https://ipfsgateway.makersplace.com/ipfs/QmZ15eQX8FPjfrtdX3QYbrhZxJpbLpvDpsgb2p3VEH8Bqq", mime-type: "image/jpeg"})))
+
+(define-read-only (get-errstr (code uint))
+  (ok (if (is-eq u401 code)
+    "nft-not-owned"
+    (if (is-eq u404 code)
+      "nft-not-found"
+      (if (is-eq u405 code)
+        "sender-equals-recipient"
+        "unknown-error")))))
+        
+(define-read-only (return-error)
+    nft-not-found-err)
+
+;; Initialize the contract
+(try! (nft-mint? beeple u1 tx-sender))

--- a/src/tests-tokens/tokens-metadata-tests.ts
+++ b/src/tests-tokens/tokens-metadata-tests.ts
@@ -183,22 +183,6 @@ describe('api tests', () => {
   test('makeReadOnlyContractCall retries on connection interruption', async () => {
     process.env['STACKS_API_METADATA_STRICT_MODE'] = '1';
 
-    // mock response with 200 status code, headers and no body
-    // const headers = {
-    //   server: ['stacks/2.0'],
-    //   date: ['Thu, Apr 21 2022 23:33:17 GMT'],
-    //   'access-control-allow-origin': ['*'],
-    //   'access-control-allow-headers': ['origin, content-type'],
-    //   'access-control-allow-methods': ['POST, GET, OPTIONS'],
-    //   'content-type': ['application/json'],
-    //   'transfer-encoding': ['chunked'],
-    //   'x-request-id': ['3692950320'],
-    //   connection: ['close'],
-    // };
-    // nock('http://127.0.0.1:20443')
-    //   .post('/v2/contracts/call-read/STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6/beeple/get-token-uri')
-    //   .reply(200, undefined, headers);
-
     const contractAddr = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
       contractName = 'beeple';
     const abi = `{"maps":[],"functions":[{"args":[{"name":"code","type":"uint128"}],"name":"nft-transfer-err","access":"private","outputs":{"type":{"response":{"ok":"none","error":"uint128"}}}},{"args":[{"name":"token-id","type":"uint128"},{"name":"sender","type":"principal"},{"name":"recipient","type":"principal"}],"name":"transfer","access":"public","outputs":{"type":{"response":{"ok":"bool","error":"uint128"}}}},{"args":[{"name":"code","type":"uint128"}],"name":"get-errstr","access":"read_only","outputs":{"type":{"response":{"ok":{"string-ascii":{"length":23}},"error":"none"}}}},{"args":[],"name":"get-last-token-id","access":"read_only","outputs":{"type":{"response":{"ok":"uint128","error":"none"}}}},{"args":[{"name":"token-id","type":"uint128"}],"name":"get-meta","access":"read_only","outputs":{"type":{"response":{"ok":{"optional":{"tuple":[{"name":"mime-type","type":{"string-ascii":{"length":10}}},{"name":"name","type":{"string-ascii":{"length":30}}},{"name":"uri","type":{"string-ascii":{"length":87}}}]}},"error":"none"}}}},{"args":[],"name":"get-nft-meta","access":"read_only","outputs":{"type":{"response":{"ok":{"optional":{"tuple":[{"name":"mime-type","type":{"string-ascii":{"length":10}}},{"name":"name","type":{"string-ascii":{"length":6}}},{"name":"uri","type":{"string-ascii":{"length":87}}}]}},"error":"none"}}}},{"args":[{"name":"token-id","type":"uint128"}],"name":"get-owner","access":"read_only","outputs":{"type":{"response":{"ok":{"optional":"principal"},"error":"none"}}}},{"args":[{"name":"token-id","type":"uint128"}],"name":"get-token-uri","access":"read_only","outputs":{"type":{"response":{"ok":{"optional":{"string-ascii":{"length":197}}},"error":"none"}}}}],"variables":[{"name":"nft-not-found-err","type":{"response":{"ok":"none","error":"uint128"}},"access":"constant"},{"name":"nft-not-owned-err","type":{"response":{"ok":"none","error":"uint128"}},"access":"constant"},{"name":"sender-equals-recipient-err","type":{"response":{"ok":"none","error":"uint128"}},"access":"constant"}],"fungible_tokens":[],"non_fungible_tokens":[{"name":"beeple","type":"uint128"}]}`;

--- a/src/tests-tokens/tokens-metadata-tests.ts
+++ b/src/tests-tokens/tokens-metadata-tests.ts
@@ -184,20 +184,20 @@ describe('api tests', () => {
     process.env['STACKS_API_METADATA_STRICT_MODE'] = '1';
 
     // mock response with 200 status code, headers and no body
-    const headers = {
-      server: ['stacks/2.0'],
-      date: ['Thu, Apr 21 2022 23:33:17 GMT'],
-      'access-control-allow-origin': ['*'],
-      'access-control-allow-headers': ['origin, content-type'],
-      'access-control-allow-methods': ['POST, GET, OPTIONS'],
-      'content-type': ['application/json'],
-      'transfer-encoding': ['chunked'],
-      'x-request-id': ['3692950320'],
-      connection: ['close'],
-    };
-    nock('http://127.0.0.1:20443')
-      .post('/v2/contracts/call-read/STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6/beeple/get-token-uri')
-      .reply(200, undefined, headers);
+    // const headers = {
+    //   server: ['stacks/2.0'],
+    //   date: ['Thu, Apr 21 2022 23:33:17 GMT'],
+    //   'access-control-allow-origin': ['*'],
+    //   'access-control-allow-headers': ['origin, content-type'],
+    //   'access-control-allow-methods': ['POST, GET, OPTIONS'],
+    //   'content-type': ['application/json'],
+    //   'transfer-encoding': ['chunked'],
+    //   'x-request-id': ['3692950320'],
+    //   connection: ['close'],
+    // };
+    // nock('http://127.0.0.1:20443')
+    //   .post('/v2/contracts/call-read/STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6/beeple/get-token-uri')
+    //   .reply(200, undefined, headers);
 
     const contractAddr = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
       contractName = 'beeple';


### PR DESCRIPTION
## Description

This PR adds a new flag to identify nft/ft strict mode is enabled to keep retrying forever if the metadata retrieval error is recoverable. If it's not, then try a given number of times before failing. 
For details refer to issue #1007 

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @rafaelcr or @zone117x for review
