### PR TITLE
fix: shorten token metadata pg notifications

### DIFF
--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -389,7 +389,7 @@ export type DataStoreEventEmitter = StrictEventEmitter<
     addressUpdate: (address: string, blockHeight: number) => void;
     nameUpdate: (info: string) => void;
     tokensUpdate: (contractID: string) => void;
-    tokenMetadataUpdateQueued: (entry: TokenMetadataUpdateInfo) => void;
+    tokenMetadataUpdateQueued: (queueId: number) => void;
   }
 >;
 
@@ -963,6 +963,12 @@ export interface DataStore extends DataStoreEventEmitter {
     limit: number;
     offset: number;
   }): Promise<{ results: DbNonFungibleTokenMetadata[]; total: number }>;
+
+  /**
+   * Returns a single entry from the `token_metadata_queue` table.
+   * @param queueId - queue entry id
+   */
+  getTokenMetadataQueueEntry(queueId: number): Promise<FoundOrNot<DbTokenMetadataQueueEntry>>;
 
   getTokenMetadataQueue(
     limit: number,

--- a/src/datastore/postgres-notifier.ts
+++ b/src/datastore/postgres-notifier.ts
@@ -21,7 +21,7 @@ export type PgAddressNotificationPayload = {
 };
 
 export type PgTokenMetadataNotificationPayload = {
-  entry: DbTokenMetadataQueueEntry;
+  queueId: number;
 };
 
 export type PgNameNotificationPayload = {


### PR DESCRIPTION
Some metadata notifications were too big, causing postgres to log errors such as:
```
2022-03-26 02:21:13.908 UTC [59] ERROR:  payload string too long
2022-03-26 02:21:13.908 UTC [59] STATEMENT:  NOTIFY "stacks-api-pg-notifier", '{"notification":{"type":"tokenMetadataUpdateQueued","payload":{"entry":{"queueId":190,"txId":"0x919a0f6831ca0b89a9ab6965323d777e159a42dd66b28d6b1e081a0c23f7e996","contractId":"SPEFVJJXM9BT0PP3H2S6V6029SWF4B92RCJFE1Y0.laser-eyes","contractAbi":{"functions":
... lots of additional data ...
{"access":"variable","name":"m_update_price","type":"uint128"}]},"blockHeight":35022,"processed":false}}}}'
```

This PR sends only the queue entry ID through notifications and queries the complete object on the other side.

Fixes #1126 