### PR TITLE
fix: use primary db for socket queries

### DIFF
--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -61,6 +61,7 @@ export interface ApiServer {
 
 export async function startApiServer(opts: {
   datastore: DataStore;
+  primaryDatastore?: DataStore;
   chainId: ChainID;
   /** If not specified, this is read from the STACKS_BLOCKCHAIN_API_HOST env var. */
   serverHost?: string;
@@ -68,7 +69,7 @@ export async function startApiServer(opts: {
   serverPort?: number;
   httpLogLevel?: LogLevel;
 }): Promise<ApiServer> {
-  const { datastore, chainId, serverHost, serverPort, httpLogLevel } = opts;
+  const { datastore, primaryDatastore, chainId, serverHost, serverPort, httpLogLevel } = opts;
 
   const app = express();
   const apiHost = serverHost ?? process.env['STACKS_BLOCKCHAIN_API_HOST'];
@@ -343,11 +344,9 @@ export async function startApiServer(opts: {
     });
   });
 
-  // Setup socket.io server
-  const io = createSocketIORouter(datastore, server);
-
-  // Setup websockets RPC endpoint
-  const wss = createWsRpcRouter(datastore, server);
+  // Setup WebSocket and socket.io servers
+  const io = createSocketIORouter(primaryDatastore ?? datastore, server);
+  const wss = createWsRpcRouter(primaryDatastore ?? datastore, server);
 
   await new Promise<void>((resolve, reject) => {
     try {

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -2785,11 +2785,13 @@ export class PgDataStore
     skipMigrations = false,
     withNotifier = true,
     eventReplay = false,
+    forcePrimary = false,
     usageName,
   }: {
     skipMigrations?: boolean;
     withNotifier?: boolean;
     eventReplay?: boolean;
+    forcePrimary?: boolean;
     usageName: string;
   }): Promise<PgDataStore> {
     const initTimer = stopwatch();
@@ -2797,7 +2799,10 @@ export class PgDataStore
     let connectionOkay = false;
     let lastElapsedLog = 0;
     do {
-      const clientConfig = getPgClientConfig({ usageName: `${usageName};init-connection-poll` });
+      const clientConfig = getPgClientConfig({
+        usageName: `${usageName};init-connection-poll`,
+        primary: forcePrimary,
+      });
       const client = new Client(clientConfig);
       try {
         await client.connect();


### PR DESCRIPTION
temporary fix to try to avoid deadlocks #1204 