### PR TITLE
Upsert nft and ft metadata

### DIFF
--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -1363,6 +1363,9 @@ export class PgWriteStore extends PgStore {
       };
       const result = await sql`
         INSERT INTO ft_metadata ${sql(values)}
+        ON CONFLICT (contract_id)
+        DO 
+          UPDATE SET ${sql(values)}
       `;
       await sql`
         UPDATE token_metadata_queue
@@ -1392,6 +1395,9 @@ export class PgWriteStore extends PgStore {
       };
       const result = await sql`
         INSERT INTO nft_metadata ${sql(values)}
+        ON CONFLICT (contract_id)
+        DO 
+          UPDATE SET ${sql(values)}
       `;
       await sql`
         UPDATE token_metadata_queue

--- a/src/migrations/1621511823381_nft_metadata.ts
+++ b/src/migrations/1621511823381_nft_metadata.ts
@@ -32,6 +32,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     contract_id: {
       type: 'string', 
       notNull: true, 
+      unique: true,
     },
     tx_id: {
       type: 'bytea',

--- a/src/migrations/1621511832113_ft_metadata.ts
+++ b/src/migrations/1621511832113_ft_metadata.ts
@@ -32,6 +32,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     contract_id: {
       type: 'string', 
       notNull: true, 
+      unique: true,
     },
     symbol: {
       type: 'string', 

--- a/src/tests-tokens/tokens-metadata-tests.ts
+++ b/src/tests-tokens/tokens-metadata-tests.ts
@@ -323,7 +323,7 @@ describe('api tests', () => {
         decimals: 5,
         image_uri: 'ft-metadata image uri example',
         image_canonical_uri: 'ft-metadata image canonical uri example',
-        contract_id: 'ABCDEFGHIJ.ft-metadata',
+        contract_id: 'ABCDEFGHIJ.ft-metadata' + i,
         tx_id: '0x123456',
         sender_address: 'ABCDEFGHIJ',
       };


### PR DESCRIPTION
## Description

This PR updates the insert query for `nft` and `ft` metadata. New approach upserts on constraint for `contract_id`.

For details refer to issue #1187 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [X] Other

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @rafaelcr or @zone117x for review
