### PR TITLE
do not tag latest on non-master branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,7 +525,7 @@ jobs:
           images: |
             blockstack/${{ github.event.repository.name }}
             hirosystems/${{ github.event.repository.name }}
-          flvaor: latest=false
+          flavor: latest=false
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -539,7 +539,7 @@ jobs:
           images: |
             blockstack/${{ github.event.repository.name }}-standalone
             hirosystems/${{ github.event.repository.name }}-standalone
-          flvaor: latest=false
+          flavor: latest=false
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,12 +525,12 @@ jobs:
           images: |
             blockstack/${{ github.event.repository.name }}
             hirosystems/${{ github.event.repository.name }}
-          flavor: latest=false
           tags: |
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}},value=${{ steps.semantic.outputs.new_release_version }},enable=${{ steps.semantic.outputs.new_release_version != '' }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.semantic.outputs.new_release_version }},enable=${{ steps.semantic.outputs.new_release_version != '' }}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Docker Standalone Meta
         id: meta_standalone
@@ -539,12 +539,12 @@ jobs:
           images: |
             blockstack/${{ github.event.repository.name }}-standalone
             hirosystems/${{ github.event.repository.name }}-standalone
-          flavor: latest=false
           tags: |
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}},value=${{ steps.semantic.outputs.new_release_version }},enable=${{ steps.semantic.outputs.new_release_version != '' }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.semantic.outputs.new_release_version }},enable=${{ steps.semantic.outputs.new_release_version != '' }}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,6 +525,7 @@ jobs:
           images: |
             blockstack/${{ github.event.repository.name }}
             hirosystems/${{ github.event.repository.name }}
+          flvaor: latest=false
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -538,6 +539,7 @@ jobs:
           images: |
             blockstack/${{ github.event.repository.name }}-standalone
             hirosystems/${{ github.event.repository.name }}-standalone
+          flvaor: latest=false
           tags: |
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
Attempting to resolve a CI bug where `non-master` branch builds are overwriting the `-latest` tagged image in hub.docker.  