### PR TITLE
feat: add indexes for index_block_hash on BNS tables

### DIFF
--- a/src/event-replay/event-replay.ts
+++ b/src/event-replay/event-replay.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { cycleMigrations, dangerousDropAllTables, PgDataStore } from '../datastore/postgres-store';
 import { startEventServer } from '../event-stream/event-server';
-import { getApiConfiguredChainID, httpPostRequest, logger } from '../helpers';
+import { defaultLogLevel, getApiConfiguredChainID, httpPostRequest, logger } from '../helpers';
 import { findBnsGenesisBlockData, findTsvBlockHeight, getDbBlockHeight } from './helpers';
 import { importV1BnsNames, importV1BnsSubdomains, importV1TokenOfferingData } from '../import-v1';
 
@@ -179,6 +179,7 @@ export async function importEventsFromTsv(
   }
   await db.finishEventReplay();
   if (process.env.BNS_IMPORT_DIR) {
+    logger.level = defaultLogLevel;
     await importV1BnsSubdomains(db, process.env.BNS_IMPORT_DIR, tsvGenesisBlockData);
   }
   console.log(`Event import and playback successful.`);

--- a/src/migrations/1608030374841_namespaces.ts
+++ b/src/migrations/1608030374841_namespaces.ts
@@ -91,6 +91,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     },
   });
 
+  pgm.createIndex('namespaces', 'index_block_hash');
   pgm.createIndex('namespaces', [
     { name: 'ready_block', sort: 'DESC' },
     { name: 'microblock_sequence', sort: 'DESC' },

--- a/src/migrations/1608030374842_names.ts
+++ b/src/migrations/1608030374842_names.ts
@@ -84,6 +84,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   });
 
   pgm.createIndex('names', 'namespace_id');
+  pgm.createIndex('names', 'index_block_hash');
   pgm.createIndex('names', [
     { name: 'registered_at', sort: 'DESC' },
     { name: 'microblock_sequence', sort: 'DESC' },

--- a/src/migrations/1610030345948_subdomains.ts
+++ b/src/migrations/1610030345948_subdomains.ts
@@ -85,6 +85,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   });
 
   pgm.createIndex('subdomains', 'name');
+  pgm.createIndex('subdomains', 'index_block_hash');
   pgm.createIndex('subdomains', [
     { name: 'block_height', sort: 'DESC' },
     { name: 'microblock_sequence', sort: 'DESC' },


### PR DESCRIPTION
Add `index_block_hash` index to optimize re-org queries.
Also, go back to the default log level before importing BNS subdomains during replay.