### PR TITLE
fix: event-replay log level configurable via env var

### DIFF
--- a/.env
+++ b/.env
@@ -95,6 +95,9 @@ MAINNET_SEND_MANY_CONTRACT_ID=SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-man
 # Enable debug logging
 # STACKS_API_LOG_LEVEL=debug
 
+# Enable debug logging for event-replay, defaults to `warn`
+# STACKS_API_EVENT_REPLAY_LOG_LEVEL=debug
+
 # Directory containing Stacks 1.0 BNS data extracted from https://storage.googleapis.com/blockstack-v1-migration-data/export-data.tar.gz
 # BNS_IMPORT_DIR=/extracted/export-data-dir/
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -176,6 +176,10 @@ const defaultLogLevel: LogLevel = (() => {
   return 'http';
 })();
 
+export function checkLogLevelValid(level: string): level is LogLevel {
+  return LOG_LEVELS.includes(level as LogLevel);
+}
+
 export const logger = winston.createLogger({
   level: defaultLogLevel,
   exitOnError: false,


### PR DESCRIPTION
Added a new env var `STACKS_API_EVENT_REPLAY_LOG_LEVEL` which can be used to specify the log level used during event-replay. 

If unspecified, it defaults to the original log level of `warn`. 
