### PR TITLE
fix: add value indices on nft_custody views

### DIFF
--- a/src/migrations/1655235863682_nft_custody_value_index.ts
+++ b/src/migrations/1655235863682_nft_custody_value_index.ts
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('nft_custody', 'value', { method: 'hash' });
+  pgm.createIndex('nft_custody_unanchored', 'value', { method: 'hash' });
+}


### PR DESCRIPTION
Greatly optimizes the performance on a BNS name resolution query:
```sql
EXPLAIN ANALYZE (
  SELECT
    value
  FROM
    nft_custody
  WHERE
    recipient <> $1
    AND value = ANY ($2));
```
Before 💀 
```
Gather  (cost=1000.00..9384.09 rows=8 width=20) (actual time=14.153..15.106 rows=0 loops=1)
  Workers Planned: 2
  Workers Launched: 2
  ->  Parallel Seq Scan on nft_custody  (cost=0.00..8383.29 rows=3 width=20) (actual time=11.470..11.470 rows=0 loops=3)
        Filter: ((value = ANY ('{""\\x7830663066""}'::bytea[])) AND (recipient <> 'SP3D6PV2ACBPEKYJTCMH7HEN02KP87QSP8KTEH335.megapont-ape-club-nft'::text))"
        Rows Removed by Filter: 89733
Planning Time: 0.116 ms
Execution Time: 15.117 ms
```
After 😎 
```
Bitmap Heap Scan on nft_custody  (cost=4.07..39.21 rows=8 width=20) (actual time=0.006..0.006 rows=0 loops=1)
  Recheck Cond: (value = ANY ('{""\\x7830663066""}'::bytea[]))"
  Filter: (recipient <> 'SP3D6PV2ACBPEKYJTCMH7HEN02KP87QSP8KTEH335.megapont-ape-club-nft'::text)"
  ->  Bitmap Index Scan on test_index2  (cost=0.00..4.07 rows=9 width=0) (actual time=0.005..0.005 rows=0 loops=1)
        Index Cond: (value = ANY ('{""\\x7830663066""}'::bytea[]))"
Planning Time: 0.157 ms
Execution Time: 0.017 ms
```
Fixes #1204 