### PR TITLE
Implement support for `coinbase-pay-to-alt-recipient` txs

### DIFF
--- a/docs/entities/transactions/transaction-4-coinbase-metadata.schema.json
+++ b/docs/entities/transactions/transaction-4-coinbase-metadata.schema.json
@@ -17,6 +17,11 @@
         "data": {
           "type": "string",
           "description": "Hex encoded 32-byte scratch space for block leader's use"
+        },
+        "alt_recipient": {
+          "type": "string",
+          "nullable": true,
+          "description": "Either a standard principal or contract principal, only specified for `coinbase-to-alt-recipient` transaction types, otherwise null."
         }
       }
     }

--- a/docs/entities/transactions/transaction-4-coinbase-metadata.schema.json
+++ b/docs/entities/transactions/transaction-4-coinbase-metadata.schema.json
@@ -21,7 +21,7 @@
         "alt_recipient": {
           "type": "string",
           "nullable": true,
-          "description": "Either a standard principal or contract principal, only specified for `coinbase-to-alt-recipient` transaction types, otherwise null."
+          "description": "A principal that will receive the miner rewards for this coinbase transaction. Can be either a standard principal or contract principal. Only specified for `coinbase-to-alt-recipient` transaction types, otherwise null."
         }
       }
     }

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -1091,6 +1091,10 @@ export interface CoinbaseTransactionMetadata {
      * Hex encoded 32-byte scratch space for block leader's use
      */
     data: string;
+    /**
+     * Either a standard principal or contract principal, only specified for `coinbase-to-alt-recipient` transaction types, otherwise null.
+     */
+    alt_recipient?: string;
   };
 }
 /**

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -1092,7 +1092,7 @@ export interface CoinbaseTransactionMetadata {
      */
     data: string;
     /**
-     * Either a standard principal or contract principal, only specified for `coinbase-to-alt-recipient` transaction types, otherwise null.
+     * A principal that will receive the miner rewards for this coinbase transaction. Can be either a standard principal or contract principal. Only specified for `coinbase-to-alt-recipient` transaction types, otherwise null.
      */
     alt_recipient?: string;
   };

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -746,6 +746,7 @@ function parseDbTxTypeMetadata(dbTx: DbTx | DbMempoolTx): TransactionMetadata {
         tx_type: 'coinbase',
         coinbase_payload: {
           data: unwrapOptional(dbTx.coinbase_payload, () => 'Unexpected nullish coinbase_payload'),
+          alt_recipient: null as any,
         },
       };
       return metadata;

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -91,6 +91,7 @@ export function getTxTypeString(typeId: DbTxTypeId): Transaction['tx_type'] {
     case DbTxTypeId.PoisonMicroblock:
       return 'poison_microblock';
     case DbTxTypeId.Coinbase:
+    case DbTxTypeId.CoinbaseToAltRecipient:
       return 'coinbase';
     default:
       throw new Error(`Unexpected DbTxTypeId: ${typeId}`);
@@ -121,7 +122,7 @@ export function getTxTypeId(typeString: Transaction['tx_type']): DbTxTypeId[] {
     case 'poison_microblock':
       return [DbTxTypeId.PoisonMicroblock];
     case 'coinbase':
-      return [DbTxTypeId.Coinbase];
+      return [DbTxTypeId.Coinbase, DbTxTypeId.CoinbaseToAltRecipient];
     default:
       throw new Error(`Unexpected tx type string: ${typeString}`);
   }
@@ -534,7 +535,10 @@ async function getRosettaBlockTxFromDataStore(opts: {
   let minerRewards: DbMinerReward[] = [],
     unlockingEvents: StxUnlockEvent[] = [];
 
-  if (opts.tx.type_id === DbTxTypeId.Coinbase) {
+  if (
+    opts.tx.type_id === DbTxTypeId.Coinbase ||
+    opts.tx.type_id === DbTxTypeId.CoinbaseToAltRecipient
+  ) {
     minerRewards = await opts.db.getMinersRewardsAtHeight({
       blockHeight: opts.block.block_height,
     });

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -746,6 +746,19 @@ function parseDbTxTypeMetadata(dbTx: DbTx | DbMempoolTx): TransactionMetadata {
       };
       return metadata;
     }
+    case DbTxTypeId.CoinbaseToAltRecipient: {
+      const metadata: CoinbaseTransactionMetadata = {
+        tx_type: 'coinbase',
+        coinbase_payload: {
+          data: unwrapOptional(dbTx.coinbase_payload, () => 'Unexpected nullish coinbase_payload'),
+          alt_recipient: unwrapOptional(
+            dbTx.coinbase_alt_recipient,
+            () => 'Unexpected nullish coinbase_alt_recipient'
+          ),
+        },
+      };
+      return metadata;
+    }
     default: {
       throw new Error(`Unexpected DbTxTypeId: ${dbTx.type_id}`);
     }

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -180,6 +180,9 @@ export interface DbTx extends BaseTx {
   /** Only valid for `coinbase` tx types. Hex encoded 32-bytes. */
   coinbase_payload?: string;
 
+  /** Only valid for `coinbase-to-alt-recipient` tx types. Either a standard principal or contract principal. */
+  coinbase_alt_recipient?: string;
+
   event_count: number;
 
   execution_cost_read_count: number;
@@ -249,6 +252,9 @@ export interface DbMempoolTx extends BaseTx {
 
   /** Only valid for `coinbase` tx types. Hex encoded 32-bytes. */
   coinbase_payload?: string;
+
+  /** Only valid for `coinbase-to-alt-recipient` tx types. Either a standard principal or contract principal. */
+  coinbase_alt_recipient?: string;
 }
 
 export interface DbSmartContract {
@@ -694,6 +700,9 @@ export interface MempoolTxQueryResult {
   // `coinbase` tx types
   coinbase_payload?: string;
 
+  /** Only valid for `coinbase-to-alt-recipient` tx types. Either a standard principal or contract principal. */
+  coinbase_alt_recipient?: string;
+
   // sending abi in case tx is contract call
   abi: unknown | null;
 }
@@ -751,6 +760,9 @@ export interface TxQueryResult {
 
   // `coinbase` tx types
   coinbase_payload?: string;
+
+  // `coinbase-to-alt-recipient` tx types
+  coinbase_alt_recipient?: string;
 
   // events count
   event_count: number;
@@ -903,6 +915,7 @@ export interface TxInsertValues {
   poison_microblock_header_1: PgBytea | null;
   poison_microblock_header_2: PgBytea | null;
   coinbase_payload: PgBytea | null;
+  coinbase_alt_recipient: string | null;
   raw_result: PgBytea;
   event_count: number;
   execution_cost_read_count: number;
@@ -941,6 +954,7 @@ export interface MempoolTxInsertValues {
   poison_microblock_header_1: PgBytea | null;
   poison_microblock_header_2: PgBytea | null;
   coinbase_payload: PgBytea | null;
+  coinbase_alt_recipient: string | null;
 }
 
 export interface BlockInsertValues {

--- a/src/datastore/helpers.ts
+++ b/src/datastore/helpers.ts
@@ -83,6 +83,7 @@ export const TX_COLUMNS = [
   'poison_microblock_header_1',
   'poison_microblock_header_2',
   'coinbase_payload',
+  'coinbase_alt_recipient',
   'raw_result',
   'event_count',
   'execution_cost_read_count',
@@ -121,6 +122,7 @@ export const MEMPOOL_TX_COLUMNS = [
   'poison_microblock_header_1',
   'poison_microblock_header_2',
   'coinbase_payload',
+  'coinbase_alt_recipient',
 ];
 
 export const BLOCK_COLUMNS = [
@@ -313,6 +315,9 @@ function parseTxTypeSpecificQueryResult(
     target.poison_microblock_header_2 = result.poison_microblock_header_2;
   } else if (target.type_id === DbTxTypeId.Coinbase) {
     target.coinbase_payload = result.coinbase_payload;
+  } else if (target.type_id === DbTxTypeId.CoinbaseToAltRecipient) {
+    target.coinbase_payload = result.coinbase_payload;
+    target.coinbase_alt_recipient = result.coinbase_alt_recipient;
   } else {
     throw new Error(`Received unexpected tx type_id from db query: ${target.type_id}`);
   }
@@ -729,6 +734,15 @@ function extractTransactionPayload(txData: DecodedTxResult, dbTx: DbTx | DbMempo
     }
     case TxPayloadTypeID.Coinbase: {
       dbTx.coinbase_payload = txData.payload.payload_buffer;
+      break;
+    }
+    case TxPayloadTypeID.CoinbaseToAltRecipient: {
+      dbTx.coinbase_payload = txData.payload.payload_buffer;
+      if (txData.payload.recipient.type_id === PrincipalTypeID.Standard) {
+        dbTx.coinbase_alt_recipient = txData.payload.recipient.address;
+      } else {
+        dbTx.coinbase_alt_recipient = `${txData.payload.recipient.address}.${txData.payload.recipient.contract_name}`;
+      }
       break;
     }
     default:

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -3686,7 +3686,7 @@ export class PgStore {
       SELECT tx_id
       FROM txs
       WHERE microblock_canonical = true AND canonical = true
-      AND block_height = ${block.block_height} AND type_id = ${DbTxTypeId.Coinbase}
+      AND block_height = ${block.block_height} AND (type_id = ${DbTxTypeId.Coinbase} OR type_id = ${DbTxTypeId.CoinbaseToAltRecipient})
       LIMIT 1
     `;
 

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -1164,6 +1164,7 @@ export class PgWriteStore extends PgStore {
       poison_microblock_header_1: tx.poison_microblock_header_1 ?? null,
       poison_microblock_header_2: tx.poison_microblock_header_2 ?? null,
       coinbase_payload: tx.coinbase_payload ?? null,
+      coinbase_alt_recipient: tx.coinbase_alt_recipient ?? null,
       raw_result: tx.raw_result,
       event_count: tx.event_count,
       execution_cost_read_count: tx.execution_cost_read_count,
@@ -1213,6 +1214,7 @@ export class PgWriteStore extends PgStore {
           poison_microblock_header_1: tx.poison_microblock_header_1 ?? null,
           poison_microblock_header_2: tx.poison_microblock_header_2 ?? null,
           coinbase_payload: tx.coinbase_payload ?? null,
+          coinbase_alt_recipient: tx.coinbase_alt_recipient ?? null,
         };
         const result = await sql`
           INSERT INTO mempool_txs ${sql(values)}

--- a/src/event-stream/reader.ts
+++ b/src/event-stream/reader.ts
@@ -298,6 +298,18 @@ export function parseMessageTransaction(
       case TxPayloadTypeID.Coinbase: {
         break;
       }
+      case TxPayloadTypeID.CoinbaseToAltRecipient: {
+        if (payload.recipient.type_id === PrincipalTypeID.Standard) {
+          logger.verbose(
+            `Coinbase to alt recipient, standard principal: ${payload.recipient.address}`
+          );
+        } else {
+          logger.verbose(
+            `Coinbase to alt recipient, contract principal: ${payload.recipient.address}.${payload.recipient.contract_name}`
+          );
+        }
+        break;
+      }
       case TxPayloadTypeID.SmartContract: {
         logger.verbose(
           `Smart contract deployed: ${parsedTx.sender_address}.${payload.contract_name}`

--- a/src/migrations/1584619633448_txs.ts
+++ b/src/migrations/1584619633448_txs.ts
@@ -160,6 +160,9 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 
     // `coinbase` tx types
     coinbase_payload: 'bytea',
+
+    // `coinbase-pay-to-alt` tx types
+    coinbase_alt_recipient: 'string',
   });
 
   pgm.createIndex('txs', 'tx_id', { method: 'hash' });
@@ -170,6 +173,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createIndex('txs', 'smart_contract_contract_id', { method: 'hash' });
   pgm.createIndex('txs', 'sponsor_address', { method: 'hash' });
   pgm.createIndex('txs', 'token_transfer_recipient_address', { method: 'hash' });
+  pgm.createIndex('txs', 'coinbase_alt_recipient');
   pgm.createIndex('txs', 'type_id');
   pgm.createIndex('txs', [{ name: 'tx_index', sort: 'DESC' }]);
   pgm.createIndex('txs', [
@@ -202,5 +206,9 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 
   pgm.addConstraint('txs', 'valid_coinbase', `CHECK (type_id != 4 OR (
     NOT (coinbase_payload) IS NULL
+  ))`);
+
+  pgm.addConstraint('txs', 'valid_coinbase-pay-to-alt', `CHECK (type_id != 5 OR (
+    NOT (coinbase_payload, coinbase_alt_recipient) IS NULL
   ))`);
 }

--- a/src/migrations/1591291822107_mempool_txs.ts
+++ b/src/migrations/1591291822107_mempool_txs.ts
@@ -93,6 +93,9 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 
     // `coinbase` tx types
     coinbase_payload: 'bytea',
+
+    // `coinbase-pay-to-alt` tx types
+    coinbase_alt_recipient: 'string',
   });
 
   pgm.createIndex('mempool_txs', 'tx_id', { method: 'hash' });
@@ -128,5 +131,9 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 
   pgm.addConstraint('mempool_txs', 'valid_coinbase', `CHECK (type_id != 4 OR (
     NOT (coinbase_payload) IS NULL
+  ))`);
+
+  pgm.addConstraint('mempool_txs', 'valid_coinbase-pay-to-alt', `CHECK (type_id != 5 OR (
+    NOT (coinbase_payload, coinbase_alt_recipient) IS NULL
   ))`);
 }

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -987,6 +987,9 @@ export function rawTxToBaseTx(raw_tx: string): BaseTx {
     case TxPayloadTypeID.Coinbase:
       transactionType = DbTxTypeId.Coinbase;
       break;
+    case TxPayloadTypeID.CoinbaseToAltRecipient:
+      transactionType = DbTxTypeId.CoinbaseToAltRecipient;
+      break;
     case TxPayloadTypeID.PoisonMicroblock:
       transactionType = DbTxTypeId.PoisonMicroblock;
       break;

--- a/src/tests/address-tests.ts
+++ b/src/tests/address-tests.ts
@@ -1581,6 +1581,7 @@ describe('address tests', () => {
           tx_index: 4,
           coinbase_payload: {
             data: '0x636f696e62617365206869',
+            alt_recipient: null,
           },
           event_count: 5,
           events: [],

--- a/src/tests/mempool-tests.ts
+++ b/src/tests/mempool-tests.ts
@@ -175,7 +175,7 @@ describe('mempool tests', () => {
       post_conditions: [],
       receipt_time: 1594307695,
       receipt_time_iso: '2020-07-09T15:14:55.000Z',
-      coinbase_payload: { data: '0x636f696e62617365206869' },
+      coinbase_payload: { data: '0x636f696e62617365206869', alt_recipient: null },
     };
 
     expect(JSON.parse(searchResult1.text)).toEqual(expectedResp1);
@@ -271,7 +271,7 @@ describe('mempool tests', () => {
       post_conditions: [],
       receipt_time: 1594307695,
       receipt_time_iso: '2020-07-09T15:14:55.000Z',
-      coinbase_payload: { data: '0x636f696e62617365206869' },
+      coinbase_payload: { data: '0x636f696e62617365206869', alt_recipient: null },
     };
 
     expect(JSON.parse(searchResult1.text)).toEqual(expectedResp1);
@@ -343,7 +343,7 @@ describe('mempool tests', () => {
       post_conditions: [],
       receipt_time: 1594307695,
       receipt_time_iso: '2020-07-09T15:14:55.000Z',
-      coinbase_payload: { data: '0x636f696e62617365206869' },
+      coinbase_payload: { data: '0x636f696e62617365206869', alt_recipient: null },
     };
     expect(JSON.parse(searchResult1.text)).toEqual(expectedResp1);
 
@@ -364,7 +364,7 @@ describe('mempool tests', () => {
       post_conditions: [],
       receipt_time: 1594307702,
       receipt_time_iso: '2020-07-09T15:15:02.000Z',
-      coinbase_payload: { data: '0x636f696e62617365206869' },
+      coinbase_payload: { data: '0x636f696e62617365206869', alt_recipient: null },
     };
 
     expect(JSON.parse(searchResult2.text)).toEqual(expectedResp2);
@@ -390,7 +390,7 @@ describe('mempool tests', () => {
       post_conditions: [],
       receipt_time: 1594307703,
       receipt_time_iso: '2020-07-09T15:15:03.000Z',
-      coinbase_payload: { data: '0x636f696e62617365206869' },
+      coinbase_payload: { data: '0x636f696e62617365206869', alt_recipient: null },
     };
     expect(JSON.parse(searchResult3.text)).toEqual(expectedResp3);
 
@@ -415,7 +415,7 @@ describe('mempool tests', () => {
       post_conditions: [],
       receipt_time: 1594307704,
       receipt_time_iso: '2020-07-09T15:15:04.000Z',
-      coinbase_payload: { data: '0x636f696e62617365206869' },
+      coinbase_payload: { data: '0x636f696e62617365206869', alt_recipient: null },
     };
     expect(JSON.parse(searchResult4.text)).toEqual(expectedResp4);
 
@@ -440,7 +440,7 @@ describe('mempool tests', () => {
       post_conditions: [],
       receipt_time: 1594307705,
       receipt_time_iso: '2020-07-09T15:15:05.000Z',
-      coinbase_payload: { data: '0x636f696e62617365206869' },
+      coinbase_payload: { data: '0x636f696e62617365206869', alt_recipient: null },
     };
     expect(JSON.parse(searchResult5.text)).toEqual(expectedResp5);
 
@@ -610,7 +610,7 @@ describe('mempool tests', () => {
           sponsored: false,
           post_condition_mode: 'allow',
           post_conditions: [],
-          coinbase_payload: { data: '0x636f696e62617365206869' },
+          coinbase_payload: { data: '0x636f696e62617365206869', alt_recipient: null },
         },
         {
           tx_id: '0x8912000000000000000000000000000000000000000000000000000000000006',
@@ -625,7 +625,7 @@ describe('mempool tests', () => {
           sponsored: false,
           post_condition_mode: 'allow',
           post_conditions: [],
-          coinbase_payload: { data: '0x636f696e62617365206869' },
+          coinbase_payload: { data: '0x636f696e62617365206869', alt_recipient: null },
         },
         {
           tx_id: '0x8912000000000000000000000000000000000000000000000000000000000005',
@@ -640,7 +640,7 @@ describe('mempool tests', () => {
           sponsored: false,
           post_condition_mode: 'allow',
           post_conditions: [],
-          coinbase_payload: { data: '0x636f696e62617365206869' },
+          coinbase_payload: { data: '0x636f696e62617365206869', alt_recipient: null },
         },
       ],
     };
@@ -1245,6 +1245,7 @@ describe('mempool tests', () => {
           post_conditions: [],
           coinbase_payload: {
             data: '0x6869',
+            alt_recipient: null,
           },
         },
       ],

--- a/src/tests/search-tests.ts
+++ b/src/tests/search-tests.ts
@@ -446,6 +446,7 @@ describe('search tests', () => {
           anchor_mode: 'any',
           coinbase_payload: {
             data: '0x636f696e62617365206869',
+            alt_recipient: null,
           },
           fee_rate: '1234',
           nonce: 0,
@@ -548,6 +549,7 @@ describe('search tests', () => {
           tx_type: 'coinbase',
           coinbase_payload: {
             data: '0x636f696e62617365206869',
+            alt_recipient: null,
           },
         },
       },

--- a/src/tests/tx-tests.ts
+++ b/src/tests/tx-tests.ts
@@ -2225,6 +2225,7 @@ describe('tx tests', () => {
       },
       coinbase_payload: {
         data: '0x636f696e62617365206869',
+        alt_recipient: null,
       },
       event_count: 1,
       events: [

--- a/src/tests/tx-tests.ts
+++ b/src/tests/tx-tests.ts
@@ -452,6 +452,276 @@ describe('tx tests', () => {
     expect(txQuery.result).toEqual(expectedResp);
   });
 
+  test('tx - coinbase pay to alt recipient - standard principal', async () => {
+    const dbBlock: DbBlock = {
+      block_hash: '0xff',
+      index_block_hash: '0x1234',
+      parent_index_block_hash: '0x5678',
+      parent_block_hash: '0x5678',
+      parent_microblock_hash: '',
+      parent_microblock_sequence: 0,
+      block_height: 1,
+      burn_block_time: 1594647995,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
+      canonical: true,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
+    };
+
+    // stacks.js does not support `coinbase-pay-to-alt-recipient` tx support as of writing, so use a known good serialized tx
+    const versionedSmartContractTx = Buffer.from(
+      '80800000000400fd3cd910d78fe7c4cd697d5228e51a912ff2ba740000000000000004000000000000000001008d36064b250dba5d3221ac235a9320adb072cfc23cd63511e6d814f97f0302e66c2ece80d7512df1b3e90ca6dce18179cb67b447973c739825ce6c6756bc247d010200000000050000000000000000000000000000000000000000000000000000000000000000051aba27f99e007c7f605a8305e318c1abde3cd220ac',
+      'hex'
+    );
+
+    const tx = decodeTransaction(versionedSmartContractTx);
+    const dbTx = createDbTxFromCoreMsg({
+      core_tx: {
+        raw_tx: bufferToHexPrefixString(versionedSmartContractTx),
+        status: 'success',
+        raw_result: '0x0100000000000000000000000000000001', // u1
+        txid: tx.tx_id,
+        tx_index: 2,
+        contract_abi: null,
+        microblock_hash: null,
+        microblock_parent_hash: null,
+        microblock_sequence: null,
+        execution_cost: {
+          read_count: 0,
+          read_length: 0,
+          runtime: 0,
+          write_count: 0,
+          write_length: 0,
+        },
+      },
+      nonce: 0,
+      raw_tx: bufferToHexPrefixString(versionedSmartContractTx),
+      parsed_tx: tx,
+      sender_address: tx.auth.origin_condition.signer.address,
+      sponsor_address: undefined,
+      index_block_hash: dbBlock.index_block_hash,
+      parent_index_block_hash: dbBlock.parent_index_block_hash,
+      parent_block_hash: dbBlock.parent_block_hash,
+      microblock_hash: '',
+      microblock_sequence: I32_MAX,
+      block_hash: dbBlock.block_hash,
+      block_height: dbBlock.block_height,
+      burn_block_time: dbBlock.burn_block_time,
+      parent_burn_block_hash: '0xaa',
+      parent_burn_block_time: 1626122935,
+    });
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: dbTx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [],
+        },
+      ],
+    });
+
+    const txQuery = await getTxFromDataStore(db, { txId: dbTx.tx_id, includeUnanchored: false });
+    expect(txQuery.found).toBe(true);
+    if (!txQuery.found) {
+      throw Error('not found');
+    }
+
+    const expectedResp = {
+      block_hash: '0xff',
+      block_height: 1,
+      burn_block_time: 1594647995,
+      burn_block_time_iso: '2020-07-13T13:46:35.000Z',
+      canonical: true,
+      microblock_canonical: true,
+      microblock_hash: '0x',
+      microblock_sequence: I32_MAX,
+      parent_block_hash: '0x5678',
+      parent_burn_block_time: 1626122935,
+      parent_burn_block_time_iso: '2021-07-12T20:48:55.000Z',
+      tx_id: '0x449f5ea5c541bbbbbf7a1bff2434c449dca2ae3cdc52ba8d24b0bd0d3632d9bc',
+      tx_index: 2,
+      tx_status: 'success',
+      tx_result: {
+        hex: '0x0100000000000000000000000000000001', // u1
+        repr: 'u1',
+      },
+      tx_type: 'coinbase',
+      fee_rate: '0',
+      is_unanchored: false,
+      nonce: 4,
+      anchor_mode: 'on_chain_only',
+      sender_address: 'ST3YKSP8GTY7YFH6DD5YN4A753A8JZWNTEJFG78GN',
+      sponsored: false,
+      post_condition_mode: 'deny',
+      post_conditions: [],
+      coinbase_payload: {
+        data: '0x0000000000000000000000000000000000000000000000000000000000000000',
+        alt_recipient: 'ST2X2FYCY01Y7YR2TGC2Y6661NFF3SMH0NGXPWTV5',
+      },
+      event_count: 0,
+      events: [],
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
+    };
+    const fetchTx = await supertest(api.server).get(`/extended/v1/tx/${dbTx.tx_id}`);
+    expect(fetchTx.status).toBe(200);
+    expect(fetchTx.type).toBe('application/json');
+    expect(JSON.parse(fetchTx.text)).toEqual(expectedResp);
+    expect(txQuery.result).toEqual(expectedResp);
+  });
+
+  test('tx - coinbase pay to alt recipient - contract principal', async () => {
+    const dbBlock: DbBlock = {
+      block_hash: '0xff',
+      index_block_hash: '0x1234',
+      parent_index_block_hash: '0x5678',
+      parent_block_hash: '0x5678',
+      parent_microblock_hash: '',
+      parent_microblock_sequence: 0,
+      block_height: 1,
+      burn_block_time: 1594647995,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
+      canonical: true,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
+    };
+
+    // stacks.js does not support `coinbase-pay-to-alt-recipient` tx support as of writing, so use a known good serialized tx
+    const versionedSmartContractTx = Buffer.from(
+      '8080000000040055a0a92720d20398211cd4c7663d65d018efcc1f00000000000000030000000000000000010118da31f542913e8c56961b87ee4794924e655a28a2034e37ef4823eeddf074747285bd6efdfbd84eecdf62cffa7c1864e683c688f4c105f4db7429066735b4e2010200000000050000000000000000000000000000000000000000000000000000000000000000061aba27f99e007c7f605a8305e318c1abde3cd220ac0b68656c6c6f5f776f726c64',
+      'hex'
+    );
+
+    const tx = decodeTransaction(versionedSmartContractTx);
+    const dbTx = createDbTxFromCoreMsg({
+      core_tx: {
+        raw_tx: bufferToHexPrefixString(versionedSmartContractTx),
+        status: 'success',
+        raw_result: '0x0100000000000000000000000000000001', // u1
+        txid: tx.tx_id,
+        tx_index: 2,
+        contract_abi: null,
+        microblock_hash: null,
+        microblock_parent_hash: null,
+        microblock_sequence: null,
+        execution_cost: {
+          read_count: 0,
+          read_length: 0,
+          runtime: 0,
+          write_count: 0,
+          write_length: 0,
+        },
+      },
+      nonce: 0,
+      raw_tx: bufferToHexPrefixString(versionedSmartContractTx),
+      parsed_tx: tx,
+      sender_address: tx.auth.origin_condition.signer.address,
+      sponsor_address: undefined,
+      index_block_hash: dbBlock.index_block_hash,
+      parent_index_block_hash: dbBlock.parent_index_block_hash,
+      parent_block_hash: dbBlock.parent_block_hash,
+      microblock_hash: '',
+      microblock_sequence: I32_MAX,
+      block_hash: dbBlock.block_hash,
+      block_height: dbBlock.block_height,
+      burn_block_time: dbBlock.burn_block_time,
+      parent_burn_block_hash: '0xaa',
+      parent_burn_block_time: 1626122935,
+    });
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: dbTx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [],
+        },
+      ],
+    });
+
+    const txQuery = await getTxFromDataStore(db, { txId: dbTx.tx_id, includeUnanchored: false });
+    expect(txQuery.found).toBe(true);
+    if (!txQuery.found) {
+      throw Error('not found');
+    }
+
+    const expectedResp = {
+      block_hash: '0xff',
+      block_height: 1,
+      burn_block_time: 1594647995,
+      burn_block_time_iso: '2020-07-13T13:46:35.000Z',
+      canonical: true,
+      microblock_canonical: true,
+      microblock_hash: '0x',
+      microblock_sequence: I32_MAX,
+      parent_block_hash: '0x5678',
+      parent_burn_block_time: 1626122935,
+      parent_burn_block_time_iso: '2021-07-12T20:48:55.000Z',
+      tx_id: '0xbd1a9e1d60ca29fc630633170f396f5b6b85c9620bd16d63384ebc5a01a1829b',
+      tx_index: 2,
+      tx_status: 'success',
+      tx_result: {
+        hex: '0x0100000000000000000000000000000001', // u1
+        repr: 'u1',
+      },
+      tx_type: 'coinbase',
+      fee_rate: '0',
+      is_unanchored: false,
+      nonce: 3,
+      anchor_mode: 'on_chain_only',
+      sender_address: 'ST1AT1A97439076113KACESHXCQ81HVYC3XWGT2F5',
+      sponsored: false,
+      post_condition_mode: 'deny',
+      post_conditions: [],
+      coinbase_payload: {
+        data: '0x0000000000000000000000000000000000000000000000000000000000000000',
+        alt_recipient: 'ST2X2FYCY01Y7YR2TGC2Y6661NFF3SMH0NGXPWTV5.hello_world',
+      },
+      event_count: 0,
+      events: [],
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
+    };
+    const fetchTx = await supertest(api.server).get(`/extended/v1/tx/${dbTx.tx_id}`);
+    expect(fetchTx.status).toBe(200);
+    expect(fetchTx.type).toBe('application/json');
+    expect(JSON.parse(fetchTx.text)).toEqual(expectedResp);
+    expect(txQuery.result).toEqual(expectedResp);
+  });
+
   test('tx - sponsored', async () => {
     const dbBlock: DbBlock = {
       block_hash: '0xff',


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/1275

The new `coinbase-pay-to-alt-recipient` transactions are now being parsed, stored in pg, and the new coinbase `alt_recipient` property is returned on applicable requests.

For regular `coinbase` transactions, the `alt_recipient` property is null.

Note: internally, we are storing this in pg as a new tx type (with the new type ID), but when generating http responses, we normalize the type as `"tx_type": "coinbase"` so as not to cause unnecessary breaking changes for clients.

### Examples

Pay-to-alt coinbase with standard principal recipient:
```json
    {
      "tx_id": "0x36604700e58ff2cb1a47d7185f528ae7af5365433df5c0c46449052e545e19f3",
      "nonce": 4,
      "fee_rate": "0",
      "sender_address": "ST3GVG66JXT2WRW0KPP5849Q2EC4K1HCS85YHA8M3",
      "sponsored": false,
      "post_condition_mode": "deny",
      "post_conditions": [],
      "anchor_mode": "on_chain_only",
      "is_unanchored": false,
      "block_hash": "0x1c531824767ff5d6d69be2ca7db0eef526105b3d72f2762b7c56b78f32161f15",
      "parent_block_hash": "0xdd19a294f2236ebb45347da54152cd3f6094488c832ba950cab05ffae925bd1a",
      "block_height": 5,
      "burn_block_time": 1660825663,
      "burn_block_time_iso": "2022-08-18T12:27:43.000Z",
      "parent_burn_block_time": 1660825661,
      "parent_burn_block_time_iso": "2022-08-18T12:27:41.000Z",
      "canonical": true,
      "tx_index": 0,
      "tx_status": "success",
      "tx_result": {
        "hex": "0x0703",
        "repr": "(ok true)"
      },
      "microblock_hash": "0x",
      "microblock_sequence": 2147483647,
      "microblock_canonical": true,
      "event_count": 0,
      "events": [],
      "execution_cost_read_count": 0,
      "execution_cost_read_length": 0,
      "execution_cost_runtime": 0,
      "execution_cost_write_count": 0,
      "execution_cost_write_length": 0,
      "tx_type": "coinbase",
      "coinbase_payload": {
        "data": "0x0000000000000000000000000000000000000000000000000000000000000000",
        "alt_recipient": "ST2X2FYCY01Y7YR2TGC2Y6661NFF3SMH0NGXPWTV5"  <-- New
      }
    }
```

Pay-to-alt coinbase with contract principal recipient:
```json
    {
      "tx_id": "0xe279c3133332bdeaa214a5867825d7c337d93343eaf2dc97470eaff5568848b1",
      "nonce": 3,
      "fee_rate": "0",
      "sender_address": "ST3GVG66JXT2WRW0KPP5849Q2EC4K1HCS85YHA8M3",
      "sponsored": false,
      "post_condition_mode": "deny",
      "post_conditions": [],
      "anchor_mode": "on_chain_only",
      "is_unanchored": false,
      "block_hash": "0xdd19a294f2236ebb45347da54152cd3f6094488c832ba950cab05ffae925bd1a",
      "parent_block_hash": "0xbe8ff9d9015be7bcd43a98367a9fa2ae5b630cd2ba02777b497a45595ea28a0b",
      "block_height": 4,
      "burn_block_time": 1660825661,
      "burn_block_time_iso": "2022-08-18T12:27:41.000Z",
      "parent_burn_block_time": 1660825660,
      "parent_burn_block_time_iso": "2022-08-18T12:27:40.000Z",
      "canonical": true,
      "tx_index": 0,
      "tx_status": "success",
      "tx_result": {
        "hex": "0x0703",
        "repr": "(ok true)"
      },
      "microblock_hash": "0x",
      "microblock_sequence": 2147483647,
      "microblock_canonical": true,
      "event_count": 2,
      "events": [],
      "execution_cost_read_count": 0,
      "execution_cost_read_length": 0,
      "execution_cost_runtime": 0,
      "execution_cost_write_count": 0,
      "execution_cost_write_length": 0,
      "tx_type": "coinbase",
      "coinbase_payload": {
        "data": "0x0000000000000000000000000000000000000000000000000000000000000000",
        "alt_recipient": "ST2X2FYCY01Y7YR2TGC2Y6661NFF3SMH0NGXPWTV5.hello_world"  <-- New
      }
    }
```

Regular coinbase tx (`alt_recipient` is null):
```json
    {
      "tx_id": "0x7948c0d2d8425a398b33838a3805d6969e130d64cbdf06b2d2e9c03cdd58ba7c",
      "nonce": 2,
      "fee_rate": "0",
      "sender_address": "ST3GVG66JXT2WRW0KPP5849Q2EC4K1HCS85YHA8M3",
      "sponsored": false,
      "post_condition_mode": "deny",
      "post_conditions": [],
      "anchor_mode": "on_chain_only",
      "is_unanchored": false,
      "block_hash": "0xbe8ff9d9015be7bcd43a98367a9fa2ae5b630cd2ba02777b497a45595ea28a0b",
      "parent_block_hash": "0xa2729a3e6d80213f065f2d9a672f2056cb87cc8aec0c51262abfd420937628c4",
      "block_height": 3,
      "burn_block_time": 1660825660,
      "burn_block_time_iso": "2022-08-18T12:27:40.000Z",
      "parent_burn_block_time": 1660825659,
      "parent_burn_block_time_iso": "2022-08-18T12:27:39.000Z",
      "canonical": true,
      "tx_index": 0,
      "tx_status": "success",
      "tx_result": {
        "hex": "0x0703",
        "repr": "(ok true)"
      },
      "microblock_hash": "0x",
      "microblock_sequence": 2147483647,
      "microblock_canonical": true,
      "event_count": 2,
      "events": [],
      "execution_cost_read_count": 0,
      "execution_cost_read_length": 0,
      "execution_cost_runtime": 0,
      "execution_cost_write_count": 0,
      "execution_cost_write_length": 0,
      "tx_type": "coinbase",
      "coinbase_payload": {
        "data": "0x0000000000000000000000000000000000000000000000000000000000000000",
        "alt_recipient": null  <-- New
      }
    }
```

TODO:
* [x] Add tests for `coinbase-pay-to-alt` tx types