### PR TITLE
fix: skip migrations on read-only start

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ async function init(): Promise<void> {
         });
   const dbWriteStore = await PgWriteStore.connect({
     usageName: `write-datastore-${apiMode}`,
-    skipMigrations: false,
+    skipMigrations: apiMode === StacksApiMode.readOnly,
   });
 
   registerMempoolPromStats(dbWriteStore.eventEmitter);


### PR DESCRIPTION
Closes #1350 