### PR TITLE
fix: import BNS v1 data during event replay

### DIFF
--- a/running_an_api.md
+++ b/running_an_api.md
@@ -78,32 +78,12 @@ Since we'll need to create some files/dirs for persistent data we'll first creat
 We'll be using:
 
 ```bash
-$ mkdir -p ./stacks-node/{persistent-data/postgres,persistent-data/stacks-blockchain,bns,config}
+$ mkdir -p ./stacks-node/{persistent-data/postgres,persistent-data/stacks-blockchain,config}
 $ docker pull blockstack/stacks-blockchain-api \
     && docker pull blockstack/stacks-blockchain \
     && docker pull postgres:alpine
 $ docker network create stacks-blockchain > /dev/null 2>&1
 $ cd ./stacks-node
-```
-
-**Optional but recommended**: If you need the v1 BNS data, there are going to be a few extra steps.
-
-1. Download the BNS data:  
-`curl -L https://storage.googleapis.com/blockstack-v1-migration-data/export-data.tar.gz -o ./bns/export-data.tar.gz`
-2. Extract the data:  
-`tar -xzvf ./bns/export-data.tar.gz -C ./bns/`
-3. Each file in `./bns` will have a corresponding `sha256` value.  
-
-To Verify, run a script like the following to check the sha256sum:
-
-```bash
-for file in `ls ./bns/* | grep -v sha256 | grep -v .tar.gz`; do
-    if [ $(sha256sum $file | awk {'print $1'}) == $(cat ${file}.sha256 ) ]; then
-        echo "sha256 Matched $file"
-    else
-        echo "sha256 Mismatch $file"
-    fi
-done
 ```
 
 ## Postgres
@@ -161,15 +141,8 @@ STACKS_BLOCKCHAIN_API_PORT=3999
 STACKS_BLOCKCHAIN_API_HOST=0.0.0.0
 STACKS_CORE_RPC_HOST=stacks-blockchain
 STACKS_CORE_RPC_PORT=20443
-BNS_IMPORT_DIR=/bns-data
 API_DOCS_URL=https://docs.hiro.so/api
 ```
-
-**Note** that here we are importing the bns data with the env var `BNS_IMPORT`.  
-
-To Disable this import, simply comment the line: `#BNS_IMPORT_DIR=/bns-data`  
-
-***If you leave this enabled***: please allow several minutes for the one-time import to complete before continuing.
 
 The other Environment Variables to pay attention to:
 
@@ -184,7 +157,6 @@ docker run -d --rm \
     --name stacks-blockchain-api \
     --net=stacks-blockchain \
     --env-file $(pwd)/.env \
-    -v $(pwd)/bns:/bns-data \
     -p 3700:3700 \
     -p 3999:3999 \
     blockstack/stacks-blockchain-api

--- a/running_api_from_source.md
+++ b/running_api_from_source.md
@@ -35,7 +35,7 @@ Since we'll need to create some files/dirs for persistent data,
 we'll first create a base directory structure and set some permissions:
 
 ```bash
-$ sudo mkdir -p /stacks-node/{persistent-data/stacks-blockchain,bns,config,binaries}
+$ sudo mkdir -p /stacks-node/{persistent-data/stacks-blockchain,config,binaries}
 $ sudo chown -R $(whoami) /stacks-node 
 $ cd /stacks-node
 ```
@@ -43,7 +43,7 @@ $ cd /stacks-node
 ## Install Requirements
 
 ```bash
-$ PG_VERSION=12 \
+$ PG_VERSION=14 \
   && NODE_VERSION=16 \
   && sudo apt-get update \
   && sudo apt-get install -y \
@@ -63,26 +63,6 @@ $ PG_VERSION=12 \
     postgresql-${PG_VERSION} \
     postgresql-client-${PG_VERSION} \
     nodejs
-```
-
-**Optional but recommended** - If you want the V1 BNS data, there are going to be a few extra steps:
-
-1. Download the BNS data:  
-`curl -L https://storage.googleapis.com/blockstack-v1-migration-data/export-data.tar.gz -o /stacks-node/bns/export-data.tar.gz`
-2. Extract the data:  
-`tar -xzvf ./bns/export-data.tar.gz -C /stacks-node/bns/`
-3. Each file in `./bns` will have a corresponding `sha256` value.
-
-To Verify, run a script like the following to check the sha256sum:
-
-```bash
-for file in `ls /stacks-node/bns/* | grep -v sha256 | grep -v .tar.gz`; do
-    if [ $(sha256sum $file | awk {'print $1'}) == $(cat ${file}.sha256 ) ]; then
-        echo "sha256 Matched $file"
-    else
-        echo "sha256 Mismatch $file"
-    fi
-done
 ```
 
 ## postgres
@@ -127,8 +107,6 @@ $ git clone https://github.com/hirosystems/stacks-blockchain-api /stacks-node/st
 The stacks blockchain api requires several Environment Variables to be set in order to run properly.  
 To reduce complexity, we're going to create a `.env` file that we'll use for these env vars.  
 
-** Note: ** to enable BNS names, uncomment `BNS_IMPORT_DIR` in the below `.env` file. 
-
 Create a new file: `/stacks-node/stacks-blockchain-api/.env` with the following content:
 
 ```bash
@@ -148,7 +126,6 @@ STACKS_BLOCKCHAIN_API_PORT=3999
 STACKS_BLOCKCHAIN_API_HOST=0.0.0.0
 STACKS_CORE_RPC_HOST=localhost
 STACKS_CORE_RPC_PORT=20443
-#BNS_IMPORT_DIR=/stacks-node/bns
 EOF
 $ cd /stacks-node/stacks-blockchain-api && nohup node ./lib/index.js &
 ```

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -439,7 +439,7 @@ export interface DataStoreAttachmentData {
   blockHeight: number;
 }
 
-export interface DataStoreSubdomainBlockData {
+export interface DataStoreBnsBlockData {
   index_block_hash: string;
   parent_index_block_hash: string;
   microblock_hash: string;
@@ -449,7 +449,7 @@ export interface DataStoreSubdomainBlockData {
 
 export interface DataStoreAttachmentSubdomainData {
   attachment?: DataStoreAttachmentData;
-  blockData?: DataStoreSubdomainBlockData;
+  blockData?: DataStoreBnsBlockData;
   subdomains?: DbBnsSubdomain[];
 }
 

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -7222,7 +7222,7 @@ export class PgDataStore
       // The `names` and `zonefiles` tables only track latest zonefile changes. We need to check
       // `nft_custody` for the latest name owner, but only for names that were NOT imported from v1
       // since they did not generate an NFT event for us to track.
-      if (nameZonefile.rows[0].registered_at !== 0) {
+      if (nameZonefile.rows[0].registered_at !== 1) {
         let value: Buffer;
         try {
           value = bnsNameCV(name);
@@ -7427,7 +7427,7 @@ export class PgDataStore
           names
         WHERE
           address = $1
-          AND registered_at = 0
+          AND registered_at = 1
           AND canonical = TRUE
           AND microblock_canonical = TRUE
         `,

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -101,7 +101,7 @@ import {
   DbAssetEventTypeId,
   DbTxGlobalStatus,
   DataStoreAttachmentData,
-  DataStoreSubdomainBlockData,
+  DataStoreBnsBlockData,
   DataStoreAttachmentSubdomainData,
 } from './common';
 import {
@@ -2175,7 +2175,7 @@ export class PgDataStore
             );
             let isCanonical = true;
             let txIndex = -1;
-            const blockData: DataStoreSubdomainBlockData = {
+            const blockData: DataStoreBnsBlockData = {
               index_block_hash: '',
               parent_index_block_hash: '',
               microblock_hash: '',

--- a/src/event-replay/helpers.ts
+++ b/src/event-replay/helpers.ts
@@ -1,5 +1,14 @@
+import * as fs from 'fs';
+import * as readline from 'readline';
+import { decodeTransaction, TxPayloadTypeID } from 'stacks-encoding-native-js';
+import { DataStoreBnsBlockData } from '../datastore/common';
 import { PgDataStore } from '../datastore/postgres-store';
 import { ReverseFileStream } from './reverse-file-stream';
+
+export type BnsGenesisBlock = DataStoreBnsBlockData & {
+  tx_id: string;
+  tx_index: number;
+};
 
 /**
  * Traverse a TSV file in reverse to find the last received `/new_block` node message and return
@@ -24,6 +33,56 @@ export async function findTsvBlockHeight(filePath: string): Promise<number> {
 
   reverseStream.destroy();
   return blockHeight;
+}
+
+/**
+ * Traverse a TSV file to find the genesis block and extract its data so we can use it during V1 BNS
+ * import.
+ * @param filePath - TSV path
+ * @returns Genesis block data
+ */
+export async function findBnsGenesisBlockData(filePath: string): Promise<BnsGenesisBlock> {
+  const rl = readline.createInterface({
+    input: fs.createReadStream(filePath),
+    crlfDelay: Infinity,
+  });
+  let genesisBlock: BnsGenesisBlock | undefined;
+  return new Promise<BnsGenesisBlock>((resolve, reject) => {
+    rl.on('line', line => {
+      const columns = line.split('\t');
+      const eventName = columns[2];
+      if (eventName === '/new_block') {
+        const payload = JSON.parse(columns[3]);
+        // Look for block 1
+        if (payload.block_height === 1) {
+          for (const tx of payload.transactions) {
+            const decodedTx = decodeTransaction(tx.raw_tx);
+            // Look for the only token transfer transaction in the genesis block. This is the one
+            // that contains all the events, including all BNS name registrations.
+            if (decodedTx.payload.type_id === TxPayloadTypeID.TokenTransfer) {
+              genesisBlock = {
+                index_block_hash: payload.index_block_hash,
+                parent_index_block_hash: payload.parent_index_block_hash,
+                microblock_hash: payload.parent_microblock,
+                microblock_sequence: payload.parent_microblock_sequence,
+                microblock_canonical: true,
+                tx_id: decodedTx.tx_id,
+                tx_index: tx.tx_index,
+              };
+              rl.close();
+            }
+          }
+        }
+      }
+    });
+    rl.on('close', () => {
+      if (genesisBlock) {
+        resolve(genesisBlock);
+      } else {
+        reject(new Error('BNS genesis block data not found'));
+      }
+    });
+  });
 }
 
 /**

--- a/src/import-v1/index.ts
+++ b/src/import-v1/index.ts
@@ -26,6 +26,7 @@ import {
 } from '../helpers';
 
 import { PoolClient } from 'pg';
+import { BnsGenesisBlock } from 'src/event-replay/helpers';
 
 const finished = util.promisify(stream.finished);
 const pipeline = util.promisify(stream.pipeline);
@@ -80,20 +81,20 @@ class ChainProcessor extends stream.Writable {
   namespace: Map<string, DbBnsNamespace>;
   db: PgDataStore;
   client: PoolClient;
-  emptyBlockData = {
-    index_block_hash: '',
-    parent_index_block_hash: '',
-    microblock_hash: '',
-    microblock_sequence: I32_MAX,
-    microblock_canonical: true,
-  } as const;
+  genesisBlock: BnsGenesisBlock;
 
-  constructor(client: PoolClient, db: PgDataStore, zhashes: Map<string, string>) {
+  constructor(
+    client: PoolClient,
+    db: PgDataStore,
+    zhashes: Map<string, string>,
+    genesisBlock: BnsGenesisBlock
+  ) {
     super();
     this.zhashes = zhashes;
     this.namespace = new Map();
     this.client = client;
     this.db = db;
+    this.genesisBlock = genesisBlock;
     logger.info(`${this.tag}: importer starting`);
   }
 
@@ -152,16 +153,16 @@ class ChainProcessor extends stream.Writable {
             name: parts[0],
             address: parts[1],
             namespace_id: ns,
-            registered_at: 0,
+            registered_at: 1,
             expire_block: namespace.lifetime,
             zonefile: zonefile,
             zonefile_hash: zonefileHash,
-            tx_id: '',
-            tx_index: 0,
+            tx_id: this.genesisBlock.tx_id,
+            tx_index: this.genesisBlock.tx_index,
             canonical: true,
             status: 'name-register',
           };
-          await this.db.updateNames(this.client, this.emptyBlockData, obj);
+          await this.db.updateNames(this.client, this.genesisBlock, obj);
           this.rowCount += 1;
           if (obj.zonefile === '') {
             logger.verbose(
@@ -175,20 +176,20 @@ class ChainProcessor extends stream.Writable {
           const obj: DbBnsNamespace = {
             namespace_id: parts[0],
             address: parts[1],
-            reveal_block: 0,
-            ready_block: 0,
+            reveal_block: 1,
+            ready_block: 1,
             buckets: parts[2],
             base: BigInt(parts[3]),
             coeff: BigInt(parts[4]),
             nonalpha_discount: parseInt(parts[5], 10),
             no_vowel_discount: parseInt(parts[6], 10),
             lifetime: parseInt(parts[7], 10),
-            tx_id: '',
-            tx_index: 0,
+            tx_id: this.genesisBlock.tx_id,
+            tx_index: this.genesisBlock.tx_index,
             canonical: true,
           };
           this.namespace.set(obj.namespace_id, obj);
-          await this.db.updateNamespaces(this.client, this.emptyBlockData, obj);
+          await this.db.updateNamespaces(this.client, this.genesisBlock, obj);
           this.rowCount += 1;
         }
       }
@@ -232,9 +233,13 @@ function btcToStxAddress(btcAddress: string) {
 }
 
 class SubdomainTransform extends stream.Transform {
-  constructor() {
+  genesisBlock: BnsGenesisBlock;
+
+  constructor(genesisBlock: BnsGenesisBlock) {
     super({ objectMode: true, highWaterMark: SUBDOMAIN_BATCH_SIZE });
+    this.genesisBlock = genesisBlock;
   }
+
   _transform(data: string, _encoding: string, callback: stream.TransformCallback) {
     const parts = data.split(',');
     if (parts[0] !== 'zonefile_hash') {
@@ -251,8 +256,8 @@ class SubdomainTransform extends stream.Transform {
         fully_qualified_subdomain: parts[2],
         owner: btcToStxAddress(parts[3]), //convert btc address to stx,
         block_height: 1, // burn_block_height: parseInt(parts[4], 10)
-        tx_index: 0,
-        tx_id: '',
+        tx_index: this.genesisBlock.tx_index,
+        tx_id: this.genesisBlock.tx_id,
         parent_zonefile_index: parseInt(parts[5], 10),
         zonefile_offset: parseInt(parts[6], 10),
         resolver: parts[7],
@@ -302,12 +307,12 @@ async function valid(fileName: string): Promise<boolean> {
   return true;
 }
 
-async function* readSubdomains(importDir: string) {
+async function* readSubdomains(importDir: string, genesisBlock: BnsGenesisBlock) {
   const metaIter = asyncIterableToGenerator<DbBnsSubdomain>(
     stream.pipeline(
       fs.createReadStream(path.join(importDir, 'subdomains.csv')),
       new LineReaderStream({ highWaterMark: SUBDOMAIN_BATCH_SIZE }),
-      new SubdomainTransform(),
+      new SubdomainTransform(genesisBlock),
       error => {
         if (error) {
           console.error('Error reading subdomains.csv');
@@ -411,7 +416,11 @@ async function validateBnsImportDir(importDir: string, importFiles: string[]) {
   }
 }
 
-export async function importV1BnsNames(db: PgDataStore, importDir: string) {
+export async function importV1BnsNames(
+  db: PgDataStore,
+  importDir: string,
+  genesisBlock: BnsGenesisBlock
+) {
   const configState = await db.getConfigState();
   if (configState.bns_names_onchain_imported) {
     logger.verbose('Stacks 1.0 BNS names are already imported');
@@ -427,7 +436,7 @@ export async function importV1BnsNames(db: PgDataStore, importDir: string) {
     await pipeline(
       fs.createReadStream(path.join(importDir, 'chainstate.txt')),
       new LineReaderStream({ highWaterMark: 100 }),
-      new ChainProcessor(client, db, zhashes)
+      new ChainProcessor(client, db, zhashes, genesisBlock)
     );
     const updatedConfigState: DbConfigState = {
       ...configState,
@@ -445,7 +454,11 @@ export async function importV1BnsNames(db: PgDataStore, importDir: string) {
   logger.info('Stacks 1.0 BNS name import completed');
 }
 
-export async function importV1BnsSubdomains(db: PgDataStore, importDir: string) {
+export async function importV1BnsSubdomains(
+  db: PgDataStore,
+  importDir: string,
+  genesisBlock: BnsGenesisBlock
+) {
   const configState = await db.getConfigState();
   if (configState.bns_subdomains_imported) {
     logger.verbose('Stacks 1.0 BNS subdomains are already imported');
@@ -457,23 +470,19 @@ export async function importV1BnsSubdomains(db: PgDataStore, importDir: string) 
   const client = await db.pool.connect();
   try {
     await client.query('BEGIN');
-    const blockData = {
-      index_block_hash: '',
-      parent_index_block_hash: '',
-      microblock_hash: '',
-      microblock_sequence: I32_MAX,
-      microblock_canonical: true,
-    };
-
     let subdomainsImported = 0;
-    const subdomainIter = readSubdomains(importDir);
+    const subdomainIter = readSubdomains(importDir, genesisBlock);
     for await (const subdomainBatch of asyncBatchIterate(
       subdomainIter,
       SUBDOMAIN_BATCH_SIZE,
       false
     )) {
-      await db.updateBatchSubdomains(client, [{ blockData, subdomains: subdomainBatch }]);
-      await db.updateBatchZonefiles(client, [{ blockData, subdomains: subdomainBatch }]);
+      await db.updateBatchSubdomains(client, [
+        { blockData: genesisBlock, subdomains: subdomainBatch },
+      ]);
+      await db.updateBatchZonefiles(client, [
+        { blockData: genesisBlock, subdomains: subdomainBatch },
+      ]);
       subdomainsImported += subdomainBatch.length;
       if (subdomainsImported % 10_000 === 0) {
         logger.info(`Subdomains imported: ${subdomainsImported}`);

--- a/src/import-v1/index.ts
+++ b/src/import-v1/index.ts
@@ -7,7 +7,6 @@ import * as path from 'path';
 import * as zlib from 'zlib';
 import { bitcoinToStacksAddress } from 'stacks-encoding-native-js';
 import * as split2 from 'split2';
-
 import {
   DbBnsName,
   DbBnsNamespace,
@@ -24,9 +23,8 @@ import {
   logger,
   REPO_DIR,
 } from '../helpers';
-
 import { PoolClient } from 'pg';
-import { BnsGenesisBlock } from 'src/event-replay/helpers';
+import { BnsGenesisBlock } from '../event-replay/helpers';
 
 const finished = util.promisify(stream.finished);
 const pipeline = util.promisify(stream.pipeline);

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ import { startEventServer } from './event-stream/event-server';
 import { StacksCoreRpcClient } from './core-rpc/client';
 import { createServer as createPrometheusServer } from '@promster/server';
 import { registerShutdownConfig } from './shutdown-handler';
-import { importV1TokenOfferingData, importV1BnsData } from './import-v1';
 import { OfflineDummyStore } from './datastore/offline-dummy-store';
 import { Socket } from 'net';
 import * as getopts from 'getopts';
@@ -123,23 +122,7 @@ async function init(): Promise<void> {
     });
 
     if (apiMode !== StacksApiMode.readOnly) {
-      if (db instanceof PgDataStore) {
-        if (isProdEnv) {
-          await importV1TokenOfferingData(db);
-        } else {
-          logger.warn(
-            `Notice: skipping token offering data import because of non-production NODE_ENV`
-          );
-        }
-        if (isProdEnv && !process.env.BNS_IMPORT_DIR) {
-          logger.warn(`Notice: full BNS functionality requires 'BNS_IMPORT_DIR' to be set.`);
-        } else if (process.env.BNS_IMPORT_DIR) {
-          await importV1BnsData(db, process.env.BNS_IMPORT_DIR);
-        }
-      }
-
       const configuredChainID = getApiConfiguredChainID();
-
       const eventServer = await startEventServer({
         datastore: db,
         chainId: configuredChainID,

--- a/src/tests-bns/api.ts
+++ b/src/tests-bns/api.ts
@@ -414,7 +414,7 @@ describe('BNS API tests', () => {
       .build();
     await db.update(block);
 
-    // Register another name in block 0 (imported from v1, so no nft_event produced)
+    // Register another name in block 1 (imported from v1, so no nft_event produced)
     const dbName2: DbBnsName = {
       name: 'imported.btc',
       address: address,
@@ -422,7 +422,7 @@ describe('BNS API tests', () => {
       expire_block: 10000,
       zonefile: 'test-zone-file',
       zonefile_hash: 'zonefileHash',
-      registered_at: 0,
+      registered_at: 1,
       canonical: true,
       tx_id: '',
       tx_index: 0,

--- a/src/tests-bns/v1-import-tests.ts
+++ b/src/tests-bns/v1-import-tests.ts
@@ -5,7 +5,7 @@ import * as supertest from 'supertest';
 import { startEventServer } from '../event-stream/event-server';
 import { Server } from 'net';
 import { ChainID } from '@stacks/transactions';
-import { importV1BnsData } from '../import-v1';
+import { importV1BnsNames, importV1BnsSubdomains } from '../import-v1';
 import * as assert from 'assert';
 import { TestBlockBuilder } from '../test-utils/test-builders';
 
@@ -28,7 +28,8 @@ describe('BNS V1 import', () => {
   });
 
   test('v1-import', async () => {
-    await importV1BnsData(db, 'src/tests-bns/import-test-files');
+    await importV1BnsNames(db, 'src/tests-bns/import-test-files');
+    await importV1BnsSubdomains(db, 'src/tests-bns/import-test-files');
 
     // Names
     const query1 = await supertest(api.server).get(`/v1/names/zumrai.id`);


### PR DESCRIPTION
* Import BNS v1 data during replay: first names and namespaces, then TSV data, then subdomains
* Obtain genesis block information from TSV to be used in BNS import
* Modify BNS insertion data to mark all imported names at block 1 instead of block 0