### PR TITLE
fix: catch pg exceptions on queries outside of express

### DIFF
--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -5,8 +5,6 @@ import * as expressWinston from 'express-winston';
 import * as winston from 'winston';
 import { v4 as uuid } from 'uuid';
 import * as cors from 'cors';
-import * as WebSocket from 'ws';
-import * as SocketIO from 'socket.io';
 
 import { createTxRouter } from './routes/tx';
 import { createDebugRouter } from './routes/debug';
@@ -47,7 +45,7 @@ import * as fs from 'fs';
 import { PgStore } from '../datastore/pg-store';
 import { PgWriteStore } from '../datastore/pg-write-store';
 import { WebSocketTransmitter } from './routes/ws/web-socket-transmitter';
-import { PostgresError } from 'postgres';
+import { isPgConnectionError } from '../datastore/helpers';
 
 export interface ApiServer {
   expressApp: express.Express;
@@ -301,7 +299,7 @@ export async function startApiServer(opts: {
     if (error && !res.headersSent) {
       if (error instanceof InvalidRequestError) {
         res.status(error.status).json({ error: error.message }).end();
-      } else if (error instanceof PostgresError) {
+      } else if (isPgConnectionError(error)) {
         res.status(503).json({ error: `The database service is unavailable` }).end();
       } else {
         res.status(500);

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -47,6 +47,7 @@ import * as fs from 'fs';
 import { PgStore } from '../datastore/pg-store';
 import { PgWriteStore } from '../datastore/pg-write-store';
 import { WebSocketTransmitter } from './routes/ws/web-socket-transmitter';
+import { PostgresError } from 'postgres';
 
 export interface ApiServer {
   expressApp: express.Express;
@@ -300,6 +301,8 @@ export async function startApiServer(opts: {
     if (error && !res.headersSent) {
       if (error instanceof InvalidRequestError) {
         res.status(error.status).json({ error: error.message }).end();
+      } else if (error instanceof PostgresError) {
+        res.status(503).json({ error: `The database service is unavailable` }).end();
       } else {
         res.status(500);
         const errorTag = uuid();

--- a/src/datastore/helpers.ts
+++ b/src/datastore/helpers.ts
@@ -184,6 +184,14 @@ export function isPgConnectionError(error: any): string | false {
     return 'Postgres connection ENOTFOUND';
   } else if (error.code === 'ECONNRESET') {
     return 'Postgres connection ECONNRESET';
+  } else if (error.code === 'CONNECTION_CLOSED') {
+    return 'Postgres connection CONNECTION_CLOSED';
+  } else if (error.code === 'CONNECTION_ENDED') {
+    return 'Postgres connection CONNECTION_ENDED';
+  } else if (error.code === 'CONNECTION_DESTROYED') {
+    return 'Postgres connection CONNECTION_DESTROYED';
+  } else if (error.code === 'CONNECTION_CONNECT_TIMEOUT') {
+    return 'Postgres connection CONNECTION_CONNECT_TIMEOUT';
   } else if (error.message) {
     const msg = (error as Error).message.toLowerCase();
     if (msg.includes('database system is starting up')) {

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -420,7 +420,7 @@ export class PgStore {
       if (blockHashValues.length === 0) {
         return {
           results: [],
-          total: 0,
+          total: block_count,
         };
       }
 

--- a/src/tests-tokens/tokens-metadata-tests.ts
+++ b/src/tests-tokens/tokens-metadata-tests.ts
@@ -14,7 +14,6 @@ import {
   DbNonFungibleTokenMetadata,
 } from '../datastore/common';
 import { startApiServer, ApiServer } from '../api/init';
-import { PoolClient } from 'pg';
 import * as fs from 'fs';
 import { EventStreamServer, startEventServer } from '../event-stream/event-server';
 import { getStacksTestnetNetwork } from '../rosetta-helpers';

--- a/src/tests/other-tests.ts
+++ b/src/tests/other-tests.ts
@@ -293,6 +293,13 @@ describe('other tests', () => {
     expect(result.body.status).toBe('ready');
   });
 
+  test('database unavailable responses', async () => {
+    // Close connection so we get an error.
+    await db.close();
+    const result = await supertest(api.server).get(`/extended/v1/block/`);
+    expect(result.body.error).toBe('The database service is unavailable');
+  });
+
   afterEach(async () => {
     await api.terminate();
     await db?.close();

--- a/src/token-metadata/tokens-processor-queue.ts
+++ b/src/token-metadata/tokens-processor-queue.ts
@@ -1,4 +1,4 @@
-import { logError, logger } from '../helpers';
+import { FoundOrNot, logError, logger } from '../helpers';
 import { Evt } from 'evt';
 import PQueue from 'p-queue';
 import { DbTokenMetadataQueueEntry, TokenMetadataUpdateInfo } from '../datastore/common';
@@ -87,7 +87,13 @@ export class TokensProcessorQueue {
   }
 
   async queueNotificationHandler(queueId: number) {
-    const queueEntry = await this.db.getTokenMetadataQueueEntry(queueId);
+    let queueEntry: FoundOrNot<DbTokenMetadataQueueEntry>;
+    try {
+      queueEntry = await this.db.getTokenMetadataQueueEntry(queueId);
+    } catch (error) {
+      logger.error(error);
+      return;
+    }
     if (queueEntry.found) {
       await this.queueHandler(queueEntry.result);
     }
@@ -105,8 +111,15 @@ export class TokensProcessorQueue {
     ) {
       return;
     }
-    const contractQuery = await this.db.getSmartContract(queueEntry.contractId);
-    if (!contractQuery.found || !contractQuery.result.abi) {
+    let abi: string;
+    try {
+      const contractQuery = await this.db.getSmartContract(queueEntry.contractId);
+      if (!contractQuery.found || !contractQuery.result.abi) {
+        return;
+      }
+      abi = contractQuery.result.abi;
+    } catch (error) {
+      logger.error(error);
       return;
     }
     logger.info(
@@ -114,7 +127,7 @@ export class TokensProcessorQueue {
     );
     this.queuedEntries.set(queueEntry.queueId, queueEntry);
 
-    const contractAbi: ClarityAbi = JSON.parse(contractQuery.result.abi);
+    const contractAbi: ClarityAbi = JSON.parse(abi);
 
     const tokenContractHandler = new TokensContractHandler({
       contractId: queueEntry.contractId,


### PR DESCRIPTION
Express has an exception handler that resolves them gracefully, but we need to make sure we catch them on any query outside of it e.g. the token metadata handlers.

This PR:
* Adds exception handlers to all queries in the token metadata handlers
* Edits the error response to a 503 when a user calls an endpoint which results in a pg connection error
* Adds the new postgres lib's connection errors to the error handlers we have in place