### PR TITLE
fix: contract-call txs returning null args in some situations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "socket.io": "4.4.0",
         "source-map-support": "0.5.21",
         "split2": "3.2.2",
-        "stacks-encoding-native-js": "0.1.1-beta.1",
+        "stacks-encoding-native-js": "0.1.2",
         "strict-event-emitter-types": "2.0.0",
         "ts-unused-exports": "7.0.3",
         "typescript": "4.6.2",
@@ -11200,9 +11200,9 @@
       "dev": true
     },
     "node_modules/stacks-encoding-native-js": {
-      "version": "0.1.1-beta.1",
-      "resolved": "https://registry.npmjs.org/stacks-encoding-native-js/-/stacks-encoding-native-js-0.1.1-beta.1.tgz",
-      "integrity": "sha512-hw5lkM3Nr0R7Sfvy+S9CsZwMQqa5ErcKaSyyg1nmD2awh7Dm75x0gbchNBYGLuBMXzB3vZ8aVFWLNiIUCHkJrg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/stacks-encoding-native-js/-/stacks-encoding-native-js-0.1.2.tgz",
+      "integrity": "sha512-xjeBt6IxTSS1+raBYtEBusHwcmeXM7QwMR9+T3o8FeKjHFQlwnap9qko/6DuY53QKOjhVeRTuY/RvpZ0/D0d1g==",
       "dependencies": {
         "@types/node": "^16.11.26",
         "detect-libc": "^2.0.1"
@@ -21370,9 +21370,9 @@
       "dev": true
     },
     "stacks-encoding-native-js": {
-      "version": "0.1.1-beta.1",
-      "resolved": "https://registry.npmjs.org/stacks-encoding-native-js/-/stacks-encoding-native-js-0.1.1-beta.1.tgz",
-      "integrity": "sha512-hw5lkM3Nr0R7Sfvy+S9CsZwMQqa5ErcKaSyyg1nmD2awh7Dm75x0gbchNBYGLuBMXzB3vZ8aVFWLNiIUCHkJrg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/stacks-encoding-native-js/-/stacks-encoding-native-js-0.1.2.tgz",
+      "integrity": "sha512-xjeBt6IxTSS1+raBYtEBusHwcmeXM7QwMR9+T3o8FeKjHFQlwnap9qko/6DuY53QKOjhVeRTuY/RvpZ0/D0d1g==",
       "requires": {
         "@types/node": "^16.11.26",
         "detect-libc": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "socket.io": "4.4.0",
     "source-map-support": "0.5.21",
     "split2": "3.2.2",
-    "stacks-encoding-native-js": "0.1.1-beta.1",
+    "stacks-encoding-native-js": "0.1.2",
     "strict-event-emitter-types": "2.0.0",
     "ts-unused-exports": "7.0.3",
     "typescript": "4.6.2",


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/1188

Fixes off-by-one bug while decoding through a serialized Clarity value array. If the last value was a single byte, it was skipped.

See https://github.com/hirosystems/stacks-encoding-native-js/pull/3 for more info.
