### PR TITLE
fix: allow null contract call function arguments

### DIFF
--- a/docs/entities/transactions/transaction-2-contract-call-metadata.schema.json
+++ b/docs/entities/transactions/transaction-2-contract-call-metadata.schema.json
@@ -30,23 +30,30 @@
           "type": "array",
           "description": "List of arguments used to invoke the function",
           "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["hex", "repr", "name", "type"],
-            "properties": {
-              "hex": {
-                "type": "string"
+            "oneOf": [
+              {
+                "type": "null"
               },
-              "repr": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "type": {
-                "type": "string"
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["hex", "repr", "name", "type"],
+                "properties": {
+                  "hex": {
+                    "type": "string"
+                  },
+                  "repr": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                }
               }
-            }
+            ]
           }
         }
       }

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -1033,12 +1033,12 @@ export interface ContractCallTransactionMetadata {
     /**
      * List of arguments used to invoke the function
      */
-    function_args?: {
+    function_args?: (null | {
       hex: string;
       repr: string;
       name: string;
       type: string;
-    }[];
+    })[];
   };
 }
 /**

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -776,7 +776,7 @@ function parseDelegateStxArgs(contract: ContractCallTransaction): RosettaDelegat
 
   // Locked amount
   let argName = 'amount-ustx';
-  const amount_ustx = contract.contract_call.function_args?.find(a => a.name === argName);
+  const amount_ustx = contract.contract_call.function_args?.find(a => a?.name === argName);
   if (!amount_ustx) {
     throw new Error(`Could not find field name ${argName} in contract call`);
   }
@@ -784,7 +784,7 @@ function parseDelegateStxArgs(contract: ContractCallTransaction): RosettaDelegat
 
   // Delegatee address
   argName = 'delegate-to';
-  const delegate_to = contract.contract_call.function_args?.find(a => a.name === argName);
+  const delegate_to = contract.contract_call.function_args?.find(a => a?.name === argName);
   if (!delegate_to) {
     throw new Error(`Could not find field name ${argName} in contract call`);
   }
@@ -792,7 +792,7 @@ function parseDelegateStxArgs(contract: ContractCallTransaction): RosettaDelegat
 
   // Height on which the relation between delegator-delagatee will end  - OPTIONAL
   argName = 'until-burn-ht';
-  const until_burn = contract.contract_call.function_args.find(a => a.name === argName);
+  const until_burn = contract.contract_call.function_args.find(a => a?.name === argName);
   if (!until_burn) {
     throw new Error(`Could not find field name ${argName} in contract call`);
   }
@@ -801,7 +801,7 @@ function parseDelegateStxArgs(contract: ContractCallTransaction): RosettaDelegat
 
   // BTC reward address - OPTIONAL
   argName = 'pox-addr';
-  const pox_address_raw = contract.contract_call.function_args?.find(a => a.name === argName);
+  const pox_address_raw = contract.contract_call.function_args?.find(a => a?.name === argName);
   if (pox_address_raw == undefined || pox_address_raw.repr == 'none') {
     args.pox_addr = 'none';
   } else {
@@ -834,7 +834,7 @@ function parseStackStxArgs(contract: ContractCallTransaction): RosettaStakeContr
 
   // Locking period
   let argName = 'lock-period';
-  const lock_period = contract.contract_call.function_args.find(a => a.name === argName);
+  const lock_period = contract.contract_call.function_args.find(a => a?.name === argName);
   if (!lock_period) {
     throw new Error(`Could not find field name ${argName} in contract call`);
   }
@@ -842,7 +842,7 @@ function parseStackStxArgs(contract: ContractCallTransaction): RosettaStakeContr
 
   // Locked amount
   argName = 'amount-ustx';
-  const amount_ustx = contract.contract_call.function_args?.find(a => a.name === argName);
+  const amount_ustx = contract.contract_call.function_args?.find(a => a?.name === argName);
   if (!amount_ustx) {
     throw new Error(`Could not find field name ${argName} in contract call`);
   }
@@ -850,7 +850,7 @@ function parseStackStxArgs(contract: ContractCallTransaction): RosettaStakeContr
 
   // Start burn height
   argName = 'start-burn-ht';
-  const start_burn_height = contract.contract_call.function_args?.find(a => a.name === argName);
+  const start_burn_height = contract.contract_call.function_args?.find(a => a?.name === argName);
   if (!start_burn_height) {
     throw new Error(`Could not find field name ${argName} in contract call`);
   }
@@ -877,7 +877,7 @@ function parseStackStxArgs(contract: ContractCallTransaction): RosettaStakeContr
 
   // BTC reward address
   argName = 'pox-addr';
-  const pox_address_raw = contract.contract_call.function_args?.find(a => a.name === argName);
+  const pox_address_raw = contract.contract_call.function_args?.find(a => a?.name === argName);
   if (!pox_address_raw) {
     throw new Error(`Could not find field name ${argName} in contract call`);
   }


### PR DESCRIPTION
Fixes #1188 
Also fixes a current issue with the explorer caused by `null` optional arguments