### PR TITLE
[Stacks 2.1] Rosetta - `stx-transfer-memo` events, misc. compatibility

### DIFF
--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -517,7 +517,7 @@ async function parseRosettaTxDetail(opts: {
     events,
     opts.unlockingEvents
   );
-  const txMemo = parseTransactionMemo(opts.tx);
+  const txMemo = parseTransactionMemo(opts.tx.token_transfer_memo);
   const rosettaTx: RosettaTransaction = {
     transaction_identifier: { hash: opts.tx.tx_id },
     operations: operations,

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -46,22 +46,29 @@ export enum RosettaOperationType {
   RevokeDelegateStx = 'revoke_delegate_stx',
 }
 
-export const RosettaOperationTypes = [
-  RosettaOperationType.TokenTransfer,
-  RosettaOperationType.ContractCall,
-  RosettaOperationType.SmartContract,
-  RosettaOperationType.Coinbase,
-  RosettaOperationType.PoisonMicroblock,
-  RosettaOperationType.Fee,
-  RosettaOperationType.Mint,
-  RosettaOperationType.Burn,
-  RosettaOperationType.MinerReward,
-  RosettaOperationType.StxLock, // stx event
-  RosettaOperationType.StxUnlock, // forged event
-  RosettaOperationType.StackStx, // PoX contract function
-  RosettaOperationType.DelegateStx, // PoX contract function
-  RosettaOperationType.RevokeDelegateStx, // PoX contract function
-];
+type RosettaOperationTypeUnion = `${RosettaOperationType}`;
+
+// Function that leverages typescript to ensure a given array contains all values from a type union
+const arrayOfAllOpTypes = <T extends RosettaOperationTypeUnion[]>(
+  array: T & ([RosettaOperationTypeUnion] extends [T[number]] ? unknown : 'Invalid')
+) => array;
+
+export const RosettaOperationTypes = arrayOfAllOpTypes([
+  'token_transfer',
+  'contract_call',
+  'smart_contract',
+  'coinbase',
+  'poison_microblock',
+  'fee',
+  'mint',
+  'burn',
+  'miner_reward',
+  'stx_lock',
+  'stx_unlock',
+  'stack_stx',
+  'delegate_stx',
+  'revoke_delegate_stx',
+]) as RosettaOperationType[];
 
 export const RosettaOperationStatuses = [
   {

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -510,7 +510,7 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
       try {
         const baseTx = rawTxToBaseTx(inputTx);
         const operations = await getOperations(baseTx, db);
-        const txMemo = parseTransactionMemo(baseTx);
+        const txMemo = parseTransactionMemo(baseTx.token_transfer_memo);
         let response: RosettaConstructionParseResponse;
         if (signed) {
           response = {

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -53,12 +53,7 @@ import { StacksCoreRpcClient } from '../../../core-rpc/client';
 import { DbBlock } from '../../../datastore/common';
 import { PgStore } from '../../../datastore/pg-store';
 import { FoundOrNot, hexToBuffer, isValidC32Address, has0xPrefix } from '../../../helpers';
-import {
-  RosettaConstants,
-  RosettaErrors,
-  RosettaErrorsTypes,
-  RosettaOperationType,
-} from '../../rosetta-constants';
+import { RosettaConstants, RosettaErrors, RosettaErrorsTypes, RosettaOperationType } from '../../rosetta-constants';
 import {
   getOperations,
   getOptionsFromOperations,
@@ -185,7 +180,7 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
       }
 
       let transaction: StacksTransaction;
-      switch (options.type) {
+      switch (options.type as RosettaOperationType) {
         case RosettaOperationType.TokenTransfer:
           // dummy transaction to calculate size
           const dummyTokenTransferTx: UnsignedTokenTransferOptions = {
@@ -328,7 +323,7 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
       }
 
       const request: RosettaConstructionMetadataRequest = req.body;
-      const options: RosettaOptions = req.body.options;
+      const options: RosettaOptions = request.options;
 
       if (options?.sender_address && !isValidC32Address(options.sender_address)) {
         res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidSender]);
@@ -345,7 +340,7 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
       }
 
       let response = {} as RosettaConstructionMetadataResponse;
-      switch (options.type) {
+      switch (options.type as RosettaOperationType) {
         case RosettaOperationType.TokenTransfer:
           const recipientAddress = options.token_transfer_recipient_address;
           if (options?.decimals !== RosettaConstants.decimals) {
@@ -642,7 +637,7 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
       }
 
       let transaction: StacksTransaction;
-      switch (options.type) {
+      switch (options.type as RosettaOperationType) {
         case RosettaOperationType.TokenTransfer: {
           const recipientAddress = options.token_transfer_recipient_address;
           if (!recipientAddress) {

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -53,7 +53,12 @@ import { StacksCoreRpcClient } from '../../../core-rpc/client';
 import { DbBlock } from '../../../datastore/common';
 import { PgStore } from '../../../datastore/pg-store';
 import { FoundOrNot, hexToBuffer, isValidC32Address, has0xPrefix } from '../../../helpers';
-import { RosettaConstants, RosettaErrors, RosettaErrorsTypes, RosettaOperationType } from '../../rosetta-constants';
+import {
+  RosettaConstants,
+  RosettaErrors,
+  RosettaErrorsTypes,
+  RosettaOperationType,
+} from '../../rosetta-constants';
 import {
   getOperations,
   getOptionsFromOperations,

--- a/src/api/routes/rosetta/mempool.ts
+++ b/src/api/routes/rosetta/mempool.ts
@@ -70,7 +70,7 @@ export function createRosettaMempoolRouter(db: PgStore, chainId: ChainID): expre
       }
 
       const operations = await getOperations(mempoolTxQuery.result, db);
-      const txMemo = parseTransactionMemo(mempoolTxQuery.result);
+      const txMemo = parseTransactionMemo(mempoolTxQuery.result.token_transfer_memo);
       const transaction: RosettaTransaction = {
         transaction_identifier: { hash: tx_id },
         operations: operations,

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -114,8 +114,8 @@ export function parseTransactionMemo(memoHex: string | undefined): string | null
     if (memoBuffer.length === 0) {
       return null;
     }
-    const memoTrimmed = '0x' + memoBuffer.toString('hex');
-    return memoTrimmed;
+    const memoDecoded = memoBuffer.toString('utf8');
+    return memoDecoded;
   }
   return null;
 }

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -120,22 +120,22 @@ export async function getOperations(
   stxUnlockEvents?: StxUnlockEvent[]
 ): Promise<RosettaOperation[]> {
   const operations: RosettaOperation[] = [];
-  const txType = getTxTypeString(tx.type_id);
+  const txType = getTxTypeString(tx.type_id) as RosettaOperationType;
   switch (txType) {
-    case 'token_transfer':
+    case RosettaOperationType.TokenTransfer:
       operations.push(makeFeeOperation(tx));
       operations.push(makeSenderOperation(tx, operations.length));
       operations.push(makeReceiverOperation(tx, operations.length));
       break;
-    case 'contract_call':
+    case RosettaOperationType.ContractCall:
       operations.push(makeFeeOperation(tx));
       operations.push(await makeCallContractOperation(tx, db, operations.length));
       break;
-    case 'smart_contract':
+    case RosettaOperationType.SmartContract:
       operations.push(makeFeeOperation(tx));
       operations.push(makeDeployContractOperation(tx, operations.length));
       break;
-    case 'coinbase':
+    case RosettaOperationType.Coinbase:
       operations.push(makeCoinbaseOperation(tx, 0));
       if (minerRewards !== undefined) {
         getMinerOperations(minerRewards, operations);
@@ -144,7 +144,7 @@ export async function getOperations(
         processUnlockingEvents(stxUnlockEvents, operations);
       }
       break;
-    case 'poison_microblock':
+    case RosettaOperationType.PoisonMicroblock:
       operations.push(makePoisonMicroblockOperation(tx, 0));
       break;
     default:
@@ -254,7 +254,7 @@ function makeStakeLockOperation(
   stake_metadata.unlock_height = tx.unlock_height.toString();
   const lock: RosettaOperation = {
     operation_identifier: { index: index },
-    type: getEventTypeString(tx.event_type),
+    type: RosettaOperationType.StxLock,
     status: getTxStatus(baseTx.status),
     account: {
       address: unwrapOptional(tx.locked_address, () => 'Unexpected nullish locked_address'),
@@ -337,7 +337,7 @@ function makeFeeOperation(tx: BaseTx): RosettaOperation {
 function makeBurnOperation(tx: DbStxEvent, baseTx: BaseTx, index: number): RosettaOperation {
   const burn: RosettaOperation = {
     operation_identifier: { index: index },
-    type: getAssetEventTypeString(tx.asset_event_type_id),
+    type: RosettaOperationType.Burn,
     status: getTxStatus(baseTx.status),
     account: {
       address: unwrapOptional(baseTx.sender_address, () => 'Unexpected nullish sender_address'),
@@ -359,7 +359,7 @@ function makeFtBurnOperation(
 ): RosettaOperation {
   const burn: RosettaOperation = {
     operation_identifier: { index: index },
-    type: getAssetEventTypeString(ftEvent.asset_event_type_id),
+    type: RosettaOperationType.Burn,
     status: getTxStatus(baseTx.status),
     account: {
       address: unwrapOptional(ftEvent.sender, () => 'Unexpected nullish sender_address'),
@@ -379,7 +379,7 @@ function makeFtBurnOperation(
 function makeMintOperation(tx: DbStxEvent, baseTx: BaseTx, index: number): RosettaOperation {
   const mint: RosettaOperation = {
     operation_identifier: { index: index },
-    type: getAssetEventTypeString(tx.asset_event_type_id),
+    type: RosettaOperationType.Mint,
     status: getTxStatus(baseTx.status),
     account: {
       address: unwrapOptional(tx.recipient, () => 'Unexpected nullish sender_address'),
@@ -403,7 +403,7 @@ function makeFtMintOperation(
 ): RosettaOperation {
   const mint: RosettaOperation = {
     operation_identifier: { index: index },
-    type: getAssetEventTypeString(ftEvent.asset_event_type_id),
+    type: RosettaOperationType.Mint,
     status: getTxStatus(baseTx.status),
     account: {
       address: unwrapOptional(ftEvent.recipient, () => 'Unexpected nullish sender_address'),
@@ -426,7 +426,7 @@ function makeFtMintOperation(
 function makeSenderOperation(tx: BaseTx, index: number): RosettaOperation {
   const sender: RosettaOperation = {
     operation_identifier: { index: index },
-    type: 'token_transfer', //Sender operation should always be token_transfer,
+    type: RosettaOperationType.TokenTransfer, //Sender operation should always be token_transfer,
     status: getTxStatus(tx.status),
     account: {
       address: unwrapOptional(tx.sender_address, () => 'Unexpected nullish sender_address'),
@@ -455,7 +455,7 @@ function makeFtSenderOperation(
 ): RosettaOperation {
   const sender: RosettaOperation = {
     operation_identifier: { index: index },
-    type: 'token_transfer',
+    type: RosettaOperationType.TokenTransfer,
     status: getTxStatus(tx.status),
     account: {
       address: unwrapOptional(ftEvent.sender, () => 'Unexpected nullish sender_address'),
@@ -482,7 +482,7 @@ function makeReceiverOperation(tx: BaseTx, index: number): RosettaOperation {
   const receiver: RosettaOperation = {
     operation_identifier: { index: index },
     related_operations: [{ index: index - 1 }],
-    type: 'token_transfer', //Receiver operation should always be token_transfer
+    type: RosettaOperationType.TokenTransfer, //Receiver operation should always be token_transfer
     status: getTxStatus(tx.status),
     account: {
       address: unwrapOptional(
@@ -515,7 +515,7 @@ function makeFtReceiverOperation(
   const receiver: RosettaOperation = {
     operation_identifier: { index: index },
     related_operations: [{ index: index - 1 }],
-    type: 'token_transfer',
+    type: RosettaOperationType.TokenTransfer,
     status: getTxStatus(tx.status),
     account: {
       address: unwrapOptional(
@@ -545,7 +545,7 @@ function makeFtReceiverOperation(
 function makeDeployContractOperation(tx: BaseTx, index: number): RosettaOperation {
   const deployer: RosettaOperation = {
     operation_identifier: { index: index },
-    type: getTxTypeString(tx.type_id),
+    type: RosettaOperationType.SmartContract,
     status: getTxStatus(tx.status),
     account: {
       address: unwrapOptional(tx.sender_address, () => 'Unexpected nullish sender_address'),
@@ -562,7 +562,7 @@ async function makeCallContractOperation(
 ): Promise<RosettaOperation> {
   const contractCallOp: RosettaOperation = {
     operation_identifier: { index: index },
-    type: getTxTypeString(tx.type_id),
+    type: RosettaOperationType.ContractCall,
     status: getTxStatus(tx.status),
     account: {
       address: unwrapOptional(tx.sender_address, () => 'Unexpected nullish sender_address'),
@@ -598,7 +598,7 @@ function makeCoinbaseOperation(tx: BaseTx, index: number): RosettaOperation {
   // TODO : Add more mappings in operations for coinbase
   const sender: RosettaOperation = {
     operation_identifier: { index: index },
-    type: getTxTypeString(tx.type_id),
+    type: RosettaOperationType.Coinbase,
     status: getTxStatus(tx.status),
     account: {
       address: unwrapOptional(tx.sender_address, () => 'Unexpected nullish sender_address'),
@@ -612,7 +612,7 @@ function makePoisonMicroblockOperation(tx: BaseTx, index: number): RosettaOperat
   // TODO : add more mappings in operations for poison-microblock
   const sender: RosettaOperation = {
     operation_identifier: { index: index },
-    type: getTxTypeString(tx.type_id),
+    type: RosettaOperationType.PoisonMicroblock,
     status: getTxStatus(tx.status),
     account: {
       address: unwrapOptional(tx.sender_address, () => 'Unexpected nullish sender_address'),
@@ -645,7 +645,7 @@ export function getOptionsFromOperations(operations: RosettaOperation[]): Rosett
   const options: RosettaOptions = {};
 
   for (const operation of operations) {
-    switch (operation.type) {
+    switch (operation.type as RosettaOperationType) {
       case RosettaOperationType.Fee:
         options.fee = operation.amount?.value;
         break;

--- a/src/test-utils/test-builders.ts
+++ b/src/test-utils/test-builders.ts
@@ -81,7 +81,7 @@ const ZONEFILE =
   '$ORIGIN test.btc\n$TTL 3600\n_http._tcp IN URI 10 1 "https://blockstack.s3.amazonaws.com/test.btc"\n';
 const ZONEFILE_HASH = 'b100a68235244b012854a95f9114695679002af9';
 
-interface TestBlockArgs {
+export interface TestBlockArgs {
   block_height?: number;
   block_hash?: string;
   index_block_hash?: string;
@@ -150,7 +150,7 @@ function testMicroblock(args?: TestMicroblockArgs): DbMicroblockPartial {
   };
 }
 
-interface TestTxArgs {
+export interface TestTxArgs {
   block_hash?: string;
   block_height?: number;
   burn_block_time?: number;
@@ -186,7 +186,7 @@ interface TestTxArgs {
  * @returns `DataStoreTxEventData`
  */
 function testTx(args?: TestTxArgs): DataStoreTxEventData {
-  return {
+  const data: DataStoreTxEventData = {
     tx: {
       tx_id: args?.tx_id ?? TX_ID,
       tx_index: args?.tx_index ?? 0,
@@ -240,6 +240,7 @@ function testTx(args?: TestTxArgs): DataStoreTxEventData {
     names: [],
     namespaces: [],
   };
+  return data;
 }
 
 interface TestMempoolTxArgs {
@@ -293,7 +294,7 @@ export function testMempoolTx(args?: TestMempoolTxArgs): DbMempoolTx {
   };
 }
 
-interface TestStxEventArgs {
+export interface TestStxEventArgs {
   amount?: bigint;
   block_height?: number;
   event_index?: number;
@@ -301,6 +302,7 @@ interface TestStxEventArgs {
   sender?: string;
   tx_id?: string;
   tx_index?: number;
+  memo?: string;
 }
 
 /**
@@ -320,6 +322,7 @@ function testStxEvent(args?: TestStxEventArgs): DbStxEvent {
     amount: args?.amount ?? TOKEN_TRANSFER_AMOUNT,
     recipient: args?.recipient ?? RECIPIENT_ADDRESS,
     sender: args?.sender ?? SENDER_ADDRESS,
+    memo: args?.memo,
   };
 }
 
@@ -447,7 +450,7 @@ function testStxLockEvent(args?: TestStxEventLockArgs): DbStxLockEvent {
   };
 }
 
-interface TestSmartContractEventArgs {
+export interface TestSmartContractEventArgs {
   tx_id?: string;
   block_height?: number;
   clarity_version?: number;

--- a/src/test-utils/test-builders.ts
+++ b/src/test-utils/test-builders.ts
@@ -156,6 +156,7 @@ export interface TestTxArgs {
   burn_block_time?: number;
   canonical?: boolean;
   microblock_canonical?: boolean;
+  coinbase_alt_recipient?: string;
   contract_call_contract_id?: string;
   contract_call_function_name?: string;
   contract_call_function_args?: string;
@@ -209,6 +210,7 @@ function testTx(args?: TestTxArgs): DataStoreTxEventData {
       sender_address: args?.sender_address ?? SENDER_ADDRESS,
       origin_hash_mode: 1,
       coinbase_payload: bufferToHexPrefixString(Buffer.from('hi')),
+      coinbase_alt_recipient: args?.coinbase_alt_recipient,
       event_count: 0,
       parent_index_block_hash: args?.parent_index_block_hash ?? INDEX_BLOCK_HASH,
       parent_block_hash: BLOCK_HASH,

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -18,7 +18,7 @@ import {
   RosettaOperation,
   RosettaTransaction,
 } from '@stacks/stacks-blockchain-api-types';
-import { RosettaConstants } from '../api/rosetta-constants';
+import { RosettaConstants, RosettaOperationType } from '../api/rosetta-constants';
 import { TestBlockBuilder } from '../test-utils/test-builders';
 import { PgWriteStore } from '../datastore/pg-write-store';
 import { cycleMigrations, runMigrations } from '../datastore/migrations';
@@ -402,7 +402,7 @@ describe('Rosetta API', () => {
         index: 0,
       },
       status: 'success',
-      type: 'coinbase',
+      type: RosettaOperationType.Coinbase,
       account: rosettaAccount,
     };
     const rosettaOperations: RosettaOperation[] = [];

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -29,6 +29,7 @@ import {
 import { PgWriteStore } from '../datastore/pg-write-store';
 import { cycleMigrations, runMigrations } from '../datastore/migrations';
 import { PgSqlClient } from '../datastore/connection';
+import { bufferToHexPrefixString } from '../helpers';
 
 describe('Rosetta API', () => {
   let db: PgWriteStore;
@@ -231,7 +232,7 @@ describe('Rosetta API', () => {
       abi: undefined,
       token_transfer_recipient_address: 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP',
       token_transfer_amount: 3852n,
-      token_transfer_memo: '0x25463526',
+      token_transfer_memo: bufferToHexPrefixString(Buffer.from('test1234')).padEnd(70, '0'),
     }
     const data = new TestBlockBuilder(block).addTx(tx).build();
     await db.update(data);
@@ -249,7 +250,7 @@ describe('Rosetta API', () => {
         hash: tx.tx_id,
       },
       metadata: {
-        memo: '0x25463526',
+        memo: 'test1234',
       },
       operations: [
         {
@@ -272,7 +273,7 @@ describe('Rosetta API', () => {
             },
           },
           metadata: {
-            memo: '0x25463526',
+            memo: 'test1234',
           },
         },
         {
@@ -289,7 +290,7 @@ describe('Rosetta API', () => {
             },
           },
           metadata: {
-            memo: '0x25463526',
+            memo: 'test1234',
           },
         },
       ],
@@ -407,7 +408,7 @@ describe('Rosetta API', () => {
               }
             },
             "metadata": {
-              "memo": "0x74657374206d656d6f206669656c64"
+              "memo": "test memo field"
             }
           },
           {
@@ -438,7 +439,7 @@ describe('Rosetta API', () => {
               }
             },
             "metadata": {
-              "memo": "0x74657374206d656d6f206669656c64"
+              "memo": "test memo field"
             }
           }
         ]

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -447,6 +447,118 @@ describe('Rosetta API', () => {
     );
   });
 
+  test('coinbase-pay-to-alt block/transaction', async () => {
+    const parentData = new TestBlockBuilder().addTx().build();
+    const block1: TestBlockArgs = {
+      block_height: 2,
+      block_hash: '0xd0dd05e3d0a1bd60640c9d9d30d57012ffe47b52fe643140c39199c757d37e3f',
+      index_block_hash: '0x6a36c14514047074c2877065809bbb70d81d52507747f4616da997deb7228fad',
+      parent_index_block_hash: parentData.block.index_block_hash,
+      parent_block_hash: parentData.block.block_hash,
+      parent_microblock_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      burn_block_hash: '0xfe15c0d3ebe314fad720a08b839a004c2e6386f5aecc19ec74807d1920cb6aeb',
+      miner_txid: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    }
+    const txCoinbase1: TestTxArgs = {
+      tx_id: '0xc152de9376bab4fc27291c9cd088643698290a12bb511d768f873cb3d280eb48',
+      tx_index: 1,
+      type_id: DbTxTypeId.Coinbase,
+      status: DbTxStatus.Success,
+      raw_result: '0x0703',
+      canonical: true,
+      microblock_canonical: true,
+      microblock_sequence: 2147483647,
+      microblock_hash: '0x00',
+      fee_rate: 180n,
+      sender_address: 'ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR',
+    };
+    const blockData1 = new TestBlockBuilder(block1).addTx(txCoinbase1).build();
+
+    const block2: TestBlockArgs = {
+      block_height: 3,
+      block_hash: '0x30dd05e3d0a1bd60640c9d9d30d57012ffe47b52fe643140c39199c757d37e3f',
+      index_block_hash: '0x3a36c14514047074c2877065809bbb70d81d52507747f4616da997deb7228fad',
+      parent_index_block_hash: blockData1.block.index_block_hash,
+      parent_block_hash: blockData1.block.block_hash,
+      parent_microblock_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      burn_block_hash: '0xfe15c0d3ebe314fad720a08b839a004c2e6386f5aecc19ec74807d1920cb6aeb',
+      miner_txid: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    }
+    const txCoinbase2: TestTxArgs = {
+      tx_id: '0x3152de9376bab4fc27291c9cd088643698290a12bb511d768f873cb3d280eb48',
+      tx_index: 1,
+      type_id: DbTxTypeId.CoinbaseToAltRecipient,
+      coinbase_alt_recipient: 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP',
+      status: DbTxStatus.Success,
+      raw_result: '0x0703',
+      canonical: true,
+      microblock_canonical: true,
+      microblock_sequence: 2147483647,
+      microblock_hash: '0x00',
+      fee_rate: 180n,
+      sender_address: 'ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR',
+    };
+    const blockData2 = new TestBlockBuilder(block2).addTx(txCoinbase2).build();
+
+    await db.update(parentData);
+    await db.update(blockData1);
+    await db.update(blockData2);
+
+    const query1 = await supertest(api.server)
+      .post(`/rosetta/v1/block/transaction`)
+      .send({
+        network_identifier: { blockchain: 'stacks', network: 'testnet' },
+        block_identifier: { index: blockData1.block.block_height, hash: blockData1.block.block_hash },
+        transaction_identifier: { hash: txCoinbase1.tx_id },
+      });
+    expect(query1.status).toBe(200);
+    expect(query1.type).toBe('application/json');
+    expect(JSON.parse(query1.text)).toEqual({
+      "operations": [
+        {
+          "account": {
+            "address": "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR",
+          },
+          "operation_identifier": {
+            "index": 0,
+          },
+          "status": "success",
+          "type": "coinbase",
+        },
+      ],
+      "transaction_identifier": {
+        "hash": "0xc152de9376bab4fc27291c9cd088643698290a12bb511d768f873cb3d280eb48",
+      },
+    });
+
+    const query2 = await supertest(api.server)
+      .post(`/rosetta/v1/block/transaction`)
+      .send({
+        network_identifier: { blockchain: 'stacks', network: 'testnet' },
+        block_identifier: { index: blockData2.block.block_height, hash: blockData2.block.block_hash },
+        transaction_identifier: { hash: txCoinbase2.tx_id },
+      });
+    expect(query2.status).toBe(200);
+    expect(query2.type).toBe('application/json');
+    expect(JSON.parse(query2.text)).toEqual({
+      "operations": [
+        {
+          "account": {
+            "address": "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR",
+          },
+          "operation_identifier": {
+            "index": 0,
+          },
+          "status": "success",
+          "type": "coinbase",
+        },
+      ],
+      "transaction_identifier": {
+        "hash": "0x3152de9376bab4fc27291c9cd088643698290a12bb511d768f873cb3d280eb48",
+      },
+    });
+  });
+
   test('block/transaction - invalid transaction hash', async () => {
     const query1 = await supertest(api.server)
       .post(`/rosetta/v1/block/transaction`)

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -265,6 +265,9 @@ describe('Rosetta API', () => {
               identifier: `${tx.tx_id}:1`,
             },
           },
+          metadata: {
+            memo: '0x25463526',
+          },
         },
         {
           operation_identifier: { index: 2 },
@@ -278,6 +281,9 @@ describe('Rosetta API', () => {
             coin_identifier: {
               identifier: `${tx.tx_id}:2`,
             },
+          },
+          metadata: {
+            memo: '0x25463526',
           },
         },
       ],

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -19,7 +19,13 @@ import {
   RosettaTransaction,
 } from '@stacks/stacks-blockchain-api-types';
 import { RosettaConstants, RosettaOperationType } from '../api/rosetta-constants';
-import { TestBlockBuilder } from '../test-utils/test-builders';
+import {
+  TestBlockArgs,
+  TestBlockBuilder,
+  TestSmartContractEventArgs,
+  TestStxEventArgs,
+  TestTxArgs,
+} from '../test-utils/test-builders';
 import { PgWriteStore } from '../datastore/pg-write-store';
 import { cycleMigrations, runMigrations } from '../datastore/migrations';
 import { PgSqlClient } from '../datastore/connection';
@@ -288,6 +294,156 @@ describe('Rosetta API', () => {
         },
       ],
     });
+  });
+
+  test('stx-transfer-memo block/transaction', async () => {
+    const parentData = new TestBlockBuilder().addTx().build();
+    const block: TestBlockArgs = {
+      block_height: 2,
+      block_hash: '0xd0dd05e3d0a1bd60640c9d9d30d57012ffe47b52fe643140c39199c757d37e3f',
+      index_block_hash: '0x6a36c14514047074c2877065809bbb70d81d52507747f4616da997deb7228fad',
+      parent_index_block_hash: parentData.block.index_block_hash,
+      parent_block_hash: parentData.block.block_hash,
+      parent_microblock_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      burn_block_hash: '0xfe15c0d3ebe314fad720a08b839a004c2e6386f5aecc19ec74807d1920cb6aeb',
+      miner_txid: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    }
+    const tx: TestTxArgs = {
+      tx_id: '0xc152de9376bab4fc27291c9cd088643698290a12bb511d768f873cb3d280eb48',
+      tx_index: 1,
+      type_id: DbTxTypeId.VersionedSmartContract,
+      status: DbTxStatus.Success,
+      raw_result: '0x0703',
+      canonical: true,
+      microblock_canonical: true,
+      microblock_sequence: 2147483647,
+      microblock_hash: '0x00',
+      fee_rate: 180n,
+      sender_address: 'ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR',
+      abi: '{"some-abi":1}',
+      smart_contract_contract_id: 'some-versioned-smart-contract-id',
+      smart_contract_source_code: '(some-versioned-contract-src)',
+      smart_contract_clarity_version: 2,
+    };
+    const stxEvent: TestStxEventArgs = {
+      amount: 3852n,
+      recipient: 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP',
+      sender: 'ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR',
+      tx_id: tx.tx_id,
+      memo: '0x74657374206d656d6f206669656c64000000',
+    };
+    const contract: TestSmartContractEventArgs = {
+      tx_id: tx.tx_id,
+      clarity_version: tx.smart_contract_clarity_version,
+      contract_id: tx.smart_contract_contract_id,
+      contract_source: tx.smart_contract_source_code,
+      abi: tx.abi,
+    };
+    const data = new TestBlockBuilder(block).addTx(tx).addTxStxEvent(stxEvent).addTxSmartContract(contract).build();
+    await db.update(parentData);
+    await db.update(data);
+    const query1 = await supertest(api.server)
+      .post(`/rosetta/v1/block/transaction`)
+      .send({
+        network_identifier: { blockchain: 'stacks', network: 'testnet' },
+        block_identifier: { index: data.block.block_height, hash: data.block.block_hash },
+        transaction_identifier: { hash: tx.tx_id },
+      });
+    expect(query1.status).toBe(200);
+    expect(query1.type).toBe('application/json');
+    expect(JSON.parse(query1.text)).toEqual(
+      {
+        "transaction_identifier": {
+          "hash": "0xc152de9376bab4fc27291c9cd088643698290a12bb511d768f873cb3d280eb48"
+        },
+        "operations": [
+          {
+            "operation_identifier": {
+              "index": 0
+            },
+            "type": "fee",
+            "status": "success",
+            "account": {
+              "address": "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
+            },
+            "amount": {
+              "value": "-180",
+              "currency": {
+                "decimals": 6,
+                "symbol": "STX"
+              }
+            }
+          },
+          {
+            "operation_identifier": {
+              "index": 1
+            },
+            "type": "smart_contract",
+            "status": "success",
+            "account": {
+              "address": "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
+            }
+          },
+          {
+            "operation_identifier": {
+              "index": 2
+            },
+            "type": "token_transfer",
+            "status": "success",
+            "account": {
+              "address": "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
+            },
+            "amount": {
+              "value": "-3852",
+              "currency": {
+                "decimals": 6,
+                "symbol": "STX"
+              }
+            },
+            "coin_change": {
+              "coin_action": "coin_spent",
+              "coin_identifier": {
+                "identifier": "0xc152de9376bab4fc27291c9cd088643698290a12bb511d768f873cb3d280eb48:2"
+              }
+            },
+            "metadata": {
+              "memo": "0x74657374206d656d6f206669656c64"
+            }
+          },
+          {
+            "operation_identifier": {
+              "index": 3
+            },
+            "related_operations": [
+              {
+                "index": 2
+              }
+            ],
+            "type": "token_transfer",
+            "status": "success",
+            "account": {
+              "address": "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
+            },
+            "amount": {
+              "value": "3852",
+              "currency": {
+                "decimals": 6,
+                "symbol": "STX"
+              }
+            },
+            "coin_change": {
+              "coin_action": "coin_created",
+              "coin_identifier": {
+                "identifier": "0xc152de9376bab4fc27291c9cd088643698290a12bb511d768f873cb3d280eb48:3"
+              }
+            },
+            "metadata": {
+              "memo": "0x74657374206d656d6f206669656c64"
+            }
+          }
+        ]
+      }
+    );
   });
 
   test('block/transaction - invalid transaction hash', async () => {


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/1284

* Include `memo` from `stx-transfer-memo` events in Rosetta token transfer operations.
* Tests that `versioned-smart-contract` tx types are parsed correctly in Rosetta responses.
* Tests that `coinbase-pay-to-alt` tx types are parsed correctly in Rosetta responses.
* Clean up several weakly typed `strings` being used for RosettaOperationType fields.
* Fixes bug in API v5 / `develop` branch where Rosetta `memo` strings were no longer decoded from hex.