### PR TITLE
fix: `/v1/names/[:name]` name resolution

### DIFF
--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -244,7 +244,7 @@ export async function startApiServer(opts: {
       const router = express.Router();
       router.use(cors());
       router.use('/namespaces', createBnsNamespacesRouter(datastore));
-      router.use('/names', createBnsNamesRouter(datastore));
+      router.use('/names', createBnsNamesRouter(datastore, chainId));
       router.use('/addresses', createBnsAddressesRouter(datastore));
       return router;
     })()

--- a/src/api/routes/bns/names.ts
+++ b/src/api/routes/bns/names.ts
@@ -5,8 +5,9 @@ import { parsePagingQueryInput } from '../../../api/pagination';
 import { isUnanchoredRequest } from '../../query-helpers';
 import { bnsBlockchain, BnsErrors } from '../../../bns-constants';
 import { BnsGetNameInfoResponse } from '@stacks/stacks-blockchain-api-types';
+import { ChainID } from '@stacks/transactions';
 
-export function createBnsNamesRouter(db: DataStore): express.Router {
+export function createBnsNamesRouter(db: DataStore, chainId: ChainID): express.Router {
   const router = express.Router();
 
   router.get(

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -6998,6 +6998,16 @@ export class PgDataStore
     const queryResult = await this.queryTx(async client => {
       const maxBlockHeight = await this.getMaxBlockHeight(client, { includeUnanchored });
       return await client.query<DbBnsName & { tx_id: Buffer; index_block_hash: Buffer }>(
+        // `
+        // SELECT names.*, zonefiles.zonefile
+        // FROM names
+        // LEFT JOIN zonefiles USING (zonefile_hash)
+        // WHERE name = $1
+        // AND registered_at <= $2
+        // AND canonical = true AND microblock_canonical = true
+        // ORDER BY registered_at DESC, microblock_sequence DESC, tx_index DESC
+        // LIMIT 1
+        // `,
         `
         SELECT DISTINCT ON (names.name) names.name, names.*, zonefiles.zonefile
         FROM names

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -9,7 +9,7 @@ import * as winston from 'winston';
 import { isValidStacksAddress, stacksToBitcoinAddress } from 'stacks-encoding-native-js';
 import * as btc from 'bitcoinjs-lib';
 import * as BN from 'bn.js';
-import { ChainID } from '@stacks/transactions';
+import { bufferCV, ChainID, cvToHex, tupleCV } from '@stacks/transactions';
 import BigNumber from 'bignumber.js';
 import {
   CliConfigSetColors,
@@ -942,6 +942,22 @@ export function parseDataUrl(
   } catch (e) {
     return false;
   }
+}
+
+/**
+ * Creates a Clarity tuple Buffer from a BNS name, just how it is stored in
+ * received NFT events.
+ */
+export function bnsNameCV(name: string): Buffer {
+  const components = name.split('.');
+  return hexToBuffer(
+    cvToHex(
+      tupleCV({
+        name: bufferCV(Buffer.from(components[0])),
+        namespace: bufferCV(Buffer.from(components[1])),
+      })
+    )
+  );
 }
 
 export function getSendManyContract(chainId: ChainID) {

--- a/src/migrations/1636130197558_nft_custody.ts
+++ b/src/migrations/1636130197558_nft_custody.ts
@@ -26,4 +26,5 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   `);
 
   pgm.createIndex('nft_custody', ['recipient', 'asset_identifier']);
+  pgm.createIndex('nft_custody', 'asset_identifier');
 }

--- a/src/migrations/1640037852136_nft_custody_unanchored.ts
+++ b/src/migrations/1640037852136_nft_custody_unanchored.ts
@@ -30,4 +30,5 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   `);
 
   pgm.createIndex('nft_custody_unanchored', ['recipient', 'asset_identifier']);
+  pgm.createIndex('nft_custody_unanchored', 'asset_identifier');
 }

--- a/src/test-utils/test-builders.ts
+++ b/src/test-utils/test-builders.ts
@@ -124,6 +124,9 @@ interface TestMicroblockArgs {
   microblock_parent_hash?: string;
   microblock_sequence?: number;
   parent_index_block_hash?: string;
+  parent_burn_block_time?: number;
+  parent_burn_block_hash?: string;
+  parent_burn_block_height?: number;
 }
 
 /**
@@ -137,9 +140,9 @@ function testMicroblock(args?: TestMicroblockArgs): DbMicroblockPartial {
     microblock_sequence: args?.microblock_sequence ?? 0,
     microblock_parent_hash: args?.microblock_parent_hash ?? BLOCK_HASH,
     parent_index_block_hash: args?.parent_index_block_hash ?? INDEX_BLOCK_HASH,
-    parent_burn_block_height: BURN_BLOCK_HEIGHT,
-    parent_burn_block_hash: BURN_BLOCK_HASH,
-    parent_burn_block_time: BURN_BLOCK_TIME,
+    parent_burn_block_height: args?.parent_burn_block_height ?? BURN_BLOCK_HEIGHT,
+    parent_burn_block_hash: args?.parent_burn_block_hash ?? BURN_BLOCK_HASH,
+    parent_burn_block_time: args?.parent_burn_block_time ?? BURN_BLOCK_TIME,
   };
 }
 
@@ -703,6 +706,7 @@ export class TestMicroblockStreamBuilder {
       microblock_hash: this.microblock.microblock_hash,
       microblock_sequence: this.microblock.microblock_sequence,
       tx_index: ++this.txIndex,
+      index_block_hash: '',
     };
     this.data.txs.push(testTx({ ...defaultBlockArgs, ...args }));
     this.eventIndex = -1;

--- a/src/test-utils/test-builders.ts
+++ b/src/test-utils/test-builders.ts
@@ -85,6 +85,9 @@ interface TestBlockArgs {
   block_hash?: string;
   index_block_hash?: string;
   burn_block_hash?: string;
+  burn_block_time?: number;
+  burn_block_height?: number;
+  miner_txid?: string;
   parent_index_block_hash?: string;
   parent_block_hash?: string;
   parent_microblock_hash?: string;
@@ -106,10 +109,10 @@ function testBlock(args?: TestBlockArgs): DbBlock {
     parent_microblock_hash: args?.parent_microblock_hash ?? '',
     parent_microblock_sequence: args?.parent_microblock_sequence ?? 0,
     block_height: args?.block_height ?? BLOCK_HEIGHT,
-    burn_block_time: BURN_BLOCK_TIME,
+    burn_block_time: args?.burn_block_time ?? BURN_BLOCK_TIME,
     burn_block_hash: args?.burn_block_hash ?? BURN_BLOCK_HASH,
-    burn_block_height: BURN_BLOCK_HEIGHT,
-    miner_txid: '0x4321',
+    burn_block_height: args?.burn_block_height ?? BURN_BLOCK_HEIGHT,
+    miner_txid: args?.miner_txid ?? '0x4321',
     canonical: args?.canonical ?? true,
     execution_cost_read_count: 0,
     execution_cost_read_length: 0,

--- a/src/tests-bns/api.ts
+++ b/src/tests-bns/api.ts
@@ -73,7 +73,7 @@ describe('BNS API tests', () => {
       .addTxNftEvent({
         asset_event_type_id: DbAssetEventTypeId.Mint,
         value: bnsNameCV('xyz.abc'),
-        asset_identifier: 'SP000000000000000000002Q6VF78.bns::names',
+        asset_identifier: 'ST000000000000000000002AMW42H.bns::names',
         recipient: 'ST5RRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1ZA',
       })
       .addTxBnsName({
@@ -267,7 +267,7 @@ describe('BNS API tests', () => {
       .addTxNftEvent({
         asset_event_type_id: DbAssetEventTypeId.Mint,
         value: bnsNameCV(name),
-        asset_identifier: 'SP000000000000000000002Q6VF78.bns::names',
+        asset_identifier: 'ST000000000000000000002AMW42H.bns::names',
         recipient: 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP',
       })
       .build();
@@ -372,7 +372,7 @@ describe('BNS API tests', () => {
       .addTxNftEvent({
         asset_event_type_id: DbAssetEventTypeId.Mint,
         value: bnsNameCV(name),
-        asset_identifier: 'SP000000000000000000002Q6VF78.bns::names',
+        asset_identifier: 'ST000000000000000000002AMW42H.bns::names',
         recipient: 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP',
       })
       .build();
@@ -556,7 +556,7 @@ describe('BNS API tests', () => {
       .addTxNftEvent({
         asset_event_type_id: DbAssetEventTypeId.Mint,
         value: bnsNameCV(name),
-        asset_identifier: 'SP000000000000000000002Q6VF78.bns::names',
+        asset_identifier: 'ST000000000000000000002AMW42H.bns::names',
         recipient: 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP',
       })
       .build();
@@ -777,7 +777,7 @@ describe('BNS API tests', () => {
       .addTx({ tx_id: '0x1111' })
       .addTxBnsName({ name: name, status: 'name-register', address: addr1 })
       .addTxNftEvent({
-        asset_identifier: 'SP000000000000000000002Q6VF78.bns::names',
+        asset_identifier: 'ST000000000000000000002AMW42H.bns::names',
         value: value,
         recipient: addr1,
       })
@@ -794,7 +794,7 @@ describe('BNS API tests', () => {
       .addTx({ tx_id: '0xf111' })
       .addTxBnsName({ name: name, status: 'name-update', address: addr2 })
       .addTxNftEvent({
-        asset_identifier: 'SP000000000000000000002Q6VF78.bns::names',
+        asset_identifier: 'ST000000000000000000002AMW42H.bns::names',
         value: value,
         sender: addr1,
         recipient: addr2,
@@ -808,7 +808,7 @@ describe('BNS API tests', () => {
       .addTx({ tx_id: '0xf112' })
       .addTxBnsName({ name: name, status: 'name-update', address: addr3 })
       .addTxNftEvent({
-        asset_identifier: 'SP000000000000000000002Q6VF78.bns::names',
+        asset_identifier: 'ST000000000000000000002AMW42H.bns::names',
         value: value,
         sender: addr1,
         recipient: addr3,

--- a/src/tests-bns/bns-integration-tests.ts
+++ b/src/tests-bns/bns-integration-tests.ts
@@ -359,7 +359,7 @@ describe('BNS integration tests', () => {
     // testing name import
     await nameImport(namespace, importZonefile, name, testnetKey);
 
-    const importQuery = await db.getName({ name: `${name}.${namespace}`, includeUnanchored: false });
+    const importQuery = await db.getName({ name: `${name}.${namespace}`, includeUnanchored: false, chainId: network.chainId });
     const importQuery1 = await supertest(api.server).get(`/v1/names/${name}.${namespace}`);
     expect(importQuery1.status).toBe(200);
     expect(importQuery1.type).toBe('application/json');
@@ -488,7 +488,7 @@ describe('BNS integration tests', () => {
     const query1 = await supertest(api.server).get(`/v1/names/${name}.${namespace}`);
     expect(query1.status).toBe(200);
     expect(query1.type).toBe('application/json');
-    const query = await db.getName({ name: `${name}.${namespace}`, includeUnanchored: false });
+    const query = await db.getName({ name: `${name}.${namespace}`, includeUnanchored: false, chainId: network.chainId });
     expect(query.found).toBe(true);
     if (query.found) {
       expect(query.result.zonefile).toBe(zonefile);

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -32,7 +32,7 @@ import * as pgConnectionString from 'pg-connection-string';
 import { parseDbEvent } from '../api/controllers/db-controller';
 import * as assert from 'assert';
 import { bnsNameCV, I32_MAX } from '../helpers';
-import { intCV, serializeCV } from '@stacks/transactions';
+import { ChainID, intCV, serializeCV } from '@stacks/transactions';
 
 function testEnvVars(
   envVars: Record<string, string | undefined>,
@@ -3812,7 +3812,11 @@ describe('postgres datastore', () => {
       ]
     );
 
-    let name = await db.getName({ name: 'xyz.abc', includeUnanchored: false });
+    let name = await db.getName({
+      name: 'xyz.abc',
+      includeUnanchored: false,
+      chainId: ChainID.Mainnet,
+    });
     assert(name.found);
     expect(name.result.canonical).toBe(true);
     expect(name.result.index_block_hash).toBe(block2.index_block_hash);
@@ -4015,7 +4019,11 @@ describe('postgres datastore', () => {
     });
     expect(names.results.length).toBe(1);
 
-    name = await db.getName({ name: 'xyz.abc', includeUnanchored: false });
+    name = await db.getName({
+      name: 'xyz.abc',
+      includeUnanchored: false,
+      chainId: ChainID.Mainnet,
+    });
     assert(name.found);
     expect(name.result.canonical).toBe(true);
     expect(name.result.index_block_hash).toBe(block2.index_block_hash);
@@ -4076,7 +4084,11 @@ describe('postgres datastore', () => {
     };
     await db.update({ block: block4b, microblocks: [], minerRewards: [], txs: [] });
 
-    name = await db.getName({ name: 'xyz.abc', includeUnanchored: false });
+    name = await db.getName({
+      name: 'xyz.abc',
+      includeUnanchored: false,
+      chainId: ChainID.Mainnet,
+    });
     assert(name.found);
     expect(name.result.canonical).toBe(true);
     expect(name.result.index_block_hash).toBe(block2b.index_block_hash);

--- a/src/tests/token-tests.ts
+++ b/src/tests/token-tests.ts
@@ -175,6 +175,7 @@ describe('/extended/v1/tokens tests', () => {
       block_height: 4,
       index_block_hash: '0x04',
       parent_index_block_hash: '0x03',
+      parent_microblock_hash: '0x11',
     })
       .addTx({ tx_id: '0x5555' })
       .build();
@@ -469,6 +470,7 @@ describe('/extended/v1/tokens tests', () => {
       block_height: 3,
       index_block_hash: '0x03',
       parent_index_block_hash: '0x02',
+      parent_microblock_hash: '0x11',
     })
       .addTx({ tx_id: '0x1004' })
       .build();
@@ -621,6 +623,7 @@ describe('/extended/v1/tokens tests', () => {
       block_height: 7,
       index_block_hash: '0x07',
       parent_index_block_hash: '0x06',
+      parent_microblock_hash: '0x14',
     })
       .addTx({ tx_id: '0x100b' })
       .build();
@@ -795,6 +798,7 @@ describe('/extended/v1/tokens tests', () => {
       block_height: 3,
       index_block_hash: '0x03',
       parent_index_block_hash: '0x02',
+      parent_microblock_hash: '0x11',
     })
       .addTx({ tx_id: '0x1004' })
       .build();
@@ -942,6 +946,7 @@ describe('/extended/v1/tokens tests', () => {
       block_height: 7,
       index_block_hash: '0x07',
       parent_index_block_hash: '0x06',
+      parent_microblock_hash: '0x14',
     })
       .addTx({ tx_id: '0x100b' })
       .build();


### PR DESCRIPTION
This PR fixes a bug where the owner of a BNS name was not correctly reported through the `/v1/names/[:name]` endpoint.

The `names` table does not really track true name ownership, given that it is mostly updated when there is a zonefile change or a set of specific contract calls, causing re-orgs not being accounted for correctly. The `nft_custody` view is now used to get the latest owner given that a name is also an NFT and we get all events for it.

Incidentally, this also fixes a previously unknown bug where `nft_custody` was not being refreshed on a deep chain re-org.

Closes #1158 