### PR TITLE
Support for Stacks 2.1 stx-transfer event memo field 

### DIFF
--- a/docs/entities/transaction-events/asset-types/transaction-event-asset.schema.json
+++ b/docs/entities/transaction-events/asset-types/transaction-event-asset.schema.json
@@ -20,6 +20,9 @@
     },
     "value": {
       "type": "string"
+    },
+    "memo": {
+      "type": "string"
     }
   }
 }

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -747,6 +747,7 @@ export interface TransactionEventAsset {
   recipient?: string;
   amount?: string;
   value?: string;
+  memo?: string;
 }
 /**
  * GET request that returns address balances

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -243,6 +243,9 @@ export function parseDbEvent(dbEvent: DbEvent): TransactionEvent {
           amount: dbEvent.amount.toString(10),
         },
       };
+      if (dbEvent.asset_event_type_id === DbAssetEventTypeId.Transfer && dbEvent.memo) {
+        event.asset.memo = dbEvent.memo;
+      }
       return event;
     }
     case DbEventTypeId.FungibleTokenAsset: {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -325,6 +325,7 @@ interface DbAssetEvent extends DbEventBase {
 export interface DbStxEvent extends DbAssetEvent {
   event_type: DbEventTypeId.StxAsset;
   amount: bigint;
+  memo?: string;
 }
 
 interface DbContractAssetEvent extends DbAssetEvent {
@@ -1009,6 +1010,7 @@ export interface StxEventInsertValues {
   sender: string | null;
   recipient: string | null;
   amount: bigint;
+  memo: PgBytea | null;
 }
 
 export interface MinerRewardInsertValues {

--- a/src/datastore/helpers.ts
+++ b/src/datastore/helpers.ts
@@ -398,6 +398,7 @@ export function parseDbEvents(
     sender?: string | undefined;
     recipient?: string | undefined;
     amount: string;
+    memo?: string;
   }[],
   ftResults: {
     event_index: number;
@@ -468,6 +469,7 @@ export function parseDbEvents(
       recipient: result.recipient,
       event_type: DbEventTypeId.StxAsset,
       amount: BigInt(result.amount),
+      memo: result.memo,
     };
     events[rowIndex++] = event;
   }
@@ -554,6 +556,7 @@ export function parseTxsWithAssetTransfers(
     event_recipient?: string | undefined;
     event_asset_identifier?: string | undefined;
     event_value?: string | undefined;
+    event_memo?: string | undefined;
   })[],
   stxAddress: string
 ) {
@@ -567,6 +570,7 @@ export function parseTxsWithAssetTransfers(
         amount: bigint;
         sender?: string;
         recipient?: string;
+        memo?: string;
       }[];
       ft_transfers: {
         asset_identifier: string;
@@ -606,6 +610,7 @@ export function parseTxsWithAssetTransfers(
             amount: eventAmount,
             sender: r.event_sender,
             recipient: r.event_recipient,
+            memo: r.event_memo,
           });
           if (r.event_sender === stxAddress) {
             txResult.stx_sent += eventAmount;

--- a/src/datastore/helpers.ts
+++ b/src/datastore/helpers.ts
@@ -469,8 +469,10 @@ export function parseDbEvents(
       recipient: result.recipient,
       event_type: DbEventTypeId.StxAsset,
       amount: BigInt(result.amount),
-      memo: result.memo,
     };
+    if (result.memo) {
+      event.memo = result.memo;
+    }
     events[rowIndex++] = event;
   }
   for (const result of ftResults) {

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -1779,7 +1779,6 @@ export class PgStore {
             sender: r.sender,
             recipient: r.recipient,
             amount: BigInt(r.amount),
-            memo: r.memo,
             locked_amount: BigInt(r.amount),
             unlock_height: Number(r.unlock_height),
             locked_address: r.sender,
@@ -1790,6 +1789,9 @@ export class PgStore {
             canonical: true,
             asset_event_type_id: r.asset_event_type_id,
           };
+          if (event.event_type === DbEventTypeId.StxAsset && r.memo) {
+            event.memo = r.memo;
+          }
           return event;
         });
       }
@@ -2260,8 +2262,10 @@ export class PgStore {
           recipient: row.recipient,
           event_type: DbEventTypeId.StxAsset,
           amount: BigInt(row.amount ?? 0),
-          memo: row.memo,
         };
+        if (row.memo) {
+          event.memo = row.memo;
+        }
         return event;
       } else if (row.asset_type === 'ft') {
         const event: DbFtEvent = {

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -709,6 +709,7 @@ export class PgWriteStore extends PgStore {
         sender: event.sender ?? null,
         recipient: event.recipient ?? null,
         amount: event.amount,
+        memo: event.memo ?? null,
       }));
       const res = await sql`
         INSERT INTO stx_events ${sql(values)}
@@ -874,6 +875,7 @@ export class PgWriteStore extends PgStore {
       sender: event.sender ?? null,
       recipient: event.recipient ?? null,
       amount: event.amount,
+      memo: event.memo ?? null,
     };
     await sql`
       INSERT INTO stx_events ${sql(values)}

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -43,6 +43,8 @@ export interface StxTransferEvent extends CoreNodeEventBase {
     recipient: string;
     sender: string;
     amount: string;
+    /** Hex-encoded string. Only provided when a memo was specified in the Clarity `stx-transfer?` function (requires a Stacks 2.1 contract). */
+    memo?: string;
   };
 }
 

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -453,6 +453,7 @@ function parseDataStoreTxEventData(
           sender: event.stx_transfer_event.sender,
           recipient: event.stx_transfer_event.recipient,
           amount: BigInt(event.stx_transfer_event.amount),
+          memo: event.stx_transfer_event.memo ? '0x' + event.stx_transfer_event.memo : undefined,
         };
         dbTx.stxEvents.push(entry);
         break;

--- a/src/migrations/1588252682585_stx_events.ts
+++ b/src/migrations/1588252682585_stx_events.ts
@@ -56,6 +56,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     },
     sender: 'string',
     recipient: 'string',
+    memo: 'bytea',
   });
 
   pgm.createIndex('stx_events', 'tx_id', { method: 'hash' });


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/1276

Implements parsing, storing, and returning the `memo` field that can be included in Stacks 2.1 `stx_transfer_event` events when the `stx-transfer-memo?` Clarity2 function is used. 

To test this, deploy a Clarity2 versioned-smart-contract with something like the contract code:
```clar
(stx-transfer-memo? 
  u60
  tx-sender
  'ST2X2FYCY01Y7YR2TGC2Y6661NFF3SMH0NGXPWTV5
  0x74657374206d656d6f206669656c64)
```

Note: you need to be able to construct and serialize a `versioned-smart-contract`, this PR adds that capability to stacks.js https://github.com/hirosystems/stacks.js/pull/1341

The resulting tx will have a stx-transfer event with the associated memo, e.g.:
```json
{
  "event_index": 0,
  "event_type": "stx_asset",
  "tx_id": "0x6b0f0d3a28693e834f90e95fb058a70922de778d189e64903f550328e6256520",
  "asset": {
    "asset_event_type": "transfer",
    "sender": "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6",
    "recipient": "ST2X2FYCY01Y7YR2TGC2Y6661NFF3SMH0NGXPWTV5",
    "amount": "60",
    "memo": "0x74657374206d656d6f206669656c64"
  }
}
```

If the stx-transfer event does not have a memo field (e.g. from a Clarity1 `stx-transfer?` function), then the `memo` field will not be included in the response.

## Examples

#### `GET /extended/v1/tx/<tx_id>`
```json
{
  "tx_id": "0x6b0f0d3a28693e834f90e95fb058a70922de778d189e64903f550328e6256520",
  "nonce": 0,
  "fee_rate": "12345",
  "sender_address": "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6",
  "sponsored": false,
  "post_condition_mode": "allow",
  "post_conditions": [],
  "anchor_mode": "any",
  "is_unanchored": false,
  "block_hash": "0x390e5ff80baaf8a8c2f1a7662969d16ead1b0b986e92ed1b649f6f6eb527adf8",
  "parent_block_hash": "0x0bcd6a598321d330f72b52a4698ebc3431ab72af82eae10909213630105f176f",
  "block_height": 14,
  "burn_block_time": 1660842957,
  "burn_block_time_iso": "2022-08-18T17:15:57.000Z",
  "parent_burn_block_time": 1660842956,
  "parent_burn_block_time_iso": "2022-08-18T17:15:56.000Z",
  "canonical": true,
  "tx_index": 1,
  "tx_status": "success",
  "tx_result": {
    "hex": "0x0703",
    "repr": "(ok true)"
  },
  "microblock_hash": "0x",
  "microblock_sequence": 2147483647,
  "microblock_canonical": true,
  "event_count": 1,
  "events": [
    {
      "event_index": 0,
      "event_type": "stx_asset",
      "tx_id": "0x6b0f0d3a28693e834f90e95fb058a70922de778d189e64903f550328e6256520",
      "asset": {
        "asset_event_type": "transfer",
        "sender": "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6",
        "recipient": "ST2X2FYCY01Y7YR2TGC2Y6661NFF3SMH0NGXPWTV5",
        "amount": "60",
        "memo": "0x74657374206d656d6f206669656c64"
      }
    }
  ],
  "execution_cost_read_count": 1,
  "execution_cost_read_length": 1,
  "execution_cost_runtime": 316963,
  "execution_cost_write_count": 2,
  "execution_cost_write_length": 118,
  "tx_type": "smart_contract",
  "smart_contract": {
    "clarity_version": 2,
    "contract_id": "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6.hello-world-contract",
    "source_code": "(stx-transfer-memo? u60 tx-sender 'ST2X2FYCY01Y7YR2TGC2Y6661NFF3SMH0NGXPWTV5 0x74657374206d656d6f206669656c64)"
  }
}
```

#### `GET /extended/v1/tx/events?tx_id=<tx_id>`
```json
{
  "limit": 96,
  "offset": 0,
  "events": [
    {
      "event_index": 0,
      "event_type": "stx_asset",
      "tx_id": "0x6b0f0d3a28693e834f90e95fb058a70922de778d189e64903f550328e6256520",
      "asset": {
        "asset_event_type": "transfer",
        "sender": "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6",
        "recipient": "ST2X2FYCY01Y7YR2TGC2Y6661NFF3SMH0NGXPWTV5",
        "amount": "60",
        "memo": "0x74657374206d656d6f206669656c64"
      }
    }
  ]
}
```

#### `GET /extended/v1/address/<principal>/assets`
```json
{
  "limit": 20,
  "offset": 0,
  "total": 1,
  "results": [
    {
      "event_index": 0,
      "event_type": "stx_asset",
      "tx_id": "0x6b0f0d3a28693e834f90e95fb058a70922de778d189e64903f550328e6256520",
      "asset": {
        "asset_event_type": "transfer",
        "sender": "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6",
        "recipient": "ST2X2FYCY01Y7YR2TGC2Y6661NFF3SMH0NGXPWTV5",
        "amount": "60",
        "memo": "0x74657374206d656d6f206669656c64"
      }
    }
  ]
}
```

TODO:
* [x] Unit tests