### PR TITLE
chore: fix bug with memo hex strings not decoded in Rosetta responses

### DIFF
--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -104,10 +104,19 @@ type RosettaRevokeDelegateContractArgs = {
 };
 
 export function parseTransactionMemo(tx: BaseTx): string | null {
-  if (tx.token_transfer_memo && tx.token_transfer_memo != '') {
+  const memoHex = tx.token_transfer_memo;
+  if (memoHex) {
     // Memos are a fixed-length 34 byte array. Any memo representing a string that is
     // less than 34 bytes long will have right-side padded null-bytes.
-    return tx.token_transfer_memo.replace(/\0.*$/g, '');
+    let memoBuffer = hexToBuffer(memoHex);
+    while (memoBuffer.length > 0 && memoBuffer[memoBuffer.length - 1] === 0) {
+      memoBuffer = memoBuffer.slice(0, memoBuffer.length - 1);
+    }
+    if (memoBuffer.length === 0) {
+      return null;
+    }
+    const memoDecoded = memoBuffer.toString('utf8');
+    return memoDecoded;
   }
   return null;
 }

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -28,6 +28,7 @@ import { TestBlockBuilder } from '../test-utils/test-builders';
 import { PgWriteStore } from '../datastore/pg-write-store';
 import { cycleMigrations, runMigrations } from '../datastore/migrations';
 import { PgSqlClient } from '../datastore/connection';
+import { bufferToHexPrefixString } from '../helpers';
 
 describe('Rosetta API', () => {
   let db: PgWriteStore;
@@ -346,7 +347,7 @@ describe('Rosetta API', () => {
       abi: undefined,
       token_transfer_recipient_address: 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP',
       token_transfer_amount: 3852n,
-      token_transfer_memo: '0x25463526',
+      token_transfer_memo: bufferToHexPrefixString(Buffer.from('test1234')).padEnd(70, '0'),
     }
     const data = new TestBlockBuilder(block).addTx(tx).build();
     await db.update(data);
@@ -364,7 +365,7 @@ describe('Rosetta API', () => {
         hash: tx.tx_id,
       },
       metadata: {
-        memo: '0x25463526',
+        memo: 'test1234',
       },
       operations: [
         {


### PR DESCRIPTION
Fix bug in `develop` branch where Rosetta `memo` strings were no longer decoded from hex.

The code was trying to trim NULL bytes from a hex string, which previously used to be a string from `Buffer.from(memoBytes).toString()` in v4.

This fixes the expected response, and trims bytes off the Buffer before converting to string, rather than depending on undefined behavior with Buffer and trailing null bytes. 