### PR TITLE
fix: nest sql transactions correctly

### DIFF
--- a/.env
+++ b/.env
@@ -9,6 +9,8 @@ PG_SSL=false
 # PG_IDLE_TIMEOUT=30
 # Max connection lifetime in seconds, defaults to 60
 # PG_MAX_LIFETIME=60
+# Seconds before force-ending running queries on connection close, defaults to 5
+# PG_CLOSE_TIMEOUT=5
 
 # Can be any string, use to specify a use case specific to a deployment
 PG_APPLICATION_NAME=stacks-blockchain-api
@@ -33,6 +35,7 @@ PG_APPLICATION_NAME=stacks-blockchain-api
 # PG_PRIMARY_SSL=
 # PG_PRIMARY_IDLE_TIMEOUT=
 # PG_PRIMARY_MAX_LIFETIME=
+# PG_PRIMARY_CLOSE_TIMEOUT=
 # The connection URI below can be used in place of the PG variables above,
 # but if enabled it must be defined without others or omitted.
 # PG_PRIMARY_CONNECTION_URI=
@@ -83,6 +86,9 @@ STACKS_CORE_RPC_PORT=20443
 
 ## configure the chainID/networkID; testnet: 0x80000000, mainnet: 0x00000001
 STACKS_CHAIN_ID=0x00000001
+
+# Seconds to allow API components to shut down gracefully before force-killing them, defaults to 60
+# STACKS_SHUTDOWN_FORCE_KILL_TIMEOUT=60
 
 BTC_RPC_HOST=http://127.0.0.1
 BTC_RPC_PORT=18443

--- a/src/api/controllers/cache-controller.ts
+++ b/src/api/controllers/cache-controller.ts
@@ -250,7 +250,7 @@ async function calculateETag(
   switch (etagType) {
     case ETagType.chainTip:
       try {
-        const chainTip = await db.getUnanchoredChainTip();
+        const chainTip = await db.getUnanchoredChainTip(db.sql);
         if (!chainTip.found) {
           // This should never happen unless the API is serving requests before it has synced any
           // blocks.
@@ -264,7 +264,7 @@ async function calculateETag(
 
     case ETagType.mempool:
       try {
-        const digest = await db.getMempoolTxDigest();
+        const digest = await db.getMempoolTxDigest(db.sql);
         if (!digest.found) {
           // This should never happen unless the API is serving requests before it has synced any
           // blocks.
@@ -287,7 +287,7 @@ async function calculateETag(
         if (normalizedTxId === false) {
           return ETAG_EMPTY;
         }
-        const status = await db.getTxStatus(normalizedTxId);
+        const status = await db.getTxStatus(db.sql, normalizedTxId);
         if (!status.found) {
           return ETAG_EMPTY;
         }

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -63,7 +63,7 @@ import { unwrapOptional, FoundOrNot, logger, unixEpochToIso, EMPTY_HASH_256 } fr
 import { serializePostCondition, serializePostConditionMode } from '../serializers/post-conditions';
 import { getOperations, parseTransactionMemo } from '../../rosetta-helpers';
 import { PgStore } from '../../datastore/pg-store';
-import { PgSqlClient, sqlTransaction } from 'src/datastore/connection';
+import { PgSqlClient, sqlTransaction } from '../../datastore/connection';
 
 export function parseTxTypeStrings(values: string[]): TransactionType[] {
   return values.map(v => {

--- a/src/api/routes/block.ts
+++ b/src/api/routes/block.ts
@@ -1,9 +1,7 @@
 import * as express from 'express';
-import * as Bluebird from 'bluebird';
 import { BlockListResponse } from '@stacks/stacks-blockchain-api-types';
-
 import { getBlockFromDataStore, getBlocksWithMetadata } from '../controllers/db-controller';
-import { timeout, waiter, has0xPrefix } from '../../helpers';
+import { has0xPrefix } from '../../helpers';
 import { InvalidRequestError, InvalidRequestErrorType } from '../../errors';
 import { parseLimitQuery, parsePagingQueryInput } from '../pagination';
 import { getBlockHeightPathParam, validateRequestHexInput } from '../query-helpers';
@@ -28,7 +26,7 @@ export function createBlockRouter(db: PgStore): express.Router {
       const limit = parseBlockQueryLimit(req.query.limit ?? 20);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
 
-      const { results, total } = await getBlocksWithMetadata({ offset, limit, db });
+      const { results, total } = await getBlocksWithMetadata(db.sql, { offset, limit, db });
       setETagCacheHeaders(res);
       // TODO: block schema validation
       const response: BlockListResponse = { limit, offset, total, results };
@@ -41,7 +39,7 @@ export function createBlockRouter(db: PgStore): express.Router {
     cacheHandler,
     asyncHandler(async (req, res, next) => {
       const height = getBlockHeightPathParam(req, res, next);
-      const block = await getBlockFromDataStore({ blockIdentifer: { height }, db });
+      const block = await getBlockFromDataStore(db.sql, { blockIdentifer: { height }, db });
       if (!block.found) {
         res.status(404).json({ error: `cannot find block by height ${height}` });
         return;
@@ -69,7 +67,10 @@ export function createBlockRouter(db: PgStore): express.Router {
           InvalidRequestErrorType.invalid_param
         );
       }
-      const block = await getBlockFromDataStore({ blockIdentifer: { burnBlockHeight }, db });
+      const block = await getBlockFromDataStore(db.sql, {
+        blockIdentifer: { burnBlockHeight },
+        db,
+      });
       if (!block.found) {
         res.status(404).json({ error: `cannot find block by height ${burnBlockHeight}` });
         return;
@@ -91,7 +92,7 @@ export function createBlockRouter(db: PgStore): express.Router {
       }
       validateRequestHexInput(hash);
 
-      const block = await getBlockFromDataStore({ blockIdentifer: { hash }, db });
+      const block = await getBlockFromDataStore(db.sql, { blockIdentifer: { hash }, db });
       if (!block.found) {
         res.status(404).json({ error: `cannot find block by hash ${hash}` });
         return;
@@ -112,7 +113,7 @@ export function createBlockRouter(db: PgStore): express.Router {
         return res.redirect('/extended/v1/block/by_burn_block_hash/0x' + burnBlockHash);
       }
 
-      const block = await getBlockFromDataStore({ blockIdentifer: { burnBlockHash }, db });
+      const block = await getBlockFromDataStore(db.sql, { blockIdentifer: { burnBlockHash }, db });
       if (!block.found) {
         res.status(404).json({ error: `cannot find block by burn block hash ${burnBlockHash}` });
         return;

--- a/src/api/routes/bns/addresses.ts
+++ b/src/api/routes/bns/addresses.ts
@@ -25,7 +25,7 @@ export function createBnsAddressesRouter(db: PgStore, chainId: ChainID): express
         return;
       }
       const includeUnanchored = isUnanchoredRequest(req, res, next);
-      const namesByAddress = await db.getNamesByAddressList({
+      const namesByAddress = await db.getNamesByAddressList(db.sql, {
         address: address,
         includeUnanchored,
         chainId,

--- a/src/api/routes/bns/namespaces.ts
+++ b/src/api/routes/bns/namespaces.ts
@@ -9,7 +9,7 @@ import {
   getETagCacheHandler,
   setETagCacheHeaders,
 } from '../../../api/controllers/cache-controller';
-import { sqlTransaction } from 'src/datastore/connection';
+import { sqlTransaction } from '../../../datastore/connection';
 
 export function createBnsNamespacesRouter(db: PgStore): express.Router {
   const router = express.Router();

--- a/src/api/routes/burnchain.ts
+++ b/src/api/routes/burnchain.ts
@@ -29,7 +29,7 @@ export function createBurnchainRouter(db: PgStore): express.Router {
       const limit = parseQueryLimit(req.query.limit ?? 96);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
 
-      const queryResults = await db.getBurnchainRewardSlotHolders({ offset, limit });
+      const queryResults = await db.getBurnchainRewardSlotHolders(db.sql, { offset, limit });
       const results = queryResults.slotHolders.map(r => {
         const slotHolder: BurnchainRewardSlotHolder = {
           canonical: r.canonical,
@@ -74,7 +74,7 @@ export function createBurnchainRouter(db: PgStore): express.Router {
         );
       }
 
-      const queryResults = await db.getBurnchainRewardSlotHolders({
+      const queryResults = await db.getBurnchainRewardSlotHolders(db.sql, {
         offset,
         limit,
         burnchainAddress,
@@ -105,7 +105,7 @@ export function createBurnchainRouter(db: PgStore): express.Router {
       const limit = parseQueryLimit(req.query.limit ?? 96);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
 
-      const queryResults = await db.getBurnchainRewards({ offset, limit });
+      const queryResults = await db.getBurnchainRewards(db.sql, { offset, limit });
       const results = queryResults.map(r => {
         const reward: BurnchainReward = {
           canonical: r.canonical,
@@ -148,7 +148,7 @@ export function createBurnchainRouter(db: PgStore): express.Router {
         );
       }
 
-      const queryResults = await db.getBurnchainRewards({
+      const queryResults = await db.getBurnchainRewards(db.sql, {
         burnchainRecipient: burnchainAddress,
         offset,
         limit,
@@ -193,7 +193,7 @@ export function createBurnchainRouter(db: PgStore): express.Router {
         );
       }
 
-      const queryResults = await db.getBurnchainRewardsTotal(burnchainAddress);
+      const queryResults = await db.getBurnchainRewardsTotal(db.sql, burnchainAddress);
       const response: BurnchainRewardsTotal = {
         reward_recipient: queryResults.reward_recipient,
         reward_amount: queryResults.reward_amount.toString(),

--- a/src/api/routes/contract.ts
+++ b/src/api/routes/contract.ts
@@ -20,7 +20,7 @@ export function createContractRouter(db: PgStore): express.Router {
       const trait_abi = parseTraitAbi(req, res, next);
       const limit = parseContractEventsQueryLimit(req.query.limit ?? 20);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
-      const smartContracts = await db.getSmartContractByTrait({
+      const smartContracts = await db.getSmartContractByTrait(db.sql, {
         trait: trait_abi,
         limit,
         offset,
@@ -41,7 +41,7 @@ export function createContractRouter(db: PgStore): express.Router {
     '/:contract_id',
     asyncHandler(async (req, res) => {
       const { contract_id } = req.params;
-      const contractQuery = await db.getSmartContract(contract_id);
+      const contractQuery = await db.getSmartContract(db.sql, contract_id);
       if (!contractQuery.found) {
         res.status(404).json({ error: `cannot find contract by ID ${contract_id}` });
         return;
@@ -60,7 +60,7 @@ export function createContractRouter(db: PgStore): express.Router {
       const { contract_id } = req.params;
       const limit = parseContractEventsQueryLimit(req.query.limit ?? 20);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
-      const eventsQuery = await db.getSmartContractEvents({
+      const eventsQuery = await db.getSmartContractEvents(db.sql, {
         contractId: contract_id,
         limit,
         offset,

--- a/src/api/routes/core-node-rpc-proxy.ts
+++ b/src/api/routes/core-node-rpc-proxy.ts
@@ -149,7 +149,7 @@ export function createCoreNodeRpcProxyRouter(db: PgStore): express.Router {
    */
   async function logTxBroadcast(response: string): Promise<void> {
     try {
-      const blockHeightQuery = await db.getCurrentBlockHeight();
+      const blockHeightQuery = await db.getCurrentBlockHeight(db.sql);
       if (!blockHeightQuery.found) {
         return;
       }

--- a/src/api/routes/debug.ts
+++ b/src/api/routes/debug.ts
@@ -437,7 +437,7 @@ export function createDebugRouter(db: PgStore): express.Router {
       if (Number.isInteger(Number.parseInt(nonce))) {
         txNonce = Number.parseInt(nonce);
       } else {
-        const latestNonces = await db.getAddressNonces({ stxAddress: senderAddress });
+        const latestNonces = await db.getAddressNonces(db.sql, { stxAddress: senderAddress });
         txNonce = latestNonces.possibleNextNonce;
       }
 
@@ -750,7 +750,7 @@ export function createDebugRouter(db: PgStore): express.Router {
     '/broadcast/contract-call/:contract_id',
     asyncHandler(async (req, res) => {
       const { contract_id } = req.params;
-      const dbContractQuery = await db.getSmartContract(contract_id);
+      const dbContractQuery = await db.getSmartContract(db.sql, contract_id);
       if (!dbContractQuery.found) {
         res.status(404).json({ error: `cannot find contract by ID ${contract_id}` });
         return;
@@ -800,7 +800,7 @@ export function createDebugRouter(db: PgStore): express.Router {
     '/broadcast/contract-call/:contract_id',
     asyncHandler(async (req, res) => {
       const contractId: string = req.params['contract_id'];
-      const dbContractQuery = await db.getSmartContract(contractId);
+      const dbContractQuery = await db.getSmartContract(db.sql, contractId);
       if (!dbContractQuery.found) {
         res.status(404).json({ error: `could not find contract by ID ${contractId}` });
         return;

--- a/src/api/routes/faucets.ts
+++ b/src/api/routes/faucets.ts
@@ -77,7 +77,7 @@ export function createFaucetRouter(db: PgWriteStore): express.Router {
         // Guard condition: requests are limited to 5 times per 5 minutes.
         // Only based on address for now, but we're keeping the IP in case
         // we want to escalate and implement a per IP policy
-        const lastRequests = await db.getBTCFaucetRequests(address);
+        const lastRequests = await db.getBTCFaucetRequests(db.sql, address);
         const now = Date.now();
         const window = 5 * 60 * 1000; // 5 minutes
         const requestsInWindow = lastRequests.results
@@ -133,7 +133,7 @@ export function createFaucetRouter(db: PgWriteStore): express.Router {
       await stxFaucetRequestQueue.add(async () => {
         const address: string = req.query.address || req.body.address;
         const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
-        const lastRequests = await db.getSTXFaucetRequests(address);
+        const lastRequests = await db.getSTXFaucetRequests(db.sql, address);
 
         const privateKey = process.env.FAUCET_PRIVATE_KEY || testnetKeys[0].secretKey;
 

--- a/src/api/routes/microblock.ts
+++ b/src/api/routes/microblock.ts
@@ -30,7 +30,7 @@ export function createMicroblockRouter(db: PgStore): express.Router {
     asyncHandler(async (req, res) => {
       const limit = parseMicroblockQueryLimit(req.query.limit ?? 20);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
-      const query = await getMicroblocksFromDataStore({ db, offset, limit });
+      const query = await getMicroblocksFromDataStore(db.sql, { db, offset, limit });
       const response: MicroblockListResponse = {
         limit,
         offset,
@@ -54,7 +54,7 @@ export function createMicroblockRouter(db: PgStore): express.Router {
 
       validateRequestHexInput(hash);
 
-      const block = await getMicroblockFromDataStore({ db, microblockHash: hash });
+      const block = await getMicroblockFromDataStore(db.sql, { db, microblockHash: hash });
       if (!block.found) {
         res.status(404).json({ error: `cannot find microblock by hash ${hash}` });
         return;
@@ -69,7 +69,7 @@ export function createMicroblockRouter(db: PgStore): express.Router {
     '/unanchored/txs',
     asyncHandler(async (req, res) => {
       // TODO: implement pagination for /unanchored/txs
-      const txs = await getUnanchoredTxsFromDataStore(db);
+      const txs = await getUnanchoredTxsFromDataStore(db.sql, db);
       const response: UnanchoredTransactionListResponse = {
         total: txs.length,
         results: txs,

--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -4,13 +4,11 @@ import { DbBlock } from '../../../datastore/common';
 import { PgStore } from '../../../datastore/pg-store';
 import { has0xPrefix, FoundOrNot } from '../../../helpers';
 import {
-  NetworkIdentifier,
   RosettaAccount,
   RosettaBlockIdentifier,
   RosettaAccountBalanceResponse,
   RosettaSubAccount,
   AddressTokenOfferingLocked,
-  AddressUnlockSchedule,
   RosettaAmount,
 } from '@stacks/stacks-blockchain-api-types';
 import { RosettaErrors, RosettaConstants, RosettaErrorsTypes } from '../../rosetta-constants';
@@ -18,6 +16,7 @@ import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../ros
 import { ChainID } from '@stacks/transactions';
 import { getValidatedFtMetadata } from '../../../rosetta-helpers';
 import { isFtMetadataEnabled } from '../../../token-metadata/helpers';
+import { sqlTransaction } from '../../../datastore/connection';
 
 export function createRosettaAccountRouter(db: PgStore, chainId: ChainID): express.Router {
   const router = express.Router();
@@ -35,128 +34,133 @@ export function createRosettaAccountRouter(db: PgStore, chainId: ChainID): expre
       const accountIdentifier: RosettaAccount = req.body.account_identifier;
       const subAccountIdentifier: RosettaSubAccount = req.body.account_identifier.sub_account;
       const blockIdentifier: RosettaBlockIdentifier = req.body.block_identifier;
-      let blockQuery: FoundOrNot<DbBlock>;
-      let blockHash: string = '0x';
 
-      // we need to return the block height/hash in the response, so we
-      // need to fetch the block first.
-      if (blockIdentifier === undefined) {
-        blockQuery = await db.getCurrentBlock();
-      } else if (blockIdentifier.index > 0) {
-        blockQuery = await db.getBlock({ height: blockIdentifier.index });
-      } else if (blockIdentifier.hash !== undefined) {
-        blockHash = blockIdentifier.hash;
-        if (!has0xPrefix(blockHash)) {
-          blockHash = '0x' + blockHash;
+      await sqlTransaction(db.sql, async sql => {
+        let blockQuery: FoundOrNot<DbBlock>;
+        let blockHash: string = '0x';
+        // we need to return the block height/hash in the response, so we
+        // need to fetch the block first.
+        if (blockIdentifier === undefined) {
+          blockQuery = await db.getCurrentBlock(sql);
+        } else if (blockIdentifier.index > 0) {
+          blockQuery = await db.getBlock(sql, { height: blockIdentifier.index });
+        } else if (blockIdentifier.hash !== undefined) {
+          blockHash = blockIdentifier.hash;
+          if (!has0xPrefix(blockHash)) {
+            blockHash = '0x' + blockHash;
+          }
+          blockQuery = await db.getBlock(sql, { hash: blockHash });
+        } else {
+          throw RosettaErrors[RosettaErrorsTypes.invalidBlockIdentifier];
         }
-        blockQuery = await db.getBlock({ hash: blockHash });
-      } else {
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidBlockIdentifier]);
-        return;
-      }
 
-      if (!blockQuery.found) {
-        res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
-        return;
-      }
-
-      const block = blockQuery.result;
-
-      if (blockIdentifier?.hash !== undefined && block.block_hash !== blockIdentifier.hash) {
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidBlockHash]);
-        return;
-      }
-
-      const stxBalance = await db.getStxBalanceAtBlock(
-        accountIdentifier.address,
-        block.block_height
-      );
-      // return spendable balance (liquid) if no sub-account is specified
-      let balance = (stxBalance.balance - stxBalance.locked).toString();
-
-      const accountNonceQuery = await db.getAddressNonceAtBlock({
-        stxAddress: accountIdentifier.address,
-        blockIdentifier: { height: block.block_height },
-      });
-      const sequenceNumber = accountNonceQuery.found
-        ? accountNonceQuery.result.possibleNextNonce
-        : 0;
-
-      const extra_metadata: any = {};
-
-      if (subAccountIdentifier !== undefined) {
-        switch (subAccountIdentifier.address) {
-          case RosettaConstants.StackedBalance:
-            const lockedBalance = stxBalance.locked;
-            balance = lockedBalance.toString();
-            break;
-          case RosettaConstants.SpendableBalance:
-            const spendableBalance = stxBalance.balance - stxBalance.locked;
-            balance = spendableBalance.toString();
-            break;
-          case RosettaConstants.VestingLockedBalance:
-          case RosettaConstants.VestingUnlockedBalance:
-            const stxVesting = await db.getTokenOfferingLocked(
-              accountIdentifier.address,
-              block.block_height
-            );
-            if (stxVesting.found) {
-              const vestingInfo = getVestingInfo(stxVesting.result);
-              balance = vestingInfo[subAccountIdentifier.address].toString();
-              extra_metadata[RosettaConstants.VestingSchedule] =
-                vestingInfo[RosettaConstants.VestingSchedule];
-            } else {
-              balance = '0';
-            }
-            break;
-          default:
-            res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidSubAccount]);
-            return;
+        if (!blockQuery.found) {
+          throw RosettaErrors[RosettaErrorsTypes.blockNotFound];
         }
-      }
-      const balances: RosettaAmount[] = [
-        {
-          value: balance,
-          currency: {
-            symbol: RosettaConstants.symbol,
-            decimals: RosettaConstants.decimals,
-          },
-          metadata: Object.keys(extra_metadata).length > 0 ? extra_metadata : undefined,
-        },
-      ];
 
-      // Add Fungible Token balances.
-      if (isFtMetadataEnabled()) {
-        const ftBalances = await db.getFungibleTokenBalances({
+        const block = blockQuery.result;
+
+        if (blockIdentifier?.hash !== undefined && block.block_hash !== blockIdentifier.hash) {
+          throw RosettaErrors[RosettaErrorsTypes.invalidBlockHash];
+        }
+
+        const stxBalance = await db.getStxBalanceAtBlock(
+          sql,
+          accountIdentifier.address,
+          block.block_height
+        );
+        // return spendable balance (liquid) if no sub-account is specified
+        let balance = (stxBalance.balance - stxBalance.locked).toString();
+
+        const accountNonceQuery = await db.getAddressNonceAtBlock(sql, {
           stxAddress: accountIdentifier.address,
-          untilBlock: block.block_height,
+          blockIdentifier: { height: block.block_height },
         });
-        for (const [ftAssetIdentifier, ftBalance] of ftBalances) {
-          const ftMetadata = await getValidatedFtMetadata(db, ftAssetIdentifier);
-          if (ftMetadata) {
-            balances.push({
-              value: ftBalance.balance.toString(),
-              currency: {
-                symbol: ftMetadata.symbol,
-                decimals: ftMetadata.decimals,
-              },
-            });
+        const sequenceNumber = accountNonceQuery.found
+          ? accountNonceQuery.result.possibleNextNonce
+          : 0;
+
+        const extra_metadata: any = {};
+
+        if (subAccountIdentifier !== undefined) {
+          switch (subAccountIdentifier.address) {
+            case RosettaConstants.StackedBalance:
+              const lockedBalance = stxBalance.locked;
+              balance = lockedBalance.toString();
+              break;
+            case RosettaConstants.SpendableBalance:
+              const spendableBalance = stxBalance.balance - stxBalance.locked;
+              balance = spendableBalance.toString();
+              break;
+            case RosettaConstants.VestingLockedBalance:
+            case RosettaConstants.VestingUnlockedBalance:
+              const stxVesting = await db.getTokenOfferingLocked(
+                sql,
+                accountIdentifier.address,
+                block.block_height
+              );
+              if (stxVesting.found) {
+                const vestingInfo = getVestingInfo(stxVesting.result);
+                balance = vestingInfo[subAccountIdentifier.address].toString();
+                extra_metadata[RosettaConstants.VestingSchedule] =
+                  vestingInfo[RosettaConstants.VestingSchedule];
+              } else {
+                balance = '0';
+              }
+              break;
+            default:
+              throw RosettaErrors[RosettaErrorsTypes.invalidSubAccount];
           }
         }
-      }
+        const balances: RosettaAmount[] = [
+          {
+            value: balance,
+            currency: {
+              symbol: RosettaConstants.symbol,
+              decimals: RosettaConstants.decimals,
+            },
+            metadata: Object.keys(extra_metadata).length > 0 ? extra_metadata : undefined,
+          },
+        ];
 
-      const response: RosettaAccountBalanceResponse = {
-        block_identifier: {
-          index: block.block_height,
-          hash: block.block_hash,
-        },
-        balances: balances,
-        metadata: {
-          sequence_number: sequenceNumber,
-        },
-      };
+        // Add Fungible Token balances.
+        if (isFtMetadataEnabled()) {
+          const ftBalances = await db.getFungibleTokenBalances(sql, {
+            stxAddress: accountIdentifier.address,
+            untilBlock: block.block_height,
+          });
+          for (const [ftAssetIdentifier, ftBalance] of ftBalances) {
+            const ftMetadata = await getValidatedFtMetadata(sql, db, ftAssetIdentifier);
+            if (ftMetadata) {
+              balances.push({
+                value: ftBalance.balance.toString(),
+                currency: {
+                  symbol: ftMetadata.symbol,
+                  decimals: ftMetadata.decimals,
+                },
+              });
+            }
+          }
+        }
 
-      res.json(response);
+        const response: RosettaAccountBalanceResponse = {
+          block_identifier: {
+            index: block.block_height,
+            hash: block.block_hash,
+          },
+          balances: balances,
+          metadata: {
+            sequence_number: sequenceNumber,
+          },
+        };
+        return response;
+      })
+        .catch(error => {
+          res.status(400).json(error);
+        })
+        .then(response => {
+          res.json(response);
+        });
     })
   );
 

--- a/src/api/routes/rosetta/block.ts
+++ b/src/api/routes/rosetta/block.ts
@@ -30,7 +30,7 @@ export function createRosettaBlockRouter(db: PgStore, chainId: ChainID): express
         block_hash = '0x' + block_hash;
       }
 
-      const block = await getRosettaBlockFromDataStore(db, true, block_hash, index);
+      const block = await getRosettaBlockFromDataStore(db.sql, db, true, block_hash, index);
 
       if (!block.found) {
         res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
@@ -57,7 +57,7 @@ export function createRosettaBlockRouter(db: PgStore, chainId: ChainID): express
         tx_hash = '0x' + tx_hash;
       }
 
-      const transaction = await getRosettaTransactionFromDataStore(tx_hash, db);
+      const transaction = await getRosettaTransactionFromDataStore(db.sql, tx_hash, db);
       if (!transaction.found) {
         res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotFound]);
         return;

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -392,7 +392,7 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
       const nonce = accountInfo.nonce;
 
       let recentBlockHash = undefined;
-      const blockQuery: FoundOrNot<DbBlock> = await db.getCurrentBlock();
+      const blockQuery: FoundOrNot<DbBlock> = await db.getCurrentBlock(db.sql);
       if (blockQuery.found) {
         recentBlockHash = blockQuery.result.block_hash;
       }
@@ -514,7 +514,7 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
       }
       try {
         const baseTx = rawTxToBaseTx(inputTx);
-        const operations = await getOperations(baseTx, db);
+        const operations = await getOperations(db.sql, baseTx, db);
         const txMemo = parseTransactionMemo(baseTx);
         let response: RosettaConstructionParseResponse;
         if (signed) {

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -535,6 +535,7 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
         res.json(response);
       } catch (error) {
         console.error(error);
+        res.status(400).json(RosettaErrors[RosettaErrorsTypes.unknownError]);
       }
     })
   );

--- a/src/api/routes/rosetta/mempool.ts
+++ b/src/api/routes/rosetta/mempool.ts
@@ -12,6 +12,7 @@ import {
 import { getOperations, parseTransactionMemo } from '../../../rosetta-helpers';
 import { RosettaErrors, RosettaErrorsTypes } from '../../rosetta-constants';
 import { ChainID } from '@stacks/transactions';
+import { sqlTransaction } from '../../../datastore/connection';
 
 const MAX_MEMPOOL_TXS_PER_REQUEST = 200;
 const parseMempoolTxQueryLimit = parseLimitQuery({
@@ -32,7 +33,7 @@ export function createRosettaMempoolRouter(db: PgStore, chainId: ChainID): expre
         return;
       }
 
-      const { results: txResults } = await db.getMempoolTxList({
+      const { results: txResults } = await db.getMempoolTxList(db.sql, {
         limit: Number.MAX_SAFE_INTEGER,
         offset: 0,
         includeUnanchored: false,
@@ -62,28 +63,38 @@ export function createRosettaMempoolRouter(db: PgStore, chainId: ChainID): expre
       if (!has0xPrefix(tx_id)) {
         tx_id = '0x' + tx_id;
       }
-      const mempoolTxQuery = await db.getMempoolTx({ txId: tx_id, includeUnanchored: false });
+      await sqlTransaction(db.sql, async sql => {
+        const mempoolTxQuery = await db.getMempoolTx(sql, {
+          txId: tx_id,
+          includeUnanchored: false,
+        });
 
-      if (!mempoolTxQuery.found) {
-        res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotFound]);
-        return;
-      }
+        if (!mempoolTxQuery.found) {
+          throw RosettaErrors[RosettaErrorsTypes.transactionNotFound];
+        }
 
-      const operations = await getOperations(mempoolTxQuery.result, db);
-      const txMemo = parseTransactionMemo(mempoolTxQuery.result);
-      const transaction: RosettaTransaction = {
-        transaction_identifier: { hash: tx_id },
-        operations: operations,
-      };
-      if (txMemo) {
-        transaction.metadata = {
-          memo: txMemo,
+        const operations = await getOperations(sql, mempoolTxQuery.result, db);
+        const txMemo = parseTransactionMemo(mempoolTxQuery.result);
+        const transaction: RosettaTransaction = {
+          transaction_identifier: { hash: tx_id },
+          operations: operations,
         };
-      }
-      const result: RosettaMempoolTransactionResponse = {
-        transaction: transaction,
-      };
-      res.json(result);
+        if (txMemo) {
+          transaction.metadata = {
+            memo: txMemo,
+          };
+        }
+        const result: RosettaMempoolTransactionResponse = {
+          transaction: transaction,
+        };
+        return result;
+      })
+        .then(result => {
+          res.json(result);
+        })
+        .catch(error => {
+          res.status(400).json(error);
+        });
     })
   );
 

--- a/src/api/routes/rosetta/network.ts
+++ b/src/api/routes/rosetta/network.ts
@@ -22,7 +22,7 @@ import {
 import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../rosetta-validate';
 import { ChainID } from '@stacks/transactions';
 import { PgStore } from '../../../datastore/pg-store';
-import { sqlTransaction } from 'src/datastore/connection';
+import { sqlTransaction } from '../../../datastore/connection';
 
 export function createRosettaNetworkRouter(db: PgStore, chainId: ChainID): express.Router {
   const router = express.Router();

--- a/src/api/routes/status.ts
+++ b/src/api/routes/status.ts
@@ -1,7 +1,5 @@
 import * as express from 'express';
-import * as fs from 'fs';
 import { ServerStatusResponse } from '@stacks/stacks-blockchain-api-types';
-import { logger } from '../../helpers';
 import { getETagCacheHandler, setETagCacheHeaders } from '../controllers/cache-controller';
 import { PgStore } from '../../datastore/pg-store';
 import { API_VERSION } from '../init';
@@ -15,7 +13,7 @@ export function createStatusRouter(db: PgStore): express.Router {
         server_version: `stacks-blockchain-api ${API_VERSION.tag} (${API_VERSION.branch}:${API_VERSION.commit})`,
         status: 'ready',
       };
-      const chainTip = await db.getUnanchoredChainTip();
+      const chainTip = await db.getUnanchoredChainTip(db.sql);
       if (chainTip.found) {
         response.chain_tip = {
           block_height: chainTip.result.blockHeight,

--- a/src/api/routes/stx-supply.ts
+++ b/src/api/routes/stx-supply.ts
@@ -28,7 +28,7 @@ export function createStxSupplyRouter(db: PgStore): express.Router {
     unlockedStx: string;
     blockHeight: number;
   }> {
-    const { stx: unlockedSupply, blockHeight } = await db.getUnlockedStxSupply(args);
+    const { stx: unlockedSupply, blockHeight } = await db.getUnlockedStxSupply(db.sql, args);
     const totalMicroStx = new BigNumber(TOTAL_STACKS).shiftedBy(STACKS_DECIMAL_PLACES);
     const unlockedPercent = new BigNumber(unlockedSupply.toString())
       .div(totalMicroStx)

--- a/src/api/routes/ws/web-socket-transmitter.ts
+++ b/src/api/routes/ws/web-socket-transmitter.ts
@@ -13,7 +13,7 @@ import { SocketIOChannel } from './channels/socket-io-channel';
 import { WsRpcChannel } from './channels/ws-rpc-channel';
 import { parseNftEvent } from '../../../datastore/helpers';
 import { logger } from '../../../helpers';
-import { sqlTransaction } from 'src/datastore/connection';
+import { sqlTransaction } from '../../../datastore/connection';
 
 /**
  * This object matches real time update `WebSocketTopics` subscriptions with internal

--- a/src/api/routes/ws/web-socket-transmitter.ts
+++ b/src/api/routes/ws/web-socket-transmitter.ts
@@ -13,6 +13,7 @@ import { SocketIOChannel } from './channels/socket-io-channel';
 import { WsRpcChannel } from './channels/ws-rpc-channel';
 import { parseNftEvent } from '../../../datastore/helpers';
 import { logger } from '../../../helpers';
+import { sqlTransaction } from 'src/datastore/connection';
 
 /**
  * This object matches real time update `WebSocketTopics` subscriptions with internal
@@ -69,7 +70,7 @@ export class WebSocketTransmitter {
   private async blockUpdate(blockHash: string) {
     if (this.channels.find(c => c.hasListeners('block'))) {
       try {
-        const blockQuery = await getBlockFromDataStore({
+        const blockQuery = await getBlockFromDataStore(this.db.sql, {
           blockIdentifer: { hash: blockHash },
           db: this.db,
         });
@@ -85,7 +86,7 @@ export class WebSocketTransmitter {
   private async microblockUpdate(microblockHash: string) {
     if (this.channels.find(c => c.hasListeners('microblock'))) {
       try {
-        const microblockQuery = await getMicroblockFromDataStore({
+        const microblockQuery = await getMicroblockFromDataStore(this.db.sql, {
           db: this.db,
           microblockHash: microblockHash,
         });
@@ -101,7 +102,7 @@ export class WebSocketTransmitter {
   private async txUpdate(txId: string) {
     if (this.channels.find(c => c.hasListeners('mempool'))) {
       try {
-        const mempoolTxs = await getMempoolTxsFromDataStore(this.db, {
+        const mempoolTxs = await getMempoolTxsFromDataStore(this.db.sql, this.db, {
           txIds: [txId],
           includeUnanchored: true,
         });
@@ -115,22 +116,27 @@ export class WebSocketTransmitter {
 
     if (this.channels.find(c => c.hasListeners('transaction', txId))) {
       try {
-        // Look at the `txs` table first so we always prefer the confirmed transaction.
-        const txQuery = await getTxFromDataStore(this.db, {
-          txId: txId,
-          includeUnanchored: true,
-        });
-        if (txQuery.found) {
-          this.channels.forEach(c => c.send('transaction', txQuery.result));
-        } else {
-          // Tx is not yet confirmed, look at `mempool_txs`.
-          const mempoolTxs = await getMempoolTxsFromDataStore(this.db, {
-            txIds: [txId],
+        const result = await sqlTransaction(this.db.sql, async sql => {
+          // Look at the `txs` table first so we always prefer the confirmed transaction.
+          const txQuery = await getTxFromDataStore(sql, this.db, {
+            txId: txId,
             includeUnanchored: true,
           });
-          if (mempoolTxs.length > 0) {
-            this.channels.forEach(c => c.send('transaction', mempoolTxs[0]));
+          if (txQuery.found) {
+            return txQuery.result;
+          } else {
+            // Tx is not yet confirmed, look at `mempool_txs`.
+            const mempoolTxs = await getMempoolTxsFromDataStore(sql, this.db, {
+              txIds: [txId],
+              includeUnanchored: true,
+            });
+            if (mempoolTxs.length > 0) {
+              return mempoolTxs[0];
+            }
           }
+        });
+        if (result) {
+          this.channels.forEach(c => c.send('transaction', result));
         }
       } catch (error) {
         logger.error(error);
@@ -140,7 +146,7 @@ export class WebSocketTransmitter {
 
   private async nftEventUpdate(txId: string, eventIndex: number) {
     try {
-      const nftEvent = await this.db.getNftEvent({ txId, eventIndex });
+      const nftEvent = await this.db.getNftEvent(this.db.sql, { txId, eventIndex });
       if (!nftEvent.found) {
         return;
       }
@@ -165,7 +171,7 @@ export class WebSocketTransmitter {
   private async addressUpdate(address: string, blockHeight: number) {
     if (this.channels.find(c => c.hasListeners('principalTransactions', address))) {
       try {
-        const dbTxsQuery = await this.db.getAddressTxsWithAssetTransfers({
+        const dbTxsQuery = await this.db.getAddressTxsWithAssetTransfers(this.db.sql, {
           stxAddress: address,
           blockHeight: blockHeight,
           atSingleBlock: true,
@@ -197,23 +203,30 @@ export class WebSocketTransmitter {
 
     if (this.channels.find(c => c.hasListeners('principalStxBalance', address))) {
       try {
-        const stxBalanceResult = await this.db.getStxBalanceAtBlock(address, blockHeight);
-        const tokenOfferingLocked = await this.db.getTokenOfferingLocked(address, blockHeight);
-        const balance: AddressStxBalanceResponse = {
-          balance: stxBalanceResult.balance.toString(),
-          total_sent: stxBalanceResult.totalSent.toString(),
-          total_received: stxBalanceResult.totalReceived.toString(),
-          total_fees_sent: stxBalanceResult.totalFeesSent.toString(),
-          total_miner_rewards_received: stxBalanceResult.totalMinerRewardsReceived.toString(),
-          lock_tx_id: stxBalanceResult.lockTxId,
-          locked: stxBalanceResult.locked.toString(),
-          lock_height: stxBalanceResult.lockHeight,
-          burnchain_lock_height: stxBalanceResult.burnchainLockHeight,
-          burnchain_unlock_height: stxBalanceResult.burnchainUnlockHeight,
-        };
-        if (tokenOfferingLocked.found) {
-          balance.token_offering_locked = tokenOfferingLocked.result;
-        }
+        const balance = await sqlTransaction(this.db.sql, async sql => {
+          const stxBalanceResult = await this.db.getStxBalanceAtBlock(sql, address, blockHeight);
+          const tokenOfferingLocked = await this.db.getTokenOfferingLocked(
+            sql,
+            address,
+            blockHeight
+          );
+          const balance: AddressStxBalanceResponse = {
+            balance: stxBalanceResult.balance.toString(),
+            total_sent: stxBalanceResult.totalSent.toString(),
+            total_received: stxBalanceResult.totalReceived.toString(),
+            total_fees_sent: stxBalanceResult.totalFeesSent.toString(),
+            total_miner_rewards_received: stxBalanceResult.totalMinerRewardsReceived.toString(),
+            lock_tx_id: stxBalanceResult.lockTxId,
+            locked: stxBalanceResult.locked.toString(),
+            lock_height: stxBalanceResult.lockHeight,
+            burnchain_lock_height: stxBalanceResult.burnchainLockHeight,
+            burnchain_unlock_height: stxBalanceResult.burnchainUnlockHeight,
+          };
+          if (tokenOfferingLocked.found) {
+            balance.token_offering_locked = tokenOfferingLocked.result;
+          }
+          return balance;
+        });
         this.channels.forEach(c => c.send('principalStxBalance', address, balance));
       } catch (error) {
         logger.error(error);

--- a/src/datastore/connection.ts
+++ b/src/datastore/connection.ts
@@ -40,8 +40,21 @@ export async function sqlTransaction<T>(
   }
   const usageName = sql.options.connection.application_name ?? '';
   return sqlTransactionContext.run({ usageName }, () => {
-    return sql.begin(readOnly ? 'read only' : '', callback);
+    return sql.begin(readOnly ? 'read only' : 'read write', callback);
   });
+}
+
+/**
+ * Start a SQL write transaction. See `sqlTransaction`.
+ * @param sql - SQL client
+ * @param callback - Callback with a scoped SQL client
+ * @returns Transaction results
+ */
+export async function sqlWriteTransaction<T>(
+  sql: PgSqlClient,
+  callback: (sql: PgSqlClient) => T | Promise<T>
+): Promise<UnwrapPromiseArray<T>> {
+  return sqlTransaction(sql, callback, false);
 }
 
 /**

--- a/src/datastore/connection.ts
+++ b/src/datastore/connection.ts
@@ -9,6 +9,17 @@ type UnwrapPromiseArray<T> = T extends any[]
       [k in keyof T]: T[k] extends Promise<infer R> ? R : T[k];
     }
   : T;
+
+/**
+ * Start a SQL transaction using a specific sql client. If this client was already scoped inside a
+ * `BEGIN` transaction, a `SAVEPOINT` will be used. This flexibility allows us to avoid repeating
+ * code while making sure we don't arrive at SQL errors such as
+ * `WARNING: there is already a transaction in progress` which may cause result inconsistencies.
+ * @param sql - SQL client
+ * @param callback - Callback with a scoped SQL client
+ * @param readOnly - If a `BEGIN` transaction should be marked as `READ ONLY`
+ * @returns Transaction results
+ */
 export async function sqlTransaction<T>(
   sql: PgSqlClient,
   callback: (sql: postgres.TransactionSql) => T | Promise<T>,
@@ -17,7 +28,7 @@ export async function sqlTransaction<T>(
   if ('savepoint' in sql) {
     return sql.savepoint(callback);
   } else {
-    return sql.begin(readOnly ? 'READ ONLY' : 'READ WRITE', callback);
+    return sql.begin(readOnly ? 'READ ONLY' : '', callback);
   }
 }
 

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -74,7 +74,7 @@ import {
   getPgConnectionEnvValue,
   PgServer,
   PgSqlClient,
-  sqlTransactionAsyncLocalStorage,
+  sqlTransactionContext,
   sqlTransaction,
 } from './connection';
 import {
@@ -121,7 +121,7 @@ export class PgStore {
   }
   private readonly _sql: PgSqlClient;
   get sql(): PgSqlClient {
-    if (sqlTransactionAsyncLocalStorage.getStore() === true) {
+    if (sqlTransactionContext.getStore()) {
       throw new Error('Connections inside an open postgres transaction are prohibited');
     }
     return this._sql;

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -401,7 +401,7 @@ export class PgWriteStore extends PgStore {
       }
 
       if (!this.isEventReplay) {
-        const mempoolStats = await this.getMempoolStatsInternal({ sql });
+        const mempoolStats = await this.getMempoolStats(sql, {});
         this.eventEmitter.emit('mempoolStatsUpdate', mempoolStats);
       }
     });
@@ -659,7 +659,7 @@ export class PgWriteStore extends PgStore {
       }
 
       if (!this.isEventReplay) {
-        const mempoolStats = await this.getMempoolStatsInternal({ sql });
+        const mempoolStats = await this.getMempoolStats(sql, {});
         this.eventEmitter.emit('mempoolStatsUpdate', mempoolStats);
       }
     });
@@ -1327,7 +1327,7 @@ export class PgWriteStore extends PgStore {
         }
       }
       if (!this.isEventReplay) {
-        const mempoolStats = await this.getMempoolStatsInternal({ sql });
+        const mempoolStats = await this.getMempoolStats(sql, {});
         this.eventEmitter.emit('mempoolStatsUpdate', mempoolStats);
       }
     });

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import { logger, logError, getOrAdd, batchIterate, isProdEnv, I32_MAX } from '../helpers';
 import {
   DbBlock,
@@ -74,7 +73,13 @@ import {
 } from './helpers';
 import { PgNotifier } from './pg-notifier';
 import { PgStore } from './pg-store';
-import { connectPostgres, PgJsonb, PgServer, PgSqlClient } from './connection';
+import {
+  connectPostgres,
+  getPgConnectionEnvValue,
+  PgJsonb,
+  PgServer,
+  PgSqlClient,
+} from './connection';
 import { runMigrations } from './migrations';
 import { getPgClientConfig } from './connection-legacy';
 import { isProcessableTokenMetadata } from '../token-metadata/helpers';
@@ -96,7 +101,9 @@ class MicroblockGapError extends Error {
  */
 export class PgWriteStore extends PgStore {
   readonly isEventReplay: boolean;
-  private cachedParameterizedInsertStrings = new Map<string, string>();
+  protected get closeTimeout(): number {
+    return parseInt(getPgConnectionEnvValue('CLOSE_TIMEOUT', PgServer.primary) ?? '5');
+  }
 
   constructor(
     sql: PgSqlClient,
@@ -1182,7 +1189,7 @@ export class PgWriteStore extends PgStore {
     burnchainBlockHeight: number;
     rewards: DbBurnchainReward[];
   }): Promise<void> {
-    return this.sql.begin(async sql => {
+    return await this.sql.begin(async sql => {
       const existingRewards = await sql<
         {
           reward_recipient: string;
@@ -1331,16 +1338,13 @@ export class PgWriteStore extends PgStore {
   }
 
   async dropMempoolTxs({ status, txIds }: { status: DbTxStatus; txIds: string[] }): Promise<void> {
-    let updatedTxs: DbMempoolTx[] = [];
-    await this.sql.begin(async sql => {
-      const updateResults = await sql<MempoolTxQueryResult[]>`
-        UPDATE mempool_txs
-        SET pruned = true, status = ${status}
-        WHERE tx_id IN ${sql(txIds)}
-        RETURNING ${sql(MEMPOOL_TX_COLUMNS)}
-      `;
-      updatedTxs = updateResults.map(r => parseMempoolTxQueryResult(r));
-    });
+    const updateResults = await this.sql<MempoolTxQueryResult[]>`
+      UPDATE mempool_txs
+      SET pruned = true, status = ${status}
+      WHERE tx_id IN ${this.sql(txIds)}
+      RETURNING ${this.sql(MEMPOOL_TX_COLUMNS)}
+    `;
+    const updatedTxs = updateResults.map(r => parseMempoolTxQueryResult(r));
     await this.refreshMaterializedView('mempool_digest');
     for (const tx of updatedTxs) {
       await this.notifier?.sendTx({ txId: tx.tx_id });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -705,10 +705,11 @@ export async function resolveOrTimeout(
 ) {
   let timer: NodeJS.Timeout;
   const result = await Promise.race([
-    new Promise(async (resolve, _) => {
-      await promise;
-      clearTimeout(timer);
-      resolve(true);
+    new Promise((resolve, reject) => {
+      promise
+        .then(() => resolve(true))
+        .catch(error => reject(error))
+        .finally(() => clearTimeout(timer));
     }),
     new Promise((resolve, _) => {
       timer = setInterval(() => {

--- a/src/shutdown-handler.ts
+++ b/src/shutdown-handler.ts
@@ -19,7 +19,7 @@ async function startShutdown() {
     return;
   }
   isShuttingDown = true;
-  const timeoutMs = 5000;
+  const timeoutMs = parseInt(process.env['STACKS_SHUTDOWN_FORCE_KILL_TIMEOUT'] ?? '60') * 1000;
   let errorEncountered = false;
   for (const config of shutdownConfigs) {
     try {

--- a/src/tests-bns/api.ts
+++ b/src/tests-bns/api.ts
@@ -737,7 +737,7 @@ describe('BNS API tests', () => {
 
   test('Failure: name info', async () => {
     const query1 = await supertest(api.server).get(`/v1/names/testname`);
-    expect(query1.status).toBe(404);
+    expect(query1.status).toBe(400);
   });
 
   test('Success: fetching name info', async () => {

--- a/src/tests-bns/api.ts
+++ b/src/tests-bns/api.ts
@@ -156,7 +156,7 @@ describe('BNS API tests', () => {
 
   test('Namespace not found', async () => {
     const query1 = await supertest(api.server).get(`/v1/namespaces/def/names`);
-    expect(query1.status).toBe(404);
+    expect(query1.status).toBe(400);
   });
 
   test('Validate: names returned length', async () => {

--- a/src/tests-bns/bns-integration-tests.ts
+++ b/src/tests-bns/bns-integration-tests.ts
@@ -436,7 +436,7 @@ describe('BNS integration tests', () => {
     expect(query4.status).toBe(200);
 
     const query5 = await supertest(api.server).get(`/v1/names/excluded.${name}.${namespace}`);
-    expect(query5.status).toBe(404);
+    expect(query5.status).toBe(400);
     expect(query5.type).toBe('application/json');
 
     // testing nameupdate 3

--- a/src/tests-bns/bns-integration-tests.ts
+++ b/src/tests-bns/bns-integration-tests.ts
@@ -51,7 +51,7 @@ describe('BNS integration tests', () => {
   function standByForTx(expectedTxId: string): Promise<DbTx> {
     const broadcastTx = new Promise<DbTx>(resolve => {
       const listener: (txId: string) => void = async txId => {
-        const dbTxQuery = await api.datastore.getTx({ txId: txId, includeUnanchored: true });
+        const dbTxQuery = await api.datastore.getTx(db.sql, { txId: txId, includeUnanchored: true });
         if (!dbTxQuery.found) {
           return;
         }
@@ -347,7 +347,7 @@ describe('BNS integration tests', () => {
     // testing name import
     await nameImport(namespace, importZonefile, name, testnetKey);
 
-    const importQuery = await db.getName({ name: `${name}.${namespace}`, includeUnanchored: false, chainId: network.chainId });
+    const importQuery = await db.getName(db.sql, { name: `${name}.${namespace}`, includeUnanchored: false, chainId: network.chainId });
     const importQuery1 = await supertest(api.server).get(`/v1/names/${name}.${namespace}`);
     expect(importQuery1.status).toBe(200);
     expect(importQuery1.type).toBe('application/json');
@@ -390,7 +390,7 @@ describe('BNS integration tests', () => {
       const query1 = await supertest(api.server).get(`/v1/names/1yeardaily.${name}.${namespace}`);
       expect(query1.status).toBe(200);
       expect(query1.type).toBe('application/json');
-      const query2 = await db.getSubdomain({ subdomain: `1yeardaily.${name}.${namespace}`, includeUnanchored: false });
+      const query2 = await db.getSubdomain(db.sql, { subdomain: `1yeardaily.${name}.${namespace}`, includeUnanchored: false });
       expect(query2.found).toBe(true);
       if(query2.result)
         expect(query2.result.resolver).toBe('');
@@ -419,7 +419,7 @@ describe('BNS integration tests', () => {
     expect(query1.status).toBe(200);
     expect(query1.type).toBe('application/json');
 
-    const query2 = await db.getSubdomainsList({ page: 0, includeUnanchored: false });
+    const query2 = await db.getSubdomainsList(db.sql, { page: 0, includeUnanchored: false });
     expect(
       query2.results.filter(function (value) {
         return value === `1yeardaily.${name}.${namespace}`;
@@ -448,7 +448,7 @@ describe('BNS integration tests', () => {
       const query6 = await supertest(api.server).get(`/v1/names/2dopequeens.${name}.${namespace}`); //check if previous sobdomains are still there
       expect(query6.status).toBe(200);
       expect(query6.type).toBe('application/json');
-      const query7 = await db.getSubdomainsList({ page: 0, includeUnanchored: false });
+      const query7 = await db.getSubdomainsList(db.sql, { page: 0, includeUnanchored: false });
       expect(query7.results).toContain(`1yeardaily.${name}.${namespace}`);
       const query8 = await supertest(api.server).get(`/v1/names/${name}.${namespace}`);
       expect(query8.status).toBe(200);
@@ -476,7 +476,7 @@ describe('BNS integration tests', () => {
     const query1 = await supertest(api.server).get(`/v1/names/${name}.${namespace}`);
     expect(query1.status).toBe(200);
     expect(query1.type).toBe('application/json');
-    const query = await db.getName({ name: `${name}.${namespace}`, includeUnanchored: false, chainId: network.chainId });
+    const query = await db.getName(db.sql, { name: `${name}.${namespace}`, includeUnanchored: false, chainId: network.chainId });
     expect(query.found).toBe(true);
     if (query.found) {
       expect(query.result.zonefile).toBe(zonefile);

--- a/src/tests-bns/event-server-tests.ts
+++ b/src/tests-bns/event-server-tests.ts
@@ -119,10 +119,10 @@ describe('BNS event server tests', () => {
       throwOnNotOK: true,
     });
 
-    const namespaces = await db.getNamespaceList({ includeUnanchored: true });
+    const namespaces = await db.getNamespaceList(db.sql, { includeUnanchored: true });
     expect(namespaces.results).toStrictEqual(['fren']);
 
-    const namespace = await db.getNamespace({ namespace: 'fren', includeUnanchored: true });
+    const namespace = await db.getNamespace(db.sql, { namespace: 'fren', includeUnanchored: true });
     expect(namespace.found).toBe(true);
     expect(namespace.result?.namespace_id).toBe('fren');
     expect(namespace.result?.lifetime).toBe(52560);
@@ -170,7 +170,7 @@ describe('BNS event server tests', () => {
       .build();
     await db.updateMicroblocks(microblock);
 
-    const name1 = await db.getName({
+    const name1 = await db.getName(db.sql, {
       name: 'dayslikewater.btc',
       includeUnanchored: true,
       chainId: ChainID.Mainnet
@@ -279,7 +279,7 @@ describe('BNS event server tests', () => {
       throwOnNotOK: true,
     });
 
-    const name2 = await db.getName({
+    const name2 = await db.getName(db.sql, {
       name: 'dayslikewater.btc',
       includeUnanchored: true,
       chainId: ChainID.Mainnet
@@ -332,7 +332,7 @@ describe('BNS event server tests', () => {
       .build();
     await db.updateMicroblocks(microblock);
 
-    const name1 = await db.getName({
+    const name1 = await db.getName(db.sql, {
       name: 'friedger.id',
       includeUnanchored: true,
       chainId: ChainID.Mainnet
@@ -406,7 +406,7 @@ describe('BNS event server tests', () => {
       throwOnNotOK: true,
     });
 
-    const name2 = await db.getName({
+    const name2 = await db.getName(db.sql, {
       name: 'friedger.id',
       includeUnanchored: true,
       chainId: ChainID.Mainnet
@@ -509,7 +509,7 @@ describe('BNS event server tests', () => {
       throwOnNotOK: true,
     });
 
-    const name = await db.getName({ name: 'jnj.btc', chainId: ChainID.Mainnet, includeUnanchored: true });
+    const name = await db.getName(db.sql, { name: 'jnj.btc', chainId: ChainID.Mainnet, includeUnanchored: true });
     expect(name.found).toBe(true);
     expect(name.result?.zonefile_hash).toBe('9198e0b61a029671e53bd59aa229e7ae05af35a3');
     expect(name.result?.index_block_hash).toBe('0x0200');
@@ -822,7 +822,7 @@ describe('BNS event server tests', () => {
       throwOnNotOK: true,
     });
 
-    const name = await db.getName({
+    const name = await db.getName(db.sql, {
       name: 'cricketwireless.btc',
       includeUnanchored: true,
       chainId: ChainID.Mainnet
@@ -1002,7 +1002,7 @@ describe('BNS event server tests', () => {
       throwOnNotOK: true,
     });
 
-    const name = await db.getName({
+    const name = await db.getName(db.sql, {
       name: 'ape.mega',
       includeUnanchored: true,
       chainId: ChainID.Mainnet
@@ -1014,11 +1014,11 @@ describe('BNS event server tests', () => {
     expect(name.result?.expire_block).toBe(1002);
     expect(name.result?.address).toBe('SPV48Q8E5WP4TCQ63E9TV6KF9R4HP01Z8WS3FBTG');
 
-    const list = await db.getNamesList({ page: 0, includeUnanchored: true });
+    const list = await db.getNamesList(db.sql, { page: 0, includeUnanchored: true });
     expect(list.results.length).toBe(1);
     expect(list.results).toStrictEqual(['ape.mega']);
 
-    const namespaceList = await db.getNamespaceNamesList({
+    const namespaceList = await db.getNamespaceNamesList(db.sql, {
       namespace: 'mega',
       page: 0,
       includeUnanchored: true

--- a/src/tests-bns/v1-import-tests.ts
+++ b/src/tests-bns/v1-import-tests.ts
@@ -156,7 +156,7 @@ describe('BNS V1 import', () => {
         '$ORIGIN flushreset.id.blockstack\n$TTL 3600\n_http._tcp	IN	URI	10	1	"https://gaia.blockstack.org/hub/1HEznKZ7mK5fmibweM7eAk8SwRgJ1bWY92/profile.json"\n\n',
     });
 
-    const dbquery = await db.getSubdomain({ subdomain: `flushreset.id.blockstack`, includeUnanchored: false });
+    const dbquery = await db.getSubdomain(db.sql, { subdomain: `flushreset.id.blockstack`, includeUnanchored: false });
     assert(dbquery.found)
     if (dbquery.result){
     expect(dbquery.result.name).toBe('id.blockstack');}

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -598,7 +598,7 @@ describe('Rosetta API', () => {
     expect(result1.status).toBe(200);
     expect(result1.type).toBe('application/json');
 
-    const curren_block = await api.datastore.getCurrentBlock();
+    const curren_block = await api.datastore.getCurrentBlock(db.sql);
     assert(curren_block.found);
 
     const amount: RosettaAmount = {

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -1086,7 +1086,7 @@ describe('Rosetta API', () => {
       },
     };
     const result = await supertest(api.server).post(`/rosetta/v1/account/balance/`).send(request);
-    expect(result.status).toBe(500);
+    expect(result.status).toBe(400);
     expect(result.type).toBe('application/json');
 
     const expectResponse = { 

--- a/src/tests-rosetta/construction.ts
+++ b/src/tests-rosetta/construction.ts
@@ -70,7 +70,7 @@ describe('Rosetta API', () => {
   function standByForTx(expectedTxId: string): Promise<DbTx> {
     const broadcastTx = new Promise<DbTx>(resolve => {
       const listener: (txId: string) => void = async txId => {
-        const dbTxQuery = await api.datastore.getTx({ txId: txId, includeUnanchored: true });
+        const dbTxQuery = await api.datastore.getTx(db.sql, { txId: txId, includeUnanchored: true });
         if (!dbTxQuery.found) {
           return;
         }
@@ -1992,9 +1992,9 @@ describe('Rosetta API', () => {
     const stxLockedTransaction = await standByForTx(submitResult.body.transaction_identifier.hash);
 
     const blockHeight = stxLockedTransaction.block_height;
-    let block = await api.datastore.getBlock({ height: blockHeight });
+    let block = await api.datastore.getBlock(db.sql, { height: blockHeight });
     assert(block.found);
-    const txs = await api.datastore.getBlockTxsRows(block.result.block_hash);
+    const txs = await api.datastore.getBlockTxsRows(db.sql, block.result.block_hash);
     assert(txs.found);
 
     const blockStxOpsQuery = await supertest(api.address)
@@ -2061,7 +2061,7 @@ describe('Rosetta API', () => {
     let current_burn_block_height = block.result.burn_block_height;
     //wait for the unlock block height
     while(current_burn_block_height < stxUnlockHeight){
-      block = await db.getCurrentBlock();
+      block = await db.getCurrentBlock(db.sql);
       assert(block.found);
       current_burn_block_height =  block.result?.burn_block_height;
       await timeout(100);
@@ -2449,9 +2449,9 @@ describe('Rosetta API', () => {
     const delegateStx = await standByForTx(submitResult.body.transaction_identifier.hash);
 
     const blockHeight = delegateStx.block_height;
-    let block = await api.datastore.getBlock({ height: blockHeight });
+    let block = await api.datastore.getBlock(db.sql, { height: blockHeight });
     assert(block.found);
-    const txs = await api.datastore.getBlockTxsRows(block.result.block_hash);
+    const txs = await api.datastore.getBlockTxsRows(db.sql, block.result.block_hash);
     assert(txs.found);
 
     const blockStxOpsQuery = await supertest(api.address)

--- a/src/tests-rosetta/offline-api-tests.ts
+++ b/src/tests-rosetta/offline-api-tests.ts
@@ -104,7 +104,7 @@ describe('Rosetta offline API', () => {
     const query1 = await supertest(api.address)
       .post(`/rosetta/v1/network/status`)
       .send({ network_identifier: { blockchain: 'stacks', network: 'testnet' } });
-    expect(query1.status).toBe(500);
+    expect(query1.status).toBe(400);
   });
 
   test('Fail: Offline - block - get latest', async () => {

--- a/src/tests-tokens/strict-mode-tests.ts
+++ b/src/tests-tokens/strict-mode-tests.ts
@@ -150,7 +150,7 @@ describe('token metadata strict mode', () => {
       dbQueueId: 1,
     });
     await handler.start();
-    const entry = await db.getTokenMetadataQueueEntry(1);
+    const entry = await db.getTokenMetadataQueueEntry(db.sql, 1);
     expect(entry.result?.retry_count).toBe(1);
     expect(entry.result?.processed).toBe(false);
   });
@@ -167,7 +167,7 @@ describe('token metadata strict mode', () => {
       dbQueueId: 1,
     });
     await handler.start();
-    const entry = await db.getTokenMetadataQueueEntry(1);
+    const entry = await db.getTokenMetadataQueueEntry(db.sql, 1);
     expect(entry.result?.retry_count).toEqual(1);
     expect(entry.result?.processed).toBe(true);
   });
@@ -185,7 +185,7 @@ describe('token metadata strict mode', () => {
       dbQueueId: 1,
     });
     await handler.start();
-    const entry = await db.getTokenMetadataQueueEntry(1);
+    const entry = await db.getTokenMetadataQueueEntry(db.sql, 1);
     expect(entry.result?.retry_count).toEqual(1);
     expect(entry.result?.processed).toBe(false);
   });
@@ -236,7 +236,7 @@ describe('token metadata strict mode', () => {
       dbQueueId: 1,
     });
     await handler.start();
-    const entry = await db.getTokenMetadataQueueEntry(1);
+    const entry = await db.getTokenMetadataQueueEntry(db.sql, 1);
     expect(entry.result?.retry_count).toEqual(1);
     expect(entry.result?.processed).toBe(false);
   });
@@ -260,7 +260,7 @@ describe('token metadata strict mode', () => {
       dbQueueId: 1,
     });
     await handler.start();
-    const entry = await db.getTokenMetadataQueueEntry(1);
+    const entry = await db.getTokenMetadataQueueEntry(db.sql, 1);
     expect(entry.result?.retry_count).toEqual(0);
     expect(entry.result?.processed).toBe(true);
   });
@@ -284,7 +284,7 @@ describe('token metadata strict mode', () => {
       dbQueueId: 1,
     });
     await handler.start();
-    const entry = await db.getTokenMetadataQueueEntry(1);
+    const entry = await db.getTokenMetadataQueueEntry(db.sql, 1);
     expect(entry.result?.retry_count).toEqual(1);
     expect(entry.result?.processed).toBe(false);
   });
@@ -308,10 +308,11 @@ describe('token metadata strict mode', () => {
       dbQueueId: 1,
     });
     await handler.start();
-    const entry = await db.getTokenMetadataQueueEntry(1);
+    const entry = await db.getTokenMetadataQueueEntry(db.sql, 1);
     expect(entry.result?.retry_count).toEqual(0);
     expect(entry.result?.processed).toBe(true);
     const metadata = await db.getNftMetadata(
+      db.sql,
       'SP176ZMV706NZGDDX8VSQRGMB7QN33BBDVZ6BMNHD.project-indigo-act1'
     );
     expect(metadata.result?.token_uri).toEqual('');
@@ -345,7 +346,7 @@ describe('token metadata strict mode', () => {
       dbQueueId: 1,
     });
     await handler.start();
-    const entry = await db.getTokenMetadataQueueEntry(1);
+    const entry = await db.getTokenMetadataQueueEntry(db.sql, 1);
     expect(entry.result?.retry_count).toEqual(0);
     expect(entry.result?.processed).toBe(true);
   });
@@ -371,12 +372,12 @@ describe('token metadata strict mode', () => {
       dbQueueId: 1,
     });
     await handler.start();
-    const entry = await db.getTokenMetadataQueueEntry(1);
+    const entry = await db.getTokenMetadataQueueEntry(db.sql, 1);
     expect(entry.result?.retry_count).toEqual(0);
     expect(entry.result?.processed).toBe(true);
 
     // Metadata still contains the rest of the data.
-    const metadata = await db.getNftMetadata(contractId);
+    const metadata = await db.getNftMetadata(db.sql, contractId);
     expect(metadata.found).toBe(true);
     expect(metadata.result?.token_uri).toBe('http://indigo.com/nft.jpeg');
   });

--- a/src/tests-tokens/tokens-metadata-tests.ts
+++ b/src/tests-tokens/tokens-metadata-tests.ts
@@ -39,7 +39,10 @@ describe('api tests', () => {
   function standByForTx(expectedTxId: string): Promise<DbTx> {
     const broadcastTx = new Promise<DbTx>((resolve, reject) => {
       const listener: (txId: string) => void = async txId => {
-        const dbTxQuery = await api.datastore.getTx({ txId: txId, includeUnanchored: true });
+        const dbTxQuery = await api.datastore.getTx(db.sql, {
+          txId: txId,
+          includeUnanchored: true,
+        });
         if (!dbTxQuery.found) {
           return;
         }
@@ -167,7 +170,7 @@ describe('api tests', () => {
   test('failed processing is retried in next block', async () => {
     const entryProcessedWaiter: Waiter<string> = waiter();
     const blockHandler = async (blockHash: string) => {
-      const entry = await db.getTokenMetadataQueueEntry(1);
+      const entry = await db.getTokenMetadataQueueEntry(db.sql, 1);
       if (entry.result?.processed) {
         entryProcessedWaiter.finish(blockHash);
       }

--- a/src/tests/address-tests.ts
+++ b/src/tests/address-tests.ts
@@ -1962,7 +1962,7 @@ describe('address tests', () => {
       execution_cost_write_length: 0,
     };
 
-    const blockTxsRows = await api.datastore.getBlockTxsRows(block.block_hash);
+    const blockTxsRows = await api.datastore.getBlockTxsRows(api.datastore.sql, block.block_hash);
     expect(blockTxsRows.found).toBe(true);
     const blockTxsRowsResult = blockTxsRows.result as DbTx[];
     const contractCallResult1 = blockTxsRowsResult.find(tx => tx.tx_id === contractCall.tx_id);
@@ -1981,7 +1981,7 @@ describe('address tests', () => {
     expect(searchResult8.type).toBe('application/json');
     expect(JSON.parse(searchResult8.text).result.metadata).toEqual(contractCallExpectedResults);
 
-    const blockTxResult = await db.getTxsFromBlock({ hash: '0x1234' }, 20, 0);
+    const blockTxResult = await db.getTxsFromBlock(api.datastore.sql, { hash: '0x1234' }, 20, 0);
     assert(blockTxResult.found);
     const contractCallResult2 = blockTxResult.result.results.find(
       tx => tx.tx_id === contractCall.tx_id

--- a/src/tests/block-tests.ts
+++ b/src/tests/block-tests.ts
@@ -116,7 +116,7 @@ describe('block tests', () => {
     };
     await db.updateTx(client, tx);
 
-    const blockQuery = await getBlockFromDataStore({
+    const blockQuery = await getBlockFromDataStore(db.sql, {
       blockIdentifer: { hash: block.block_hash },
       db,
     });

--- a/src/tests/cache-control-tests.ts
+++ b/src/tests/cache-control-tests.ts
@@ -145,7 +145,7 @@ describe('cache-control tests', () => {
       ],
     });
 
-    const blockQuery = await getBlockFromDataStore({
+    const blockQuery = await getBlockFromDataStore(db.sql, {
       blockIdentifer: { hash: block1.block_hash },
       db,
     });
@@ -290,7 +290,7 @@ describe('cache-control tests', () => {
       ],
     });
 
-    const chainTip2 = await db.getUnanchoredChainTip();
+    const chainTip2 = await db.getUnanchoredChainTip(db.sql);
     expect(chainTip2.found).toBeTruthy();
     expect(chainTip2.result?.blockHash).toBe(block1.block_hash);
     expect(chainTip2.result?.blockHeight).toBe(block1.block_height);

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -25,7 +25,7 @@ import { getBlocksWithMetadata, parseDbEvent } from '../api/controllers/db-contr
 import * as assert from 'assert';
 import { PgWriteStore } from '../datastore/pg-write-store';
 import { cycleMigrations, runMigrations } from '../datastore/migrations';
-import { getPostgres, PgSqlClient } from '../datastore/connection';
+import { getPostgres, PgServer, PgSqlClient } from '../datastore/connection';
 import { bnsNameCV, bufferToHexPrefixString, I32_MAX } from '../helpers';
 import { ChainID } from '@stacks/transactions';
 import { TestBlockBuilder } from '../test-utils/test-builders';
@@ -206,6 +206,45 @@ describe('postgres datastore', () => {
         expect(sql.options.pass).toBe('pg_password_password1');
         expect(sql.options.host).toStrictEqual(['pg_host_host1']);
         expect(sql.options.port).toStrictEqual([9876]);
+        expect(sql.options.ssl).toBe(true);
+        expect(sql.options.max_lifetime).toBe(5);
+        expect(sql.options.idle_timeout).toBe(1);
+        expect(sql.options.connection.search_path).toBe('pg_schema_schema1');
+        expect(sql.options.connection.application_name).toBe('test-env-vars:tests');
+      }
+    );
+  });
+
+  test('postgres primary env var config fallback', () => {
+    testEnvVars(
+      {
+        PG_CONNECTION_URI: undefined,
+        PG_DATABASE: 'pg_db_db1',
+        PG_USER: 'pg_user_user1',
+        PG_PASSWORD: 'pg_password_password1',
+        PG_HOST: 'pg_host_host1',
+        PG_PORT: '9876',
+        PG_SSL: 'true',
+        PG_SCHEMA: 'pg_schema_schema1',
+        PG_APPLICATION_NAME: 'test-env-vars',
+        PG_MAX_LIFETIME: '5',
+        PG_IDLE_TIMEOUT: '1',
+        // Primary values:
+        PG_PRIMARY_DATABASE: 'primary_db',
+        PG_PRIMARY_USER: 'primary_user',
+        PG_PRIMARY_PASSWORD: 'primary_password',
+        PG_PRIMARY_HOST: 'primary_host',
+        PG_PRIMARY_PORT: '9999',
+      },
+      () => {
+        const sql = getPostgres({ usageName: 'tests', pgServer: PgServer.primary });
+        // Primary values take precedence.
+        expect(sql.options.database).toBe('primary_db');
+        expect(sql.options.user).toBe('primary_user');
+        expect(sql.options.pass).toBe('primary_password');
+        expect(sql.options.host).toStrictEqual(['primary_host']);
+        expect(sql.options.port).toStrictEqual([9999]);
+        // Other values come from defaults.
         expect(sql.options.ssl).toBe(true);
         expect(sql.options.max_lifetime).toBe(5);
         expect(sql.options.idle_timeout).toBe(1);

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -457,10 +457,22 @@ describe('postgres datastore', () => {
     await db.updateTx(client, tx);
     await db.updateTx(client, tx2);
 
-    const addrAResult = await db.getStxBalance({ stxAddress: 'addrA', includeUnanchored: false });
-    const addrBResult = await db.getStxBalance({ stxAddress: 'addrB', includeUnanchored: false });
-    const addrCResult = await db.getStxBalance({ stxAddress: 'addrC', includeUnanchored: false });
-    const addrDResult = await db.getStxBalance({ stxAddress: 'addrD', includeUnanchored: false });
+    const addrAResult = await db.getStxBalance(db.sql, {
+      stxAddress: 'addrA',
+      includeUnanchored: false,
+    });
+    const addrBResult = await db.getStxBalance(db.sql, {
+      stxAddress: 'addrB',
+      includeUnanchored: false,
+    });
+    const addrCResult = await db.getStxBalance(db.sql, {
+      stxAddress: 'addrC',
+      includeUnanchored: false,
+    });
+    const addrDResult = await db.getStxBalance(db.sql, {
+      stxAddress: 'addrD',
+      includeUnanchored: false,
+    });
 
     expect(addrAResult).toEqual({
       balance: 198291n,
@@ -638,19 +650,19 @@ describe('postgres datastore', () => {
     });
 
     const blockHeight = await db.getMaxBlockHeight(client, { includeUnanchored: false });
-    const addrAResult = await db.getFungibleTokenBalances({
+    const addrAResult = await db.getFungibleTokenBalances(db.sql, {
       stxAddress: 'addrA',
       untilBlock: blockHeight,
     });
-    const addrBResult = await db.getFungibleTokenBalances({
+    const addrBResult = await db.getFungibleTokenBalances(db.sql, {
       stxAddress: 'addrB',
       untilBlock: blockHeight,
     });
-    const addrCResult = await db.getFungibleTokenBalances({
+    const addrCResult = await db.getFungibleTokenBalances(db.sql, {
       stxAddress: 'addrC',
       untilBlock: blockHeight,
     });
-    const addrDResult = await db.getFungibleTokenBalances({
+    const addrDResult = await db.getFungibleTokenBalances(db.sql, {
       stxAddress: 'addrD',
       untilBlock: blockHeight,
     });
@@ -804,19 +816,19 @@ describe('postgres datastore', () => {
 
     const blockHeight = await db.getMaxBlockHeight(client, { includeUnanchored: false });
 
-    const addrAResult = await db.getNonFungibleTokenCounts({
+    const addrAResult = await db.getNonFungibleTokenCounts(db.sql, {
       stxAddress: 'addrA',
       untilBlock: blockHeight,
     });
-    const addrBResult = await db.getNonFungibleTokenCounts({
+    const addrBResult = await db.getNonFungibleTokenCounts(db.sql, {
       stxAddress: 'addrB',
       untilBlock: blockHeight,
     });
-    const addrCResult = await db.getNonFungibleTokenCounts({
+    const addrCResult = await db.getNonFungibleTokenCounts(db.sql, {
       stxAddress: 'addrC',
       untilBlock: blockHeight,
     });
-    const addrDResult = await db.getNonFungibleTokenCounts({
+    const addrDResult = await db.getNonFungibleTokenCounts(db.sql, {
       stxAddress: 'addrD',
       untilBlock: blockHeight,
     });
@@ -859,7 +871,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
     };
     await db.updateBlock(client, block);
-    const blockQuery = await db.getBlock({ hash: block.block_hash });
+    const blockQuery = await db.getBlock(db.sql, { hash: block.block_hash });
     assert(blockQuery.found);
     expect(blockQuery.result).toEqual(block);
 
@@ -898,7 +910,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
     };
     await db.updateTx(client, tx);
-    const blockTxs = await db.getBlockTxs(block.index_block_hash);
+    const blockTxs = await db.getBlockTxs(db.sql, block.index_block_hash);
     expect(blockTxs.results).toHaveLength(1);
     expect(blockTxs.results[0]).toBe('0x1234');
   });
@@ -1015,42 +1027,42 @@ describe('postgres datastore', () => {
 
     const blockHeight = await db.getMaxBlockHeight(client, { includeUnanchored: false });
 
-    const addrAResult = await db.getAddressTxs({
+    const addrAResult = await db.getAddressTxs(db.sql, {
       stxAddress: 'addrA',
       limit: 3,
       offset: 0,
       blockHeight: blockHeight,
       atSingleBlock: false,
     });
-    const addrBResult = await db.getAddressTxs({
+    const addrBResult = await db.getAddressTxs(db.sql, {
       stxAddress: 'addrB',
       limit: 3,
       offset: 0,
       blockHeight: blockHeight,
       atSingleBlock: false,
     });
-    const addrCResult = await db.getAddressTxs({
+    const addrCResult = await db.getAddressTxs(db.sql, {
       stxAddress: 'addrC',
       limit: 3,
       offset: 0,
       blockHeight: blockHeight,
       atSingleBlock: false,
     });
-    const addrDResult = await db.getAddressTxs({
+    const addrDResult = await db.getAddressTxs(db.sql, {
       stxAddress: 'addrD',
       limit: 3,
       offset: 0,
       blockHeight: blockHeight,
       atSingleBlock: false,
     });
-    const addrEResult = await db.getAddressTxs({
+    const addrEResult = await db.getAddressTxs(db.sql, {
       stxAddress: 'addrE',
       limit: 3,
       offset: 0,
       blockHeight: blockHeight,
       atSingleBlock: false,
     });
-    const addrEResultP2 = await db.getAddressTxs({
+    const addrEResultP2 = await db.getAddressTxs(db.sql, {
       stxAddress: 'addrE',
       limit: 3,
       offset: 3,
@@ -1208,7 +1220,7 @@ describe('postgres datastore', () => {
       })),
     });
 
-    const addrAAtBlockResult = await db.getAddressTxs({
+    const addrAAtBlockResult = await db.getAddressTxs(db.sql, {
       stxAddress: 'addrA',
       limit: 1000,
       offset: 0,
@@ -1216,7 +1228,7 @@ describe('postgres datastore', () => {
       atSingleBlock: true,
     });
 
-    const addrAAllBlockResult = await db.getAddressTxs({
+    const addrAAllBlockResult = await db.getAddressTxs(db.sql, {
       stxAddress: 'addrA',
       limit: 1000,
       offset: 0,
@@ -1508,7 +1520,7 @@ describe('postgres datastore', () => {
 
     const blockHeight = await db.getMaxBlockHeight(client, { includeUnanchored: false });
 
-    const assetDbEvents = await db.getAddressAssetEvents({
+    const assetDbEvents = await db.getAddressAssetEvents(db.sql, {
       stxAddress: 'addrA',
       limit: 10000,
       offset: 0,
@@ -2256,7 +2268,7 @@ describe('postgres datastore', () => {
         },
       ],
     });
-    const txQuery = await db.getTx({ txId: tx.tx_id, includeUnanchored: false });
+    const txQuery = await db.getTx(db.sql, { txId: tx.tx_id, includeUnanchored: false });
     assert(txQuery.found);
     expect(txQuery.result).toEqual(tx);
   });
@@ -2338,7 +2350,7 @@ describe('postgres datastore', () => {
         },
       ],
     });
-    const txQuery = await db.getTx({ txId: tx.tx_id, includeUnanchored: false });
+    const txQuery = await db.getTx(db.sql, { txId: tx.tx_id, includeUnanchored: false });
     assert(txQuery.found);
     expect(txQuery.result).toEqual(tx);
   });
@@ -2427,7 +2439,7 @@ describe('postgres datastore', () => {
         },
       ],
     });
-    const txQuery = await db.getTx({ txId: tx.tx_id, includeUnanchored: false });
+    const txQuery = await db.getTx(db.sql, { txId: tx.tx_id, includeUnanchored: false });
     assert(txQuery.found);
     expect(txQuery.result).toEqual(tx);
   });
@@ -2509,7 +2521,7 @@ describe('postgres datastore', () => {
         },
       ],
     });
-    const txQuery = await db.getTx({ txId: tx.tx_id, includeUnanchored: false });
+    const txQuery = await db.getTx(db.sql, { txId: tx.tx_id, includeUnanchored: false });
     assert(txQuery.found);
     expect(txQuery.result).toEqual(tx);
   });
@@ -2590,7 +2602,7 @@ describe('postgres datastore', () => {
         },
       ],
     });
-    const txQuery = await db.getTx({ txId: tx.tx_id, includeUnanchored: false });
+    const txQuery = await db.getTx(db.sql, { txId: tx.tx_id, includeUnanchored: false });
     assert(txQuery.found);
     expect(txQuery.result).toEqual(tx);
   });
@@ -2670,7 +2682,7 @@ describe('postgres datastore', () => {
         },
       ],
     });
-    const txQuery = await db.getTx({ txId: tx.tx_id, includeUnanchored: false });
+    const txQuery = await db.getTx(db.sql, { txId: tx.tx_id, includeUnanchored: false });
     assert(txQuery.found);
     expect(txQuery.result).toEqual(tx);
   });
@@ -2733,7 +2745,7 @@ describe('postgres datastore', () => {
     };
     const updatedRows = await db.updateTx(client, tx);
     expect(updatedRows).toBe(1);
-    const txQuery = await db.getTx({ txId: tx.tx_id, includeUnanchored: false });
+    const txQuery = await db.getTx(db.sql, { txId: tx.tx_id, includeUnanchored: false });
     assert(txQuery.found);
     expect(txQuery.result).toEqual(tx);
     try {
@@ -2923,23 +2935,23 @@ describe('postgres datastore', () => {
       ],
     });
 
-    const fetchTx1 = await db.getTx({ txId: tx1.tx_id, includeUnanchored: false });
+    const fetchTx1 = await db.getTx(db.sql, { txId: tx1.tx_id, includeUnanchored: false });
     assert(fetchTx1.found);
     expect(fetchTx1.result).toEqual(tx1);
 
-    const fetchTx2 = await db.getTx({ txId: tx2.tx_id, includeUnanchored: false });
+    const fetchTx2 = await db.getTx(db.sql, { txId: tx2.tx_id, includeUnanchored: false });
     assert(fetchTx2.found);
     expect(fetchTx2.result).toEqual(tx2);
 
-    const fetchBlock1 = await db.getBlock({ hash: block1.block_hash });
+    const fetchBlock1 = await db.getBlock(db.sql, { hash: block1.block_hash });
     assert(fetchBlock1.found);
     expect(fetchBlock1.result).toEqual(block1);
 
-    const fetchContract1 = await db.getSmartContract(smartContract1.contract_id);
+    const fetchContract1 = await db.getSmartContract(db.sql, smartContract1.contract_id);
     assert(fetchContract1.found);
     expect(fetchContract1.result).toEqual(smartContract1);
 
-    const fetchTx1Events = await db.getTxEvents({
+    const fetchTx1Events = await db.getTxEvents(db.sql, {
       txId: tx1.tx_id,
       indexBlockHash: tx1.index_block_hash,
       limit: 100,
@@ -2991,7 +3003,7 @@ describe('postgres datastore', () => {
       burnchainBlockHeight: reward3.burn_block_height,
       rewards: [reward3],
     });
-    const rewardQuery = await db.getBurnchainRewards({
+    const rewardQuery = await db.getBurnchainRewards(db.sql, {
       burnchainRecipient: addr1,
       limit: 100,
       offset: 0,
@@ -3083,13 +3095,13 @@ describe('postgres datastore', () => {
       rewards: [reward4],
     });
     // Should return zero rewards since given address was only in blocks that have been reorged into non-canonical.
-    const rewardQuery1 = await db.getBurnchainRewards({
+    const rewardQuery1 = await db.getBurnchainRewards(db.sql, {
       burnchainRecipient: addr1,
       limit: 100,
       offset: 0,
     });
     expect(rewardQuery1).toEqual([]);
-    const rewardQuery2 = await db.getBurnchainRewards({
+    const rewardQuery2 = await db.getBurnchainRewards(db.sql, {
       burnchainRecipient: addr2,
       limit: 100,
       offset: 0,
@@ -3304,7 +3316,10 @@ describe('postgres datastore', () => {
     };
 
     await db.updateMempoolTxs({ mempoolTxs: [tx1Mempool] });
-    const txQuery1 = await db.getMempoolTx({ txId: tx1Mempool.tx_id, includeUnanchored: false });
+    const txQuery1 = await db.getMempoolTx(db.sql, {
+      txId: tx1Mempool.tx_id,
+      includeUnanchored: false,
+    });
     expect(txQuery1.found).toBe(true);
     expect(txQuery1?.result?.status).toBe(DbTxStatus.Pending);
     expect(txQuery1?.result?.raw_tx).toBe('0x746573742d7261772d7478');
@@ -3336,7 +3351,10 @@ describe('postgres datastore', () => {
       ],
     });
     // tx should still be in mempool since it was included in a non-canonical chain-tip
-    const txQuery2 = await db.getMempoolTx({ txId: tx1Mempool.tx_id, includeUnanchored: false });
+    const txQuery2 = await db.getMempoolTx(db.sql, {
+      txId: tx1Mempool.tx_id,
+      includeUnanchored: false,
+    });
     expect(txQuery2.found).toBe(true);
     expect(txQuery2?.result?.status).toBe(DbTxStatus.Pending);
 
@@ -3347,11 +3365,14 @@ describe('postgres datastore', () => {
       txs: [],
     });
     // the fork containing this tx was made canonical, it should no longer be in the mempool
-    const txQuery3 = await db.getMempoolTx({ txId: tx1Mempool.tx_id, includeUnanchored: false });
+    const txQuery3 = await db.getMempoolTx(db.sql, {
+      txId: tx1Mempool.tx_id,
+      includeUnanchored: false,
+    });
     expect(txQuery3.found).toBe(false);
 
     // the tx should be in the mined tx table, marked as canonical and success status
-    const txQuery4 = await db.getTx({ txId: tx1.tx_id, includeUnanchored: false });
+    const txQuery4 = await db.getTx(db.sql, { txId: tx1.tx_id, includeUnanchored: false });
     expect(txQuery4.found).toBe(true);
     expect(txQuery4?.result?.status).toBe(DbTxStatus.Success);
     expect(txQuery4?.result?.canonical).toBe(true);
@@ -3368,13 +3389,16 @@ describe('postgres datastore', () => {
     }
 
     // the tx should be in the mined tx table, marked as non-canonical
-    const txQuery5 = await db.getTx({ txId: tx1.tx_id, includeUnanchored: false });
+    const txQuery5 = await db.getTx(db.sql, { txId: tx1.tx_id, includeUnanchored: false });
     expect(txQuery5.found).toBe(true);
     expect(txQuery5?.result?.status).toBe(DbTxStatus.Success);
     expect(txQuery5?.result?.canonical).toBe(false);
 
     // the fork containing this tx was made canonical again, it should now in the mempool
-    const txQuery6 = await db.getMempoolTx({ txId: tx1Mempool.tx_id, includeUnanchored: false });
+    const txQuery6 = await db.getMempoolTx(db.sql, {
+      txId: tx1Mempool.tx_id,
+      includeUnanchored: false,
+    });
     expect(txQuery6.found).toBe(true);
     expect(txQuery6?.result?.status).toBe(DbTxStatus.Pending);
 
@@ -3399,11 +3423,11 @@ describe('postgres datastore', () => {
     });
 
     // tx should no longer be in the mempool after being mined
-    const txQuery7 = await db.getMempoolTx({ txId: tx1b.tx_id, includeUnanchored: false });
+    const txQuery7 = await db.getMempoolTx(db.sql, { txId: tx1b.tx_id, includeUnanchored: false });
     expect(txQuery7.found).toBe(false);
 
     // tx should be back in the mined tx table and associated with the new block
-    const txQuery8 = await db.getTx({ txId: tx1b.tx_id, includeUnanchored: false });
+    const txQuery8 = await db.getTx(db.sql, { txId: tx1b.tx_id, includeUnanchored: false });
     expect(txQuery8.found).toBe(true);
     expect(txQuery8.result?.index_block_hash).toBe(block6.index_block_hash);
     expect(txQuery8.result?.canonical).toBe(true);
@@ -3658,13 +3682,13 @@ describe('postgres datastore', () => {
       },
     });
 
-    const blockQuery1 = await db.getBlock({ hash: block1.block_hash });
+    const blockQuery1 = await db.getBlock(db.sql, { hash: block1.block_hash });
     expect(blockQuery1.result?.canonical).toBe(true);
 
-    const blockQuery2 = await db.getBlock({ hash: block2.block_hash });
+    const blockQuery2 = await db.getBlock(db.sql, { hash: block2.block_hash });
     expect(blockQuery2.result?.canonical).toBe(true);
 
-    const blockQuery3B = await db.getBlock({ hash: block3B.block_hash });
+    const blockQuery3B = await db.getBlock(db.sql, { hash: block3B.block_hash });
     expect(blockQuery3B.result?.canonical).toBe(false);
   });
 
@@ -3928,7 +3952,7 @@ describe('postgres datastore', () => {
       ]
     );
 
-    let name = await db.getName({
+    let name = await db.getName(db.sql, {
       name: 'xyz.abc',
       includeUnanchored: false,
       chainId: ChainID.Mainnet,
@@ -3937,12 +3961,15 @@ describe('postgres datastore', () => {
     expect(name.result.canonical).toBe(true);
     expect(name.result.index_block_hash).toBe(block2.index_block_hash);
 
-    let namespace = await db.getNamespace({ namespace: 'abc', includeUnanchored: false });
+    let namespace = await db.getNamespace(db.sql, { namespace: 'abc', includeUnanchored: false });
     assert(namespace.found);
     expect(namespace.result.canonical).toBe(true);
     expect(namespace.result.index_block_hash).toBe(block2.index_block_hash);
 
-    let subdomain = await db.getSubdomain({ subdomain: 'def.xyz.abc', includeUnanchored: false });
+    let subdomain = await db.getSubdomain(db.sql, {
+      subdomain: 'def.xyz.abc',
+      includeUnanchored: false,
+    });
     assert(subdomain.found);
     expect(subdomain.result.canonical).toBe(true);
     expect(subdomain.result.index_block_hash).toBe(block2.index_block_hash);
@@ -4093,7 +4120,7 @@ describe('postgres datastore', () => {
         },
       ],
     });
-    const isBlock2bCanonical = await db.getBlock({ hash: block2b.block_hash });
+    const isBlock2bCanonical = await db.getBlock(db.sql, { hash: block2b.block_hash });
     await db.resolveBnsSubdomains(
       {
         index_block_hash: block2b.index_block_hash,
@@ -4122,20 +4149,20 @@ describe('postgres datastore', () => {
       ]
     );
 
-    const blockQuery1 = await db.getBlock({ hash: block2b.block_hash });
+    const blockQuery1 = await db.getBlock(db.sql, { hash: block2b.block_hash });
     expect(blockQuery1.result?.canonical).toBe(false);
     const chainTip1 = await db.getChainTip(client);
     expect(chainTip1).toEqual({ blockHash: '0x33', blockHeight: 3, indexBlockHash: '0xcc' });
-    const namespaces = await db.getNamespaceList({ includeUnanchored: false });
+    const namespaces = await db.getNamespaceList(db.sql, { includeUnanchored: false });
     expect(namespaces.results.length).toBe(1);
-    const names = await db.getNamespaceNamesList({
+    const names = await db.getNamespaceNamesList(db.sql, {
       namespace: 'abc',
       page: 0,
       includeUnanchored: false,
     });
     expect(names.results.length).toBe(1);
 
-    name = await db.getName({
+    name = await db.getName(db.sql, {
       name: 'xyz.abc',
       includeUnanchored: false,
       chainId: ChainID.Mainnet,
@@ -4144,12 +4171,15 @@ describe('postgres datastore', () => {
     expect(name.result.canonical).toBe(true);
     expect(name.result.index_block_hash).toBe(block2.index_block_hash);
 
-    namespace = await db.getNamespace({ namespace: 'abc', includeUnanchored: false });
+    namespace = await db.getNamespace(db.sql, { namespace: 'abc', includeUnanchored: false });
     assert(namespace.found);
     expect(namespace.result.canonical).toBe(true);
     expect(namespace.result.index_block_hash).toBe(block2.index_block_hash);
 
-    subdomain = await db.getSubdomain({ subdomain: 'def.xyz.abc', includeUnanchored: false });
+    subdomain = await db.getSubdomain(db.sql, {
+      subdomain: 'def.xyz.abc',
+      includeUnanchored: false,
+    });
     assert(subdomain.found);
     expect(subdomain.result.canonical).toBe(true);
     expect(subdomain.result.index_block_hash).toBe(block2.index_block_hash);
@@ -4174,7 +4204,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
     };
     await db.update({ block: block3b, microblocks: [], minerRewards: [], txs: [] });
-    const blockQuery2 = await db.getBlock({ hash: block3b.block_hash });
+    const blockQuery2 = await db.getBlock(db.sql, { hash: block3b.block_hash });
     expect(blockQuery2.result?.canonical).toBe(false);
     const chainTip2 = await db.getChainTip(client);
     expect(chainTip2).toEqual({ blockHash: '0x33', blockHeight: 3, indexBlockHash: '0xcc' });
@@ -4200,7 +4230,7 @@ describe('postgres datastore', () => {
     };
     await db.update({ block: block4b, microblocks: [], minerRewards: [], txs: [] });
 
-    name = await db.getName({
+    name = await db.getName(db.sql, {
       name: 'xyz.abc',
       includeUnanchored: false,
       chainId: ChainID.Mainnet,
@@ -4209,22 +4239,22 @@ describe('postgres datastore', () => {
     expect(name.result.canonical).toBe(true);
     expect(name.result.index_block_hash).toBe(block2b.index_block_hash);
 
-    namespace = await db.getNamespace({ namespace: 'abc', includeUnanchored: false });
+    namespace = await db.getNamespace(db.sql, { namespace: 'abc', includeUnanchored: false });
     assert(namespace.found);
     expect(namespace.result.canonical).toBe(true);
     expect(namespace.result.index_block_hash).toBe(block2b.index_block_hash);
 
-    const blockQuery3 = await db.getBlock({ hash: block3b.block_hash });
+    const blockQuery3 = await db.getBlock(db.sql, { hash: block3b.block_hash });
     expect(blockQuery3.result?.canonical).toBe(true);
     const chainTip3 = await db.getChainTip(client);
     expect(chainTip3).toEqual({ blockHash: '0x44bb', blockHeight: 4, indexBlockHash: '0xddbb' });
 
-    const b1 = await db.getBlock({ hash: block1.block_hash });
-    const b2 = await db.getBlock({ hash: block2.block_hash });
-    const b2b = await db.getBlock({ hash: block2b.block_hash });
-    const b3 = await db.getBlock({ hash: block3.block_hash });
-    const b3b = await db.getBlock({ hash: block3b.block_hash });
-    const b4 = await db.getBlock({ hash: block4b.block_hash });
+    const b1 = await db.getBlock(db.sql, { hash: block1.block_hash });
+    const b2 = await db.getBlock(db.sql, { hash: block2.block_hash });
+    const b2b = await db.getBlock(db.sql, { hash: block2b.block_hash });
+    const b3 = await db.getBlock(db.sql, { hash: block3.block_hash });
+    const b3b = await db.getBlock(db.sql, { hash: block3b.block_hash });
+    const b4 = await db.getBlock(db.sql, { hash: block4b.block_hash });
     expect(b1.result?.canonical).toBe(true);
     expect(b2.result?.canonical).toBe(false);
     expect(b2b.result?.canonical).toBe(true);
@@ -4232,36 +4262,36 @@ describe('postgres datastore', () => {
     expect(b3b.result?.canonical).toBe(true);
     expect(b4.result?.canonical).toBe(true);
 
-    const r1 = await db.getStxBalance({
+    const r1 = await db.getStxBalance(db.sql, {
       stxAddress: minerReward1.recipient,
       includeUnanchored: false,
     });
-    const r2 = await db.getStxBalance({
+    const r2 = await db.getStxBalance(db.sql, {
       stxAddress: minerReward2.recipient,
       includeUnanchored: false,
     });
     expect(r1.totalMinerRewardsReceived).toBe(1014n);
     expect(r2.totalMinerRewardsReceived).toBe(0n);
 
-    const lock1 = await db.getStxBalance({
+    const lock1 = await db.getStxBalance(db.sql, {
       stxAddress: stxLockEvent1.locked_address,
       includeUnanchored: false,
     });
-    const lock2 = await db.getStxBalance({
+    const lock2 = await db.getStxBalance(db.sql, {
       stxAddress: stxLockEvent2.locked_address,
       includeUnanchored: false,
     });
     expect(lock1.locked).toBe(1234n);
     expect(lock2.locked).toBe(0n);
 
-    const t1 = await db.getTx({ txId: tx1.tx_id, includeUnanchored: false });
-    const t2 = await db.getTx({ txId: tx2.tx_id, includeUnanchored: false });
-    const t3 = await db.getTx({ txId: tx3.tx_id, includeUnanchored: false });
+    const t1 = await db.getTx(db.sql, { txId: tx1.tx_id, includeUnanchored: false });
+    const t2 = await db.getTx(db.sql, { txId: tx2.tx_id, includeUnanchored: false });
+    const t3 = await db.getTx(db.sql, { txId: tx3.tx_id, includeUnanchored: false });
     expect(t1.result?.canonical).toBe(true);
     expect(t2.result?.canonical).toBe(false);
     expect(t3.result?.canonical).toBe(true);
 
-    const sc1 = await db.getSmartContract(contract1.contract_id);
+    const sc1 = await db.getSmartContract(db.sql, contract1.contract_id);
     expect(sc1.found && sc1.result?.canonical).toBe(true);
   });
 
@@ -4339,7 +4369,7 @@ describe('postgres datastore', () => {
       ],
     });
 
-    const fetchTx1 = await db.getRawTx(tx1.tx_id);
+    const fetchTx1 = await db.getRawTx(db.sql, tx1.tx_id);
     assert(fetchTx1.found);
     expect(fetchTx1.result.raw_tx).toEqual('0x616263');
   });
@@ -4418,7 +4448,7 @@ describe('postgres datastore', () => {
       ],
     });
 
-    const fetchTx1 = await db.getRawTx('0x12');
+    const fetchTx1 = await db.getRawTx(db.sql, '0x12');
     expect(fetchTx1.found).toEqual(false);
   });
 
@@ -4562,9 +4592,9 @@ describe('postgres datastore', () => {
       ],
     });
 
-    const fetchTx1 = await db.getTx({ txId: tx1.tx_id, includeUnanchored: false });
+    const fetchTx1 = await db.getTx(db.sql, { txId: tx1.tx_id, includeUnanchored: false });
     expect(fetchTx1.result?.event_count).toBe(4);
-    const fetchTx2 = await db.getTx({ txId: tx2.tx_id, includeUnanchored: false });
+    const fetchTx2 = await db.getTx(db.sql, { txId: tx2.tx_id, includeUnanchored: false });
     expect(fetchTx2.result?.event_count).toBe(0);
   });
 
@@ -4622,7 +4652,7 @@ describe('postgres datastore', () => {
       },
       namespace
     );
-    const { results } = await db.getNamespaceList({ includeUnanchored: false });
+    const { results } = await db.getNamespaceList(db.sql, { includeUnanchored: false });
     expect(results.length).toBe(1);
     expect(results[0]).toBe('abc');
   });
@@ -4677,7 +4707,7 @@ describe('postgres datastore', () => {
       },
       name
     );
-    const { results } = await db.getNamespaceNamesList({
+    const { results } = await db.getNamespaceNamesList(db.sql, {
       namespace: 'abc',
       page: 0,
       includeUnanchored: false,
@@ -4741,7 +4771,7 @@ describe('postgres datastore', () => {
       },
       subdomains
     );
-    const { results } = await db.getSubdomainsList({ page: 0, includeUnanchored: false });
+    const { results } = await db.getSubdomainsList(db.sql, { page: 0, includeUnanchored: false });
     expect(results.length).toBe(1);
     expect(results[0]).toBe('test.nametest.namespacetest');
   });
@@ -4767,7 +4797,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
     };
     await db.updateBlock(client, block);
-    const blockQuery = await db.getBlock({ hash: block.block_hash });
+    const blockQuery = await db.getBlock(db.sql, { hash: block.block_hash });
     assert(blockQuery.found);
     expect(blockQuery.result).toEqual(block);
 
@@ -4843,7 +4873,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
     };
     await db.updateTx(client, tx2);
-    const blockTxs = await db.getTxsFromBlock({ hash: block.block_hash }, 20, 0);
+    const blockTxs = await db.getTxsFromBlock(db.sql, { hash: block.block_hash }, 20, 0);
     assert(blockTxs.found);
     expect(blockTxs.result.results.length).toBe(2);
     expect(blockTxs.result.total).toBe(2);
@@ -4870,7 +4900,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
     };
     await db.updateBlock(client, block);
-    const blockQuery = await db.getBlock({ hash: block.block_hash });
+    const blockQuery = await db.getBlock(db.sql, { hash: block.block_hash });
     assert(blockQuery.found);
     expect(blockQuery.result).toEqual(block);
 
@@ -4909,7 +4939,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
     };
     await db.updateTx(client, tx);
-    const blockTxs = await db.getTxsFromBlock({ hash: block.block_hash }, 20, 6);
+    const blockTxs = await db.getTxsFromBlock(db.sql, { hash: block.block_hash }, 20, 6);
     assert(blockTxs.found);
     expect(blockTxs.result.results.length).toBe(0);
     expect(blockTxs.result.total).toBe(1);
@@ -4932,7 +4962,7 @@ describe('postgres datastore', () => {
       block: 19157,
     };
     await db.updateBatchTokenOfferingLocked(client, [lockedInfo, lockedInfo2, lockedInfo3]);
-    const results = await db.getTokenOfferingLocked(lockedInfo.address, 29157);
+    const results = await db.getTokenOfferingLocked(db.sql, lockedInfo.address, 29157);
     expect(results.found).toBe(true);
     const total = lockedInfo.value + lockedInfo2.value + lockedInfo3.value;
     expect(
@@ -4960,6 +4990,7 @@ describe('postgres datastore', () => {
 
   test('pg token offering locked: not found', async () => {
     const results = await db.getTokenOfferingLocked(
+      db.sql,
       'SM1ZH700J7CEDSEHM5AJ4C4MKKWNESTS35DD3SZM5',
       100
     );
@@ -4981,7 +5012,7 @@ describe('postgres datastore', () => {
     const rowCount = await db.updateNFtMetadata(nftMetadata, 1);
     expect(rowCount).toBe(1);
 
-    const query = await db.getNftMetadata(nftMetadata.contract_id);
+    const query = await db.getNftMetadata(db.sql, nftMetadata.contract_id);
     expect(query.found).toBe(true);
     if (query.found) expect(query.result).toStrictEqual(nftMetadata);
   });
@@ -5003,7 +5034,7 @@ describe('postgres datastore', () => {
     const rowCount = await db.updateFtMetadata(ftMetadata, 1);
     expect(rowCount).toBe(1);
 
-    const query = await db.getFtMetadata(ftMetadata.contract_id);
+    const query = await db.getFtMetadata(db.sql, ftMetadata.contract_id);
     expect(query.found).toBe(true);
     if (query.found) expect(query.result).toStrictEqual(ftMetadata);
   });
@@ -5013,12 +5044,16 @@ describe('postgres datastore', () => {
     await db.update(block);
 
     // Blocks with limit=0
-    await expect(getBlocksWithMetadata({ limit: 0, offset: 0, db: db })).resolves.not.toThrow();
+    await expect(
+      getBlocksWithMetadata(db.sql, { limit: 0, offset: 0, db: db })
+    ).resolves.not.toThrow();
     // Mempool search with empty txIds
-    await expect(db.getMempoolTxs({ txIds: [], includeUnanchored: true })).resolves.not.toThrow();
+    await expect(
+      db.getMempoolTxs(db.sql, { txIds: [], includeUnanchored: true })
+    ).resolves.not.toThrow();
     // NFT holdings with empty asset identifier list
     await expect(
-      db.getNftHoldings({
+      db.getNftHoldings(db.sql, {
         principal: 'S',
         assetIdentifiers: [],
         limit: 10,
@@ -5029,7 +5064,7 @@ describe('postgres datastore', () => {
     ).resolves.not.toThrow();
     // Tx list details with empty txIds
     await expect(
-      db.getTxListDetails({ txIds: [], includeUnanchored: true })
+      db.getTxListDetails(db.sql, { txIds: [], includeUnanchored: true })
     ).resolves.not.toThrow();
   });
 

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -265,8 +265,12 @@ describe('postgres datastore', () => {
           skipMigrations: true,
         });
         try {
-          const name = await testDb.getConnectionApplicationName();
-          expect(name).toStrictEqual('test-app-name:test-usage-name;datastore-crud');
+          const result = await testDb.sql<{ application_name: string }[]>`
+            SELECT application_name FROM pg_stat_activity WHERE pid = pg_backend_pid()
+          `;
+          expect(result[0].application_name).toStrictEqual(
+            'test-app-name:test-usage-name;datastore-crud'
+          );
         } finally {
           await testDb.close();
         }

--- a/src/tests/import-genesis-tests.ts
+++ b/src/tests/import-genesis-tests.ts
@@ -24,19 +24,19 @@ describe('import genesis data tests', () => {
     expect(newDbConfigState.token_offering_imported).toBe(true);
 
     const addr1 = 'SP04MFJ3RWTADV6ZWTWD68DBZ14EJSDXT50Q7TE6';
-    const res1 = await db.getTokenOfferingLocked(addr1, 0);
+    const res1 = await db.getTokenOfferingLocked(db.sql, addr1, 0);
     expect(res1?.result?.total_locked).toEqual('33115155552');
 
     const addr2 = 'SM2M7XTPCJK6S5XG7JKH4SGYDY9W49ZQ962MC4XPM';
-    const res2 = await db.getTokenOfferingLocked(addr2, 0);
+    const res2 = await db.getTokenOfferingLocked(db.sql, addr2, 0);
     expect(res2?.result?.total_locked).toEqual('111111111108');
 
     const addr3 = 'SM37EFPD9ZVR3YRJE7673MJ3W0T350JM1HVZVCDC3';
-    const res3 = await db.getTokenOfferingLocked(addr3, 0);
+    const res3 = await db.getTokenOfferingLocked(db.sql, addr3, 0);
     expect(res3?.result?.total_locked).toEqual('111111109');
 
     const addr4 = 'SM260QHD6ZM2KKPBKZB8PFE5XWP0MHSKTD1B7BHYR';
-    const res4 = await db.getTokenOfferingLocked(addr4, 0);
+    const res4 = await db.getTokenOfferingLocked(db.sql, addr4, 0);
     expect(res4?.result?.total_locked).toEqual('1666666664');
   });
 

--- a/src/tests/mempool-tests.ts
+++ b/src/tests/mempool-tests.ts
@@ -55,7 +55,7 @@ describe('mempool tests', () => {
       }
 
       // Make sure we only have mempool txs for block_height >= 3
-      const mempoolTxResult = await db.getMempoolTxList({
+      const mempoolTxResult = await db.getMempoolTxList(db.sql, {
         limit: 10,
         offset: 0,
         includeUnanchored: false,

--- a/src/tests/microblock-tests.ts
+++ b/src/tests/microblock-tests.ts
@@ -383,7 +383,7 @@ describe('microblock tests', () => {
           ],
         });
 
-        const chainTip1 = await db.getUnanchoredChainTip();
+        const chainTip1 = await db.getUnanchoredChainTip(db.sql);
         expect(chainTip1.found).toBeTruthy();
         expect(chainTip1.result?.blockHash).toBe(block1.block_hash);
         expect(chainTip1.result?.blockHeight).toBe(block1.block_height);
@@ -541,7 +541,7 @@ describe('microblock tests', () => {
           ],
         });
 
-        const chainTip2 = await db.getUnanchoredChainTip();
+        const chainTip2 = await db.getUnanchoredChainTip(db.sql);
         expect(chainTip2.found).toBeTruthy();
         expect(chainTip2.result?.blockHash).toBe(block1.block_hash);
         expect(chainTip2.result?.blockHeight).toBe(block1.block_height);

--- a/src/tests/tx-tests.ts
+++ b/src/tests/tx-tests.ts
@@ -352,7 +352,10 @@ describe('tx tests', () => {
       ],
     });
 
-    const txQuery = await getTxFromDataStore(db, { txId: dbTx.tx_id, includeUnanchored: false });
+    const txQuery = await getTxFromDataStore(db.sql, db, {
+      txId: dbTx.tx_id,
+      includeUnanchored: false,
+    });
     expect(txQuery.found).toBe(true);
     if (!txQuery.found) {
       throw Error('not found');
@@ -540,7 +543,10 @@ describe('tx tests', () => {
       source_code: '()',
       abi: JSON.stringify(contractAbi),
     });
-    const txQuery = await getTxFromDataStore(db, { txId: dbTx.tx_id, includeUnanchored: false });
+    const txQuery = await getTxFromDataStore(db.sql, db, {
+      txId: dbTx.tx_id,
+      includeUnanchored: false,
+    });
     expect(txQuery.found).toBe(true);
     if (!txQuery.found) {
       throw Error('not found');
@@ -735,7 +741,10 @@ describe('tx tests', () => {
         },
       ],
     });
-    const txQuery = await getTxFromDataStore(db, { txId: dbTx.tx_id, includeUnanchored: false });
+    const txQuery = await getTxFromDataStore(db.sql, db, {
+      txId: dbTx.tx_id,
+      includeUnanchored: false,
+    });
     expect(txQuery.found).toBe(true);
     if (!txQuery.found) {
       throw Error('not found');
@@ -932,7 +941,10 @@ describe('tx tests', () => {
       ],
     });
 
-    const txQuery = await getTxFromDataStore(db, { txId: dbTx.tx_id, includeUnanchored: false });
+    const txQuery = await getTxFromDataStore(db.sql, db, {
+      txId: dbTx.tx_id,
+      includeUnanchored: false,
+    });
     expect(txQuery.found).toBe(true);
     if (!txQuery.found) {
       throw Error('not found');
@@ -1073,7 +1085,10 @@ describe('tx tests', () => {
       ],
     });
 
-    const txQuery = await getTxFromDataStore(db, { txId: dbTx.tx_id, includeUnanchored: false });
+    const txQuery = await getTxFromDataStore(db.sql, db, {
+      txId: dbTx.tx_id,
+      includeUnanchored: false,
+    });
     expect(txQuery.found).toBe(true);
     if (!txQuery.found) {
       throw Error('not found');

--- a/src/token-metadata/tokens-processor-queue.ts
+++ b/src/token-metadata/tokens-processor-queue.ts
@@ -59,6 +59,7 @@ export class TokensProcessorQueue {
       const queuedEntries = [...this.queuedEntries.keys()];
       try {
         entries = await this.db.getTokenMetadataQueue(
+          this.db.sql,
           TOKEN_METADATA_PARSING_CONCURRENCY_LIMIT,
           queuedEntries
         );
@@ -82,6 +83,7 @@ export class TokensProcessorQueue {
       let entries: DbTokenMetadataQueueEntry[];
       try {
         entries = await this.db.getTokenMetadataQueue(
+          this.db.sql,
           TOKEN_METADATA_PARSING_CONCURRENCY_LIMIT,
           queuedEntries
         );
@@ -98,7 +100,7 @@ export class TokensProcessorQueue {
   async queueNotificationHandler(queueId: number) {
     let queueEntry: FoundOrNot<DbTokenMetadataQueueEntry>;
     try {
-      queueEntry = await this.db.getTokenMetadataQueueEntry(queueId);
+      queueEntry = await this.db.getTokenMetadataQueueEntry(this.db.sql, queueId);
     } catch (error) {
       logger.error(error);
       return;
@@ -122,7 +124,7 @@ export class TokensProcessorQueue {
     }
     let abi: string;
     try {
-      const contractQuery = await this.db.getSmartContract(queueEntry.contractId);
+      const contractQuery = await this.db.getSmartContract(this.db.sql, queueEntry.contractId);
       if (!contractQuery.found || !contractQuery.result.abi) {
         return;
       }


### PR DESCRIPTION
This PR fixes the use of postgres `BEGIN`/`COMMIT` transactions across the entire API

### Background
For code reusability, we have functions within `PgStore` that each perform a series of queries against the DB within their own `BEGIN`/`COMMIT` transaction blocks for result consistency. We then group some of these function calls inside other utility functions (e.g. in `db-controller.ts`) and use them in different parts of the API like endpoints, tests, Rosetta, etc.

This creates several problems:

1. If SQL transactions are performed in series without an enclosing transaction, results may be inconsistent or wrong if a new block is being written to the DB at the same time (causing #1370)
2. If SQL transactions are nested (i.e. a function that opens a transaction and calls another function inside which opens another transaction) it can lead to an incorrect use of SQL connections and to `WARNING: there is already a transaction in progress` logs appearing in the DB (probably causing #1375)

### Solution
This PR creates a new utility function called `sqlTransaction` which allows us to use and nest transaction blocks wherever we want.

When used, this function checks the SQL connection to see if it was already scoped to a transaction. If so, it runs queries directly instead of calling `BEGIN`. This allows us to keep consistent transaction use and to return correct results in all of our endpoints.

To enforce correct transaction use, all `PgStore` functions now require a first `PgSqlClient` parameter which indicates the connection they'll use to begin transactions if needed. Also, `AsyncLocalStorage` is used to store transaction data in an `async`/`await` context so we can identify if a connection is being attempted that would break a postgres transaction.

---

### Note for reviewers
This PR appears very large but the core of it is in `src/datastore/connection.ts`. All other changes are just to accomodate the use of this function.
