### PR TITLE
[Stacks 2.1] Include `stx-transfer-memo` results in `/address/<recipient>/stx_inbound`

### DIFF
--- a/docs/entities/transfers/inbound-stx-transfer.schema.json
+++ b/docs/entities/transfers/inbound-stx-transfer.schema.json
@@ -27,7 +27,7 @@
     },
     "transfer_type": {
       "type": "string",
-      "enum": ["bulk-send", "stx-transfer"],
+      "enum": ["bulk-send", "stx-transfer", "stx-transfer-memo"],
       "description": "Indicates if the transfer is from a stx-transfer transaction or a contract-call transaction"
     },
     "tx_index": {

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -888,7 +888,7 @@ export interface InboundStxTransfer {
   /**
    * Indicates if the transfer is from a stx-transfer transaction or a contract-call transaction
    */
-  transfer_type: "bulk-send" | "stx-transfer";
+  transfer_type: "bulk-send" | "stx-transfer" | "stx-transfer-memo";
   /**
    * Index of the transaction within a block
    */

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -2677,6 +2677,24 @@ export class PgStore {
             AND stx_events.canonical = true AND stx_events.microblock_canonical = true
             AND contract_logs.canonical = true AND contract_logs.microblock_canonical = true
           UNION ALL
+
+          SELECT
+            stx_events.amount AS amount,
+            stx_events.memo AS memo,
+            stx_events.sender AS sender,
+            stx_events.block_height AS block_height,
+            stx_events.tx_id,
+            stx_events.microblock_sequence,
+            stx_events.tx_index,
+            'stx-transfer-memo' as transfer_type
+          FROM stx_events
+          WHERE
+            stx_events.memo IS NOT NULL
+            AND canonical = true
+            AND microblock_canonical = true
+            AND recipient = ${args.stxAddress}
+          UNION ALL
+
           SELECT
             token_transfer_amount AS amount,
             token_transfer_memo AS memo,

--- a/src/tests/tx-tests.ts
+++ b/src/tests/tx-tests.ts
@@ -1265,6 +1265,28 @@ describe('tx tests', () => {
         memo: '0x74657374206d656d6f206669656c64',
       },
     });
+
+    const req6 = await supertest(api.server).get(
+      `/extended/v1/address/${dbStxEvent.recipient}/stx_inbound`
+    );
+    expect(req6.status).toBe(200);
+    expect(req6.type).toBe('application/json');
+    expect(req6.body).toEqual({
+      limit: 20,
+      offset: 0,
+      results: [
+        {
+          amount: '60',
+          block_height: 1,
+          memo: '0x74657374206d656d6f206669656c64',
+          sender: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
+          transfer_type: 'stx-transfer-memo',
+          tx_id: '0x421234',
+          tx_index: 0,
+        },
+      ],
+      total: 1,
+    });
   });
 
   test('tx store and processing', async () => {


### PR DESCRIPTION
Follow-up to https://github.com/hirosystems/stacks-blockchain-api/pull/1285 

Added support for returning STX transfers w/ memos to the `/address/<recipient>/stx_inbound` endpoint. In Stacks 2.1, smart contract txs (leveraging `stx-transfer-memo?`) can now send STX w/ memos in a way supported by most exchange deposit requirements without having to use the [`send-many-stx` work-around contract/tool](https://github.com/stacks-network/send-many-stx-cli)
