### PR TITLE
Included query params in redirecting to prefix 0x in tx endpoint

### DIFF
--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -18,6 +18,7 @@ import {
   isValidPrincipal,
   hexToBuffer,
   parseEventTypeStrings,
+  queryToString,
 } from '../../helpers';
 import { InvalidRequestError, InvalidRequestErrorType } from '../../errors';
 import {
@@ -240,7 +241,8 @@ export function createTxRouter(db: PgStore): express.Router {
     asyncHandler(async (req, res, next) => {
       const { tx_id } = req.params;
       if (!has0xPrefix(tx_id)) {
-        return res.redirect('/extended/v1/tx/0x' + tx_id);
+        const queryParams = queryToString(req.query);
+        return res.redirect('/extended/v1/tx/0x' + tx_id + queryParams);
       }
 
       const eventLimit = parseTxQueryEventsLimit(req.query['event_limit'] ?? 96);

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -42,7 +42,6 @@ import {
   setETagCacheHeaders,
 } from '../controllers/cache-controller';
 import { PgStore } from '../../datastore/pg-store';
-import * as url from 'url';
 
 const MAX_TXS_PER_REQUEST = 200;
 const parseTxQueryLimit = parseLimitQuery({
@@ -241,8 +240,9 @@ export function createTxRouter(db: PgStore): express.Router {
     asyncHandler(async (req, res, next) => {
       const { tx_id } = req.params;
       if (!has0xPrefix(tx_id)) {
-        const queryParams = url.parse(req.url, true).search ?? '';
-        return res.redirect('/extended/v1/tx/0x' + tx_id + queryParams);
+        const baseURL = req.protocol + '://' + req.headers.host + '/';
+        const url = new URL(req.url, baseURL);
+        return res.redirect('/extended/v1/tx/0x' + tx_id + url.search);
       }
 
       const eventLimit = parseTxQueryEventsLimit(req.query['event_limit'] ?? 96);

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -43,6 +43,7 @@ import {
   setETagCacheHeaders,
 } from '../controllers/cache-controller';
 import { PgStore } from '../../datastore/pg-store';
+import * as url from 'url';
 
 const MAX_TXS_PER_REQUEST = 200;
 const parseTxQueryLimit = parseLimitQuery({
@@ -241,7 +242,7 @@ export function createTxRouter(db: PgStore): express.Router {
     asyncHandler(async (req, res, next) => {
       const { tx_id } = req.params;
       if (!has0xPrefix(tx_id)) {
-        const queryParams = queryToString(req.query);
+        const queryParams = url.parse(req.url, true).search ?? '';
         return res.redirect('/extended/v1/tx/0x' + tx_id + queryParams);
       }
 

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -18,7 +18,6 @@ import {
   isValidPrincipal,
   hexToBuffer,
   parseEventTypeStrings,
-  queryToString,
 } from '../../helpers';
 import { InvalidRequestError, InvalidRequestErrorType } from '../../errors';
 import {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1019,12 +1019,3 @@ export function parseEventTypeStrings(values: string[]): DbEventTypeId[] {
     }
   });
 }
-
-export function queryToString(query: any) {
-  const queryParams = Object.keys(query)
-    .map(k => {
-      return k + '=' + query[k];
-    })
-    .join('&');
-  return queryParams ? '?' + queryParams : '';
-}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1019,3 +1019,12 @@ export function parseEventTypeStrings(values: string[]): DbEventTypeId[] {
     }
   });
 }
+
+export function queryToString(query: any) {
+  const queryParams = Object.keys(query)
+    .map(k => {
+      return k + '=' + query[k];
+    })
+    .join('&');
+  return queryParams ? '?' + queryParams : '';
+}


### PR DESCRIPTION
## Description

The query params were discarded when redirecting to 0x prefix in `tx/tx_id` endpoint. This PR redirects with the given query params. 

For details refer to issue #1195 

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @rafaelcr or @zone117x for review
