### PR TITLE
fix: remove duplicate tx socket updates inside db transactions

### DIFF
--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -2022,9 +2022,6 @@ export class PgWriteStore extends PgStore {
       RETURNING tx_id
     `;
     const deletedTxs = deletedTxResults.map(r => r.tx_id);
-    for (const txId of deletedTxs) {
-      await this.notifier?.sendTx({ txId: txId });
-    }
     return { deletedTxs: deletedTxs };
   }
 


### PR DESCRIPTION
These events are already being sent outside the update transaction. Sending them here may be causing postgres transaction consistency errors in reader pods.