### PR TITLE
fix: add postgres connection error checking for ECONNRESET code

### DIFF
--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -313,6 +313,8 @@ function isPgConnectionError(error: any): string | false {
     return 'Postgres connection ETIMEDOUT';
   } else if (error.code === 'ENOTFOUND') {
     return 'Postgres connection ENOTFOUND';
+  } else if (error.code === 'ECONNRESET') {
+    return 'Postgres connection ECONNRESET';
   } else if (error.message) {
     const msg = (error as Error).message.toLowerCase();
     if (msg.includes('database system is starting up')) {


### PR DESCRIPTION
## Description

Adds a check for the `ECONNRESET` error code when connecting to postgres. This should help reduce API terminations when the postgres db is behind a proxy (e.g. istio).

Closes https://github.com/hirosystems/stacks-blockchain-api/issues/1299

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

Tested in k8s and verified fixed!