### PR TITLE
fix: arm64-alpine image, bump stacks-encoding-native-js #1217

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "socket.io": "4.4.0",
         "source-map-support": "0.5.21",
         "split2": "3.2.2",
-        "stacks-encoding-native-js": "0.1.2",
+        "stacks-encoding-native-js": "0.1.3",
         "strict-event-emitter-types": "2.0.0",
         "ts-unused-exports": "7.0.3",
         "typescript": "4.6.2",
@@ -11200,9 +11200,9 @@
       "dev": true
     },
     "node_modules/stacks-encoding-native-js": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/stacks-encoding-native-js/-/stacks-encoding-native-js-0.1.2.tgz",
-      "integrity": "sha512-xjeBt6IxTSS1+raBYtEBusHwcmeXM7QwMR9+T3o8FeKjHFQlwnap9qko/6DuY53QKOjhVeRTuY/RvpZ0/D0d1g==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/stacks-encoding-native-js/-/stacks-encoding-native-js-0.1.3.tgz",
+      "integrity": "sha512-baxOMfw3LJLN3EeqJ/Mqy5v+1W/5lmzyHt6FzJLmWhDInBTXfYeEqTsnWynDTEj5zS0vs/kteArfDBW1/6jUWw==",
       "dependencies": {
         "@types/node": "^16.11.26",
         "detect-libc": "^2.0.1"
@@ -21370,9 +21370,9 @@
       "dev": true
     },
     "stacks-encoding-native-js": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/stacks-encoding-native-js/-/stacks-encoding-native-js-0.1.2.tgz",
-      "integrity": "sha512-xjeBt6IxTSS1+raBYtEBusHwcmeXM7QwMR9+T3o8FeKjHFQlwnap9qko/6DuY53QKOjhVeRTuY/RvpZ0/D0d1g==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/stacks-encoding-native-js/-/stacks-encoding-native-js-0.1.3.tgz",
+      "integrity": "sha512-baxOMfw3LJLN3EeqJ/Mqy5v+1W/5lmzyHt6FzJLmWhDInBTXfYeEqTsnWynDTEj5zS0vs/kteArfDBW1/6jUWw==",
       "requires": {
         "@types/node": "^16.11.26",
         "detect-libc": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "socket.io": "4.4.0",
     "source-map-support": "0.5.21",
     "split2": "3.2.2",
-    "stacks-encoding-native-js": "0.1.2",
+    "stacks-encoding-native-js": "0.1.3",
     "strict-event-emitter-types": "2.0.0",
     "ts-unused-exports": "7.0.3",
     "typescript": "4.6.2",


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/1217

Bumps `stacks-encoding-native-js` to a version that includes a binary for the linux-musl-arm64 target. 


See https://github.com/hirosystems/stacks-encoding-native-js/issues/4 for more info.