### PR TITLE
fix: treat incorrect get-token-uri none values as undefined

### DIFF
--- a/src/token-metadata/tokens-contract-handler.ts
+++ b/src/token-metadata/tokens-contract-handler.ts
@@ -505,13 +505,15 @@ export class TokensContractHandler {
     );
   }
 
-  private checkAndParseString(responseCV: ClarityValue): string {
+  private checkAndParseString(responseCV: ClarityValue): string | undefined {
     const unwrappedClarityValue = this.unwrapClarityType(responseCV);
     if (
       unwrappedClarityValue.type === ClarityType.StringASCII ||
       unwrappedClarityValue.type === ClarityType.StringUTF8
     ) {
       return unwrappedClarityValue.data;
+    } else if (unwrappedClarityValue.type === ClarityType.OptionalNone) {
+      return undefined;
     }
     throw new RetryableTokenMetadataError(
       `Unexpected Clarity type '${unwrappedClarityValue.type}' while unwrapping string`

--- a/src/token-metadata/tokens-processor-queue.ts
+++ b/src/token-metadata/tokens-processor-queue.ts
@@ -144,9 +144,6 @@ export class TokensProcessorQueue {
           contractId: queueEntry.contractId,
           txId: queueEntry.txId,
         });
-        logger.info(
-          `[token-metadata] finished token contract processing for: ${queueEntry.contractId} from tx ${queueEntry.txId}`
-        );
         if (this.queuedEntries.size < this.queue.concurrency) {
           void this.checkDbQueue();
         }


### PR DESCRIPTION
Some contracts incorrectly return `none` in their `get-token-uri` functions, causing an infinite retry loop in strict token metadata mode.