### PR TITLE
Optimized block endpoint

### DIFF
--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -413,7 +413,7 @@ export async function getMicroblocksFromDataStore(args: {
 }
 
 export async function getBlocksMetadata(args: { limit: number; offset: number; db: PgStore }) {
-  const blocks = await args.db.getMetadataBlocks({ limit: args.limit, offset: args.offset });
+  const blocks = await args.db.getBlocksWithMetadata({ limit: args.limit, offset: args.offset });
   const results = blocks.results.map(block =>
     parseDbBlock(
       block.block,

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -412,6 +412,20 @@ export async function getMicroblocksFromDataStore(args: {
   };
 }
 
+export async function getBlocksMetadata(args: { limit: number; offset: number; db: PgStore }) {
+  const blocks = await args.db.getMetadataBlocks({ limit: args.limit, offset: args.offset });
+  const results = blocks.results.map(block =>
+    parseDbBlock(
+      block.block,
+      block.txs,
+      block.microblocks_accepted,
+      block.microblocks_streamed,
+      block.microblock_tx_count
+    )
+  );
+  return { results, total: blocks.total };
+}
+
 export async function getBlockFromDataStore({
   blockIdentifer,
   db,

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -412,7 +412,7 @@ export async function getMicroblocksFromDataStore(args: {
   };
 }
 
-export async function getBlocksMetadata(args: { limit: number; offset: number; db: PgStore }) {
+export async function getBlocksWithMetadata(args: { limit: number; offset: number; db: PgStore }) {
   const blocks = await args.db.getBlocksWithMetadata({ limit: args.limit, offset: args.offset });
   const results = blocks.results.map(block =>
     parseDbBlock(

--- a/src/api/routes/block.ts
+++ b/src/api/routes/block.ts
@@ -2,7 +2,7 @@ import * as express from 'express';
 import * as Bluebird from 'bluebird';
 import { BlockListResponse } from '@stacks/stacks-blockchain-api-types';
 
-import { getBlockFromDataStore, getBlocksMetadata } from '../controllers/db-controller';
+import { getBlockFromDataStore, getBlocksWithMetadata } from '../controllers/db-controller';
 import { timeout, waiter, has0xPrefix } from '../../helpers';
 import { InvalidRequestError, InvalidRequestErrorType } from '../../errors';
 import { parseLimitQuery, parsePagingQueryInput } from '../pagination';
@@ -28,7 +28,7 @@ export function createBlockRouter(db: PgStore): express.Router {
       const limit = parseBlockQueryLimit(req.query.limit ?? 20);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
 
-      const { results, total } = await getBlocksMetadata({ offset, limit, db });
+      const { results, total } = await getBlocksWithMetadata({ offset, limit, db });
       setETagCacheHeaders(res);
       // TODO: block schema validation
       const response: BlockListResponse = { limit, offset, total, results };

--- a/src/api/routes/block.ts
+++ b/src/api/routes/block.ts
@@ -2,7 +2,7 @@ import * as express from 'express';
 import * as Bluebird from 'bluebird';
 import { BlockListResponse } from '@stacks/stacks-blockchain-api-types';
 
-import { getBlockFromDataStore } from '../controllers/db-controller';
+import { getBlockFromDataStore, getBlocksMetadata } from '../controllers/db-controller';
 import { timeout, waiter, has0xPrefix } from '../../helpers';
 import { InvalidRequestError, InvalidRequestErrorType } from '../../errors';
 import { parseLimitQuery, parsePagingQueryInput } from '../pagination';
@@ -28,19 +28,7 @@ export function createBlockRouter(db: PgStore): express.Router {
       const limit = parseBlockQueryLimit(req.query.limit ?? 20);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
 
-      // TODO: use getBlockWithMetadata or similar to avoid transaction integrity issues from lazy resolving block tx data (primarily the contract-call ABI data)
-      const { results: blocks, total } = await db.getBlocks({ offset, limit });
-      // TODO: fix duplicate pg queries
-      const results = await Bluebird.mapSeries(blocks, async block => {
-        const blockQuery = await getBlockFromDataStore({
-          blockIdentifer: { hash: block.block_hash },
-          db,
-        });
-        if (!blockQuery.found) {
-          throw new Error('unexpected block not found -- fix block enumeration query');
-        }
-        return blockQuery.result;
-      });
+      const { results, total } = await getBlocksMetadata({ offset, limit, db });
       setETagCacheHeaders(res);
       // TODO: block schema validation
       const response: BlockListResponse = { limit, offset, total, results };

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -761,6 +761,17 @@ export interface TransferQueryResult {
   amount: string;
 }
 
+export interface BlocksWithMetadata {
+  results: {
+    block: DbBlock;
+    txs: string[];
+    microblocks_accepted: string[];
+    microblocks_streamed: string[];
+    microblock_tx_count: Record<string, number>;
+  }[];
+  total: number;
+}
+
 export interface NonFungibleTokenMetadataQueryResult {
   token_uri: string;
   name: string;

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -408,11 +408,11 @@ export class PgStore {
     return await this.sql.begin(async sql => {
       // get block list
       const { results: blocks, total: block_count } = await this.getBlocks({ limit, offset });
-      const blockHashValues: Buffer[] = [];
-      const indexBlockHashValues: Buffer[] = [];
+      const blockHashValues: string[] = [];
+      const indexBlockHashValues: string[] = [];
       blocks.forEach(block => {
-        const indexBytea = hexToBuffer(block.index_block_hash);
-        const parentBytea = hexToBuffer(block.parent_index_block_hash);
+        const indexBytea = block.index_block_hash;
+        const parentBytea = block.parent_index_block_hash;
         indexBlockHashValues.push(indexBytea, parentBytea);
         blockHashValues.push(indexBytea);
       });

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -10848,6 +10848,57 @@ describe('api tests', () => {
     expect(result.body.txs[0]).toEqual(tx_id);
   });
 
+  test('/block', async () => {
+    const block_hash = '0x1234',
+      index_block_hash = '0xabcd',
+      tx_id = '0x12ff';
+
+    const block1 = new TestBlockBuilder({
+      block_hash,
+      index_block_hash,
+      // parent_index_block_hash: genesis_index_block_hash,
+      block_height: 1,
+    })
+      .addTx({ block_hash, tx_id, index_block_hash })
+      .build();
+    const microblock = new TestMicroblockStreamBuilder()
+      .addMicroblock({ parent_index_block_hash: index_block_hash })
+      .build();
+    await db.update(block1);
+    await db.updateMicroblocks(microblock);
+    const expectedResp = {
+      limit: 20,
+      offset: 0,
+      total: 1,
+      results: [
+        {
+          canonical: true,
+          height: 1,
+          hash: block_hash,
+          parent_block_hash: '0x',
+          burn_block_time: 94869286,
+          burn_block_time_iso: '1973-01-03T00:34:46.000Z',
+          burn_block_hash: '0xf44f44',
+          burn_block_height: 713000,
+          miner_txid: '0x4321',
+          parent_microblock_hash: '0x00',
+          parent_microblock_sequence: 0,
+          txs: [tx_id],
+          microblocks_accepted: [],
+          microblocks_streamed: [microblock.microblocks[0].microblock_hash],
+          execution_cost_read_count: 0,
+          execution_cost_read_length: 0,
+          execution_cost_runtime: 0,
+          execution_cost_write_count: 0,
+          execution_cost_write_length: 0,
+          microblock_tx_count: {},
+        },
+      ],
+    };
+    const result = await supertest(api.server).get(`/extended/v1/block/`);
+    expect(result.body).toEqual(expectedResp);
+  });
+
   afterEach(async () => {
     await api.terminate();
     await db?.close();


### PR DESCRIPTION
## Description

This PR optimizes `/block` endpoint. It changes the previous approach of individual queries for each block to 3 queries for `blocks`, `txs`, and `microblocks`. 
For details refer to issue #1173 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [X] Other

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @rafaelcr or @zone117x for review
