### PR TITLE
feat: add ENV configs for DB close and API shutdown timeouts

### DIFF
--- a/.env
+++ b/.env
@@ -9,6 +9,8 @@ PG_SSL=false
 # PG_IDLE_TIMEOUT=30
 # Max connection lifetime in seconds, defaults to 60
 # PG_MAX_LIFETIME=60
+# Seconds before force-ending running queries on connection close, defaults to 5
+# PG_CLOSE_TIMEOUT=5
 
 # Can be any string, use to specify a use case specific to a deployment
 PG_APPLICATION_NAME=stacks-blockchain-api
@@ -33,6 +35,7 @@ PG_APPLICATION_NAME=stacks-blockchain-api
 # PG_PRIMARY_SSL=
 # PG_PRIMARY_IDLE_TIMEOUT=
 # PG_PRIMARY_MAX_LIFETIME=
+# PG_PRIMARY_CLOSE_TIMEOUT=
 # The connection URI below can be used in place of the PG variables above,
 # but if enabled it must be defined without others or omitted.
 # PG_PRIMARY_CONNECTION_URI=

--- a/.env
+++ b/.env
@@ -87,6 +87,9 @@ STACKS_CORE_RPC_PORT=20443
 ## configure the chainID/networkID; testnet: 0x80000000, mainnet: 0x00000001
 STACKS_CHAIN_ID=0x00000001
 
+# Seconds to allow API components to shut down gracefully before force-killing them, defaults to 60
+# STACKS_SHUTDOWN_FORCE_KILL_TIMEOUT=60
+
 BTC_RPC_HOST=http://127.0.0.1
 BTC_RPC_PORT=18443
 BTC_RPC_USER=btc

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -69,7 +69,7 @@ import {
   StxUnlockEvent,
   TransferQueryResult,
 } from './common';
-import { connectPostgres, PgServer, PgSqlClient } from './connection';
+import { connectPostgres, getPgConnectionEnvValue, PgServer, PgSqlClient } from './connection';
 import {
   abiColumn,
   BLOCK_COLUMNS,
@@ -110,6 +110,9 @@ export class PgStore {
   readonly sql: PgSqlClient;
   readonly eventEmitter: PgStoreEventEmitter;
   readonly notifier?: PgNotifier;
+  protected get closeTimeout(): number {
+    return parseInt(getPgConnectionEnvValue('CLOSE_TIMEOUT', PgServer.default) ?? '5');
+  }
 
   constructor(sql: PgSqlClient, notifier: PgNotifier | undefined = undefined) {
     this.sql = sql;
@@ -133,7 +136,7 @@ export class PgStore {
 
   async close(): Promise<void> {
     await this.notifier?.close();
-    await this.sql.end();
+    await this.sql.end({ timeout: this.closeTimeout });
   }
 
   /**

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -954,7 +954,7 @@ export class PgStore {
     if (args.txIds.length === 0) {
       return [];
     }
-    return await this.sql.begin(async client => {
+    return await this.sql.begin('READ ONLY', async client => {
       const result = await this.sql<MempoolTxQueryResult[]>`
         SELECT ${unsafeCols(this.sql, [...MEMPOOL_TX_COLUMNS, abiColumn('mempool_txs')])}
         FROM mempool_txs
@@ -3616,7 +3616,7 @@ export class PgStore {
   }
 
   async getUnlockedAddressesAtBlock(block: DbBlock): Promise<StxUnlockEvent[]> {
-    return await this.sql.begin(async client => {
+    return await this.sql.begin('READ ONLY', async client => {
       return await this.internalGetUnlockedAccountsAtHeight(client, block);
     });
   }

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -1182,7 +1182,7 @@ export class PgWriteStore extends PgStore {
     burnchainBlockHeight: number;
     rewards: DbBurnchainReward[];
   }): Promise<void> {
-    return this.sql.begin(async sql => {
+    return await this.sql.begin(async sql => {
       const existingRewards = await sql<
         {
           reward_recipient: string;

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import { logger, logError, getOrAdd, batchIterate, isProdEnv, I32_MAX } from '../helpers';
 import {
   DbBlock,
@@ -74,7 +73,13 @@ import {
 } from './helpers';
 import { PgNotifier } from './pg-notifier';
 import { PgStore } from './pg-store';
-import { connectPostgres, PgJsonb, PgServer, PgSqlClient } from './connection';
+import {
+  connectPostgres,
+  getPgConnectionEnvValue,
+  PgJsonb,
+  PgServer,
+  PgSqlClient,
+} from './connection';
 import { runMigrations } from './migrations';
 import { getPgClientConfig } from './connection-legacy';
 import { isProcessableTokenMetadata } from '../token-metadata/helpers';
@@ -96,7 +101,9 @@ class MicroblockGapError extends Error {
  */
 export class PgWriteStore extends PgStore {
   readonly isEventReplay: boolean;
-  private cachedParameterizedInsertStrings = new Map<string, string>();
+  protected get closeTimeout(): number {
+    return parseInt(getPgConnectionEnvValue('CLOSE_TIMEOUT', PgServer.primary) ?? '5');
+  }
 
   constructor(
     sql: PgSqlClient,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -705,10 +705,11 @@ export async function resolveOrTimeout(
 ) {
   let timer: NodeJS.Timeout;
   const result = await Promise.race([
-    new Promise(async (resolve, _) => {
-      await promise;
-      clearTimeout(timer);
-      resolve(true);
+    new Promise((resolve, reject) => {
+      promise
+        .then(() => resolve(true))
+        .catch(error => reject(error))
+        .finally(() => clearTimeout(timer));
     }),
     new Promise((resolve, _) => {
       timer = setInterval(() => {

--- a/src/shutdown-handler.ts
+++ b/src/shutdown-handler.ts
@@ -19,7 +19,7 @@ async function startShutdown() {
     return;
   }
   isShuttingDown = true;
-  const timeoutMs = 5000;
+  const timeoutMs = parseInt(process.env['STACKS_SHUTDOWN_FORCE_KILL_TIMEOUT'] ?? '60') * 1000;
   let errorEncountered = false;
   for (const config of shutdownConfigs) {
     try {

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -229,6 +229,7 @@ describe('postgres datastore', () => {
         PG_APPLICATION_NAME: 'test-env-vars',
         PG_MAX_LIFETIME: '5',
         PG_IDLE_TIMEOUT: '1',
+        // Primary values:
         PG_PRIMARY_DATABASE: 'primary_db',
         PG_PRIMARY_USER: 'primary_user',
         PG_PRIMARY_PASSWORD: 'primary_password',
@@ -237,11 +238,13 @@ describe('postgres datastore', () => {
       },
       () => {
         const sql = getPostgres({ usageName: 'tests', pgServer: PgServer.primary });
+        // Primary values take precedence.
         expect(sql.options.database).toBe('primary_db');
         expect(sql.options.user).toBe('primary_user');
         expect(sql.options.pass).toBe('primary_password');
         expect(sql.options.host).toStrictEqual(['primary_host']);
         expect(sql.options.port).toStrictEqual([9999]);
+        // Other values come from defaults.
         expect(sql.options.ssl).toBe(true);
         expect(sql.options.max_lifetime).toBe(5);
         expect(sql.options.idle_timeout).toBe(1);

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -25,7 +25,7 @@ import { getBlocksWithMetadata, parseDbEvent } from '../api/controllers/db-contr
 import * as assert from 'assert';
 import { PgWriteStore } from '../datastore/pg-write-store';
 import { cycleMigrations, runMigrations } from '../datastore/migrations';
-import { getPostgres, PgSqlClient } from '../datastore/connection';
+import { getPostgres, PgServer, PgSqlClient } from '../datastore/connection';
 import { bnsNameCV, bufferToHexPrefixString, I32_MAX } from '../helpers';
 import { ChainID } from '@stacks/transactions';
 import { TestBlockBuilder } from '../test-utils/test-builders';
@@ -206,6 +206,42 @@ describe('postgres datastore', () => {
         expect(sql.options.pass).toBe('pg_password_password1');
         expect(sql.options.host).toStrictEqual(['pg_host_host1']);
         expect(sql.options.port).toStrictEqual([9876]);
+        expect(sql.options.ssl).toBe(true);
+        expect(sql.options.max_lifetime).toBe(5);
+        expect(sql.options.idle_timeout).toBe(1);
+        expect(sql.options.connection.search_path).toBe('pg_schema_schema1');
+        expect(sql.options.connection.application_name).toBe('test-env-vars:tests');
+      }
+    );
+  });
+
+  test('postgres primary env var config fallback', () => {
+    testEnvVars(
+      {
+        PG_CONNECTION_URI: undefined,
+        PG_DATABASE: 'pg_db_db1',
+        PG_USER: 'pg_user_user1',
+        PG_PASSWORD: 'pg_password_password1',
+        PG_HOST: 'pg_host_host1',
+        PG_PORT: '9876',
+        PG_SSL: 'true',
+        PG_SCHEMA: 'pg_schema_schema1',
+        PG_APPLICATION_NAME: 'test-env-vars',
+        PG_MAX_LIFETIME: '5',
+        PG_IDLE_TIMEOUT: '1',
+        PG_PRIMARY_DATABASE: 'primary_db',
+        PG_PRIMARY_USER: 'primary_user',
+        PG_PRIMARY_PASSWORD: 'primary_password',
+        PG_PRIMARY_HOST: 'primary_host',
+        PG_PRIMARY_PORT: '9999',
+      },
+      () => {
+        const sql = getPostgres({ usageName: 'tests', pgServer: PgServer.primary });
+        expect(sql.options.database).toBe('primary_db');
+        expect(sql.options.user).toBe('primary_user');
+        expect(sql.options.pass).toBe('primary_password');
+        expect(sql.options.host).toStrictEqual(['primary_host']);
+        expect(sql.options.port).toStrictEqual([9999]);
         expect(sql.options.ssl).toBe(true);
         expect(sql.options.max_lifetime).toBe(5);
         expect(sql.options.idle_timeout).toBe(1);


### PR DESCRIPTION
* Add `PG_CLOSE_TIMEOUT` and `PG_PRIMARY_CLOSE_TIMEOUT` to control seconds before killing in-flight queries when closing `PgStore` and `PgWriteStore`. Fixes #1352 
* Add `STACKS_SHUTDOWN_FORCE_KILL_TIMEOUT` to control seconds before force-killing an API component when shutting down
* Add `READ ONLY` annotation to all `BEGIN` postgres transactions on `PgStore`. No real performance upgrades from this but it is an extra security measure to avoid any modifications to the DB during read-only API execution: https://www.postgresql.org/docs/current/sql-set-transaction.html
* Fix style for `async`/`await` pg transaction use