### PR TITLE
feat: add average fee to block response

### DIFF
--- a/docs/entities/blocks/block.schema.json
+++ b/docs/entities/blocks/block.schema.json
@@ -112,6 +112,10 @@
     "execution_cost_write_length": {
       "type": "integer",
       "description": "Execution cost write length."
+    },
+    "average_fee": {
+      "type": "string",
+      "description": "Average fee for transactions included in the block."
     }
   }
 }

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -1176,6 +1176,10 @@ export interface Block {
    * Execution cost write length.
    */
   execution_cost_write_length: number;
+  /**
+   * Average fee for transactions included in the block.
+   */
+  average_fee?: string;
 }
 /**
  * Error

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -444,11 +444,14 @@ export async function getBlockFromDataStore({
     return { found: false };
   }
   const result = blockQuery.result;
+  const averageFee =
+    result.txs.reduce((acc, tx) => acc + tx.fee_rate, BigInt(0)) / BigInt(result.txs.length);
   const apiBlock = parseDbBlock(
     result.block,
     result.txs.map(tx => tx.tx_id),
     result.microblocks.accepted.map(mb => mb.microblock_hash),
-    result.microblocks.streamed.map(mb => mb.microblock_hash)
+    result.microblocks.streamed.map(mb => mb.microblock_hash),
+    averageFee
   );
   return { found: true, result: apiBlock };
 }
@@ -457,7 +460,8 @@ function parseDbBlock(
   dbBlock: DbBlock,
   txIds: string[],
   microblocksAccepted: string[],
-  microblocksStreamed: string[]
+  microblocksStreamed: string[],
+  averageFee: bigint
 ): Block {
   const apiBlock: Block = {
     canonical: dbBlock.canonical,
@@ -481,6 +485,7 @@ function parseDbBlock(
     execution_cost_runtime: dbBlock.execution_cost_runtime,
     execution_cost_write_count: dbBlock.execution_cost_write_count,
     execution_cost_write_length: dbBlock.execution_cost_write_length,
+    average_fee: averageFee.toString(10),
   };
   return apiBlock;
 }
@@ -1081,7 +1086,9 @@ export async function searchHashWithMetadata(
       blockQuery.result.block,
       blockQuery.result.txs.map(tx => tx.tx_id),
       blockQuery.result.microblocks.accepted.map(mb => mb.microblock_hash),
-      blockQuery.result.microblocks.streamed.map(mb => mb.microblock_hash)
+      blockQuery.result.microblocks.streamed.map(mb => mb.microblock_hash),
+      blockQuery.result.txs.reduce((acc, tx) => acc + tx.fee_rate, BigInt(0)) /
+        BigInt(blockQuery.result.txs.length)
     );
     return {
       found: true,

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -2338,6 +2338,7 @@ describe('api tests', () => {
       parent_microblock_hash: '',
       parent_microblock_sequence: 0,
       txs: ['0x4567000000000000000000000000000000000000000000000000000000000000'],
+      average_fee: '1234',
     };
 
     const searchResult1 = await supertest(api.server).get(
@@ -7250,7 +7251,11 @@ describe('api tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
     };
+
+    const tx2 = Object.assign({}, tx, { tx_id: '0x1235', fee_rate: 2222n });
+
     await db.updateTx(client, tx);
+    await db.updateTx(client, tx2);
 
     const blockQuery = await getBlockFromDataStore({
       blockIdentifer: { hash: block.block_hash },
@@ -7272,7 +7277,7 @@ describe('api tests', () => {
       parent_block_hash: '0xff0011',
       parent_microblock_hash: '',
       parent_microblock_sequence: 0,
-      txs: ['0x1234'],
+      txs: ['0x1235', '0x1234'],
       microblocks_accepted: [],
       microblocks_streamed: [],
       execution_cost_read_count: 0,
@@ -7280,6 +7285,7 @@ describe('api tests', () => {
       execution_cost_runtime: 0,
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
+      average_fee: '1728',
     };
 
     expect(blockQuery.result).toEqual(expectedResp);
@@ -7401,6 +7407,7 @@ describe('api tests', () => {
       parent_microblock_hash: '',
       parent_microblock_sequence: 0,
       txs: ['0x0001'],
+      average_fee: '50',
     };
     const fetch1 = await supertest(api.server).get(
       `/extended/v1/block/by_height/${block1.block.block_height}`
@@ -7447,6 +7454,7 @@ describe('api tests', () => {
       parent_microblock_sequence: microblock1.microblocks[0].microblock_sequence,
       // Ensure micro-orphaned tx `0x1002` is not included
       txs: ['0x0002', '0x1001'],
+      average_fee: '50',
     };
     expect(fetch2.status).toBe(200);
     expect(fetch2.type).toBe('application/json');

--- a/src/tests/cache-control-tests.ts
+++ b/src/tests/cache-control-tests.ts
@@ -167,6 +167,7 @@ describe('cache-control tests', () => {
       execution_cost_runtime: 0,
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
+      average_fee: '1234',
     };
 
     expect(blockQuery.result).toEqual(expectedResp1);
@@ -310,6 +311,7 @@ describe('cache-control tests', () => {
       execution_cost_runtime: 0,
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
+      average_fee: '1234',
     };
 
     const fetchBlockByHash2 = await supertest(api.server).get(


### PR DESCRIPTION
Adding a new attribute `average_fee` to block response, closes #1209