### PR TITLE
fix: resolve bns names correctly in `/v1/addresses/stacks/[:address]`

### DIFF
--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -245,7 +245,7 @@ export async function startApiServer(opts: {
       router.use(cors());
       router.use('/namespaces', createBnsNamespacesRouter(datastore));
       router.use('/names', createBnsNamesRouter(datastore, chainId));
-      router.use('/addresses', createBnsAddressesRouter(datastore));
+      router.use('/addresses', createBnsAddressesRouter(datastore, chainId));
       return router;
     })()
   );

--- a/src/api/routes/bns/addresses.ts
+++ b/src/api/routes/bns/addresses.ts
@@ -2,10 +2,11 @@ import * as express from 'express';
 import { asyncHandler } from '../../async-handler';
 import { DataStore } from '../../../datastore/common';
 import { isUnanchoredRequest } from '../../query-helpers';
+import { ChainID } from '@stacks/transactions';
 
 const SUPPORTED_BLOCKCHAINS = ['stacks'];
 
-export function createBnsAddressesRouter(db: DataStore): express.Router {
+export function createBnsAddressesRouter(db: DataStore, chainId: ChainID): express.Router {
   const router = express.Router();
   router.get(
     '/:blockchain/:address',
@@ -20,6 +21,7 @@ export function createBnsAddressesRouter(db: DataStore): express.Router {
       const namesByAddress = await db.getNamesByAddressList({
         address: address,
         includeUnanchored,
+        chainId,
       });
       if (namesByAddress.found) {
         res.json({ names: namesByAddress.result });

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -20,7 +20,7 @@ import {
 } from '@stacks/stacks-blockchain-api-types';
 import { getTxSenderAddress } from '../event-stream/reader';
 import { RawTxQueryResult } from './postgres-store';
-import { ClarityAbi } from '@stacks/transactions';
+import { ChainID, ClarityAbi } from '@stacks/transactions';
 import { Block } from '@stacks/stacks-blockchain-api-types';
 
 export interface DbBlock {
@@ -947,6 +947,7 @@ export interface DataStore extends DataStoreEventEmitter {
   getNamesByAddressList(args: {
     address: string;
     includeUnanchored: boolean;
+    chainId: ChainID;
   }): Promise<FoundOrNot<string[]>>;
   getNamesList(args: {
     page: number;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -9,7 +9,15 @@ import * as winston from 'winston';
 import { isValidStacksAddress, stacksToBitcoinAddress } from 'stacks-encoding-native-js';
 import * as btc from 'bitcoinjs-lib';
 import * as BN from 'bn.js';
-import { bufferCV, ChainID, cvToHex, tupleCV } from '@stacks/transactions';
+import {
+  BufferCV,
+  bufferCV,
+  ChainID,
+  cvToHex,
+  hexToCV,
+  TupleCV,
+  tupleCV,
+} from '@stacks/transactions';
 import BigNumber from 'bignumber.js';
 import {
   CliConfigSetColors,
@@ -958,6 +966,24 @@ export function bnsNameCV(name: string): Buffer {
       })
     )
   );
+}
+
+/**
+ * Converts a hex Clarity value for a BNS name NFT into the string name
+ * @param hex - hex encoded Clarity value of BNS name NFT
+ * @returns BNS name string
+ */
+export function bnsHexValueToName(hex: string): string {
+  const tuple = hexToCV(hex) as TupleCV;
+  const name = tuple.data.name as BufferCV;
+  const namespace = tuple.data.namespace as BufferCV;
+  return `${name.buffer.toString('utf8')}.${namespace.buffer.toString('utf8')}`;
+}
+
+export function getBnsSmartContractId(chainId: ChainID): string {
+  return chainId === ChainID.Mainnet
+    ? 'SP000000000000000000002Q6VF78.bns::names'
+    : 'ST000000000000000000002AMW42H.bns::names';
 }
 
 export function getSendManyContract(chainId: ChainID) {


### PR DESCRIPTION
Resolves names correctly, considering both subdomains and names including those who were imported from Blockstack v1 and don't generate an NFT event.

Fixes #1172 