### PR TITLE
Fetch subdomains list for a name

### DIFF
--- a/docs/api/bns/subdomains/subdomains-list.example.json
+++ b/docs/api/bns/subdomains/subdomains-list.example.json
@@ -1,0 +1,7 @@
+[
+  "address_test.id.blockstack",
+  "previous_subdomain.id.blockstack",
+  "subdomain.id.blockstack",
+  "zonefile_test.id.blockstack",
+  "zone_test.id.blockstack"
+]

--- a/docs/api/bns/subdomains/subdomains-list.schema.json
+++ b/docs/api/bns/subdomains/subdomains-list.schema.json
@@ -1,11 +1,11 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "subdomains-list-in-name",
-    "title": "GetAllSubdomainsInName",
-    "description": "Fetch a list of subdomains in a name.",
-    "type": "array",
-    "items": {
-      "type": "string",
-      "pattern": "^([a-z0-9-_.+]{3,37})$"
-    }
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "subdomains-list-in-name",
+  "title": "GetAllSubdomainsInName",
+  "description": "Fetch a list of subdomains in a name.",
+  "type": "array",
+  "items": {
+    "type": "string",
+    "pattern": "^([a-z0-9-_.+]{3,37})$"
   }
+}

--- a/docs/api/bns/subdomains/subdomains-list.schema.json
+++ b/docs/api/bns/subdomains/subdomains-list.schema.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "subdomains-list-in-name",
+    "title": "GetAllSubdomainsInName",
+    "description": "Fetch a list of subdomains in a name.",
+    "type": "array",
+    "items": {
+      "type": "string",
+      "pattern": "^([a-z0-9-_.+]{3,37})$"
+    }
+  }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2536,9 +2536,9 @@ paths:
               example:
                 $ref: ./api/bns/errors/bns-no-such-name.example.json
 
-  /v1/names/{name}/subdomains_list/:
+  /v1/names/{name}/subdomains/:
     get:
-      summary: Get Subdomains List
+      summary: Get Name Subdomains
       description: Retrieves the list of subdomains for a specific name
       tags:
         - Names

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2536,7 +2536,7 @@ paths:
               example:
                 $ref: ./api/bns/errors/bns-no-such-name.example.json
 
-  /v1/names/{name}/subdomains/:
+  /v1/names/{name}/subdomains:
     get:
       summary: Get Name Subdomains
       description: Retrieves the list of subdomains for a specific name

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2536,6 +2536,32 @@ paths:
               example:
                 $ref: ./api/bns/errors/bns-no-such-name.example.json
 
+  /v1/names/{name}/subdomains_list/:
+    get:
+      summary: Get Subdomains List
+      description: Retrieves the list of subdomains for a specific name
+      tags:
+        - Names
+      operationId: fetch_subdomains_list_for_name
+      parameters:
+        - name: name
+          in: path
+          description: fully-qualified name
+          required: true
+          example: id.blockstack
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: ./api/bns/subdomains-list/bns-fetch-subdomains-in-name.schema.json
+              example:
+                $ref: ./api/bns/subdomains-list/bns-fetch-subdomains-in-name.example.json
+        
+
   /v1/names/{name}/zonefile:
     get:
       summary: Get Zone File

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2557,9 +2557,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: ./api/bns/subdomains-list/bns-fetch-subdomains-in-name.schema.json
+                $ref: ./api/bns/subdomains/subdomains-list.schema.json
               example:
-                $ref: ./api/bns/subdomains-list/bns-fetch-subdomains-in-name.example.json
+                $ref: ./api/bns/subdomains/subdomains-list.example.json
         
 
   /v1/names/{name}/zonefile:

--- a/src/api/routes/bns/names.ts
+++ b/src/api/routes/bns/names.ts
@@ -37,7 +37,7 @@ export function createBnsNamesRouter(db: DataStore): express.Router {
   );
 
   router.get(
-    '/:name/subdomains/',
+    '/:name/subdomains',
     asyncHandler(async (req, res, next) => {
       const { name } = req.params;
       const includeUnanchored = isUnanchoredRequest(req, res, next);

--- a/src/api/routes/bns/names.ts
+++ b/src/api/routes/bns/names.ts
@@ -37,7 +37,7 @@ export function createBnsNamesRouter(db: DataStore): express.Router {
   );
 
   router.get(
-    '/:name/subdomains_list/',
+    '/:name/subdomains/',
     asyncHandler(async (req, res, next) => {
       const { name } = req.params;
       const includeUnanchored = isUnanchoredRequest(req, res, next);

--- a/src/api/routes/bns/names.ts
+++ b/src/api/routes/bns/names.ts
@@ -37,6 +37,16 @@ export function createBnsNamesRouter(db: DataStore): express.Router {
   );
 
   router.get(
+    '/:name/subdomains_list/',
+    asyncHandler(async (req, res, next) => {
+      const { name } = req.params;
+      const includeUnanchored = isUnanchoredRequest(req, res, next);
+      const subdomainsList = await db.getSubdomainsListInName({ name, includeUnanchored });
+      res.json(subdomainsList.results);
+    })
+  );
+
+  router.get(
     '/:name/zonefile',
     asyncHandler(async (req, res, next) => {
       // Fetch a user’s raw zone file. This only works for RFC-compliant zone files. This method returns an error for names that have non-standard zone files.

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -924,6 +924,10 @@ export interface DataStore extends DataStoreEventEmitter {
   }): Promise<{
     results: string[];
   }>;
+  /**
+   * This function returns the subdomains for a specific name
+   * @param name - The name for which subdomains are required
+   */
   getSubdomainsListInName(args: {
     name: string;
     includeUnanchored: boolean;

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -924,6 +924,10 @@ export interface DataStore extends DataStoreEventEmitter {
   }): Promise<{
     results: string[];
   }>;
+  getSubdomainsListInName(args: {
+    name: string;
+    includeUnanchored: boolean;
+  }): Promise<{ results: string[] }>;
   getSubdomainsList(args: {
     page: number;
     includeUnanchored: boolean;

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -6907,6 +6907,30 @@ export class PgDataStore
     return { found: false } as const;
   }
 
+  async getSubdomainsListInName({
+    name,
+    includeUnanchored,
+  }: {
+    name: string;
+    includeUnanchored: boolean;
+  }) {
+    const queryResult = await this.queryTx(async client => {
+      const maxBlockHeight = await this.getMaxBlockHeight(client, { includeUnanchored });
+      return await client.query<{ fully_qualified_subdomain: string }>(
+        `
+        SELECT DISTINCT ON (fully_qualified_subdomain) fully_qualified_subdomain
+        FROM subdomains
+        WHERE name = $1 AND block_height <= $2
+        AND canonical = true AND microblock_canonical = true
+        ORDER BY fully_qualified_subdomain, block_height DESC, tx_index DESC
+        `,
+        [name, maxBlockHeight]
+      );
+    });
+    const results = queryResult.rows.map(r => r.fully_qualified_subdomain);
+    return { results };
+  }
+
   async getSubdomainsList({
     page,
     includeUnanchored,

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -6913,7 +6913,7 @@ export class PgDataStore
   }: {
     name: string;
     includeUnanchored: boolean;
-  }) {
+  }): Promise<{ results: string[] }> {
     const queryResult = await this.queryTx(async client => {
       const maxBlockHeight = await this.getMaxBlockHeight(client, { includeUnanchored });
       return await client.query<{ fully_qualified_subdomain: string }>(

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -6922,7 +6922,7 @@ export class PgDataStore
         FROM subdomains
         WHERE name = $1 AND block_height <= $2
         AND canonical = true AND microblock_canonical = true
-        ORDER BY fully_qualified_subdomain, block_height DESC, tx_index DESC
+        ORDER BY fully_qualified_subdomain, block_height DESC, microblock_sequence DESC, tx_index DESC
         `,
         [name, maxBlockHeight]
       );

--- a/src/tests-bns/api.ts
+++ b/src/tests-bns/api.ts
@@ -742,6 +742,20 @@ describe('BNS API tests', () => {
     );
   });
 
+  test('Success: subdomains in name', async () => {
+    const query = await supertest(api.server).get(`/v1/names/id.blockstack/subdomains_list/`);
+    console.log(query);
+    console.log('query result above^');
+    const expectedResult =  [
+      'address_test.id.blockstack',
+      'previous_subdomain.id.blockstack',
+      'subdomain.id.blockstack',
+      'zonefile_test.id.blockstack',
+      'zone_test.id.blockstack'
+    ];
+    expect(query.body).toEqual(expectedResult);
+  });
+
   afterAll(async () => {
     await api.terminate();
     client.release();

--- a/src/tests-bns/api.ts
+++ b/src/tests-bns/api.ts
@@ -743,9 +743,7 @@ describe('BNS API tests', () => {
   });
 
   test('Success: subdomains in name', async () => {
-    const query = await supertest(api.server).get(`/v1/names/id.blockstack/subdomains_list/`);
-    console.log(query);
-    console.log('query result above^');
+    const query = await supertest(api.server).get(`/v1/names/id.blockstack/subdomains/`);
     const expectedResult =  [
       'address_test.id.blockstack',
       'previous_subdomain.id.blockstack',


### PR DESCRIPTION
## Description

This PR creates an endpoint for fetching the list of `fully_qualified_subdomain` of subdomains for a specific `name` and returning the array of strings in response. The endpoint is as follows:
```
/v1/names/:name/subdomains_list/
```

For details refer to issue #1097 

## Type of Change
- [X] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @rafaelcr or @zone117x for review
