### PR TITLE
chore: disabling latest tag on non-master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,6 +530,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}},value=${{ steps.semantic.outputs.new_release_version }},enable=${{ steps.semantic.outputs.new_release_version != '' }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.semantic.outputs.new_release_version }},enable=${{ steps.semantic.outputs.new_release_version != '' }}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Docker Standalone Meta
         id: meta_standalone
@@ -543,6 +544,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}},value=${{ steps.semantic.outputs.new_release_version }},enable=${{ steps.semantic.outputs.new_release_version != '' }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.semantic.outputs.new_release_version }},enable=${{ steps.semantic.outputs.new_release_version != '' }}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Login to DockerHub
         uses: docker/login-action@v1


### PR DESCRIPTION
fixing an issue where non-master branch builds are tagging containers with `-latest` and overwriting the "real" `latest` image