### PR TITLE
Update docs to include a simple sql query

### DIFF
--- a/running_an_api.md
+++ b/running_an_api.md
@@ -295,7 +295,8 @@ To verfiy the database is ready:
     - *this will require a locally installed postgresql client*
     - use the password from the [Environment Variable](#postgres) `POSTGRES_PASSWORD`
 2. List current databases: `\l`
-3. Disconnect from the DB : `\q`
+3. Verify data is being written to the database: `select * from blocks limit 1;`
+4. Disconnect from the DB : `\q`
 
 ### stacks-blockchain testing
 

--- a/running_api_from_source.md
+++ b/running_api_from_source.md
@@ -226,10 +226,11 @@ $ sudo kill $(ps -ef | grep "/stacks-node/binaries/stacks-node" | grep -v grep |
 
 To verfiy the database is ready:
 
-1. Connect to the DB instance:  `psql -h localhost -U stacks stacks_db`
-    - use the password from the [Postgres Permissions Step](#postgres-permissions)
+1. Connect to the DB instance: `psql -h localhost -U stacks stacks_db`
+   - use the password from the [Postgres Permissions Step](#postgres-permissions)
 2. List current databases: `\l`
-3. Disconnect from the DB : `\q`
+3. Verify data is being written to the database: `select * from blocks limit 1;`
+4. Disconnect from the DB : `\q`
 
 ### stacks-blockchain testing
 


### PR DESCRIPTION
Adds an additional line to the markdown docs for deploying the API:
```
3. Verify data is being written to the database: `select * from blocks limit 1;`
```

During the step to verify the DB is setup, running this query will confirm data is being written to the DB.

in the case where the blockchain was syncing from genesis *without* the event observer, then restarted with the event observer, the previous commands will make it appear as though the DB is fine, but not adding records. this single query will confirm if the API is running normally. 
