### PR TITLE
ci: add flavor param

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,6 +526,8 @@ jobs:
           images: |
             blockstack/${{ github.event.repository.name }}
             hirosystems/${{ github.event.repository.name }}
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -540,6 +542,8 @@ jobs:
           images: |
             blockstack/${{ github.event.repository.name }}-standalone
             hirosystems/${{ github.event.repository.name }}-standalone
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
There seems to be conflicting configuration settings when it comes to _not_ tagging with `latest`.   The Priority attribute might be invalidating the `type=raw,value=latest,enable={{is_default_branch}}` line which is last in the list so it gets superseded by `type=semver,pattern=...` and triggers the default `flavor` attribute behavior.  I can try to move the line up, but that might cause unwanted tagging behaviors for the semver tags.

That being said it looks like setting the `flavor` param is a best way to _not_ tag with the `lastest`.  