### PR TITLE
fix: handle websocket messages with a priority queue

### DIFF
--- a/.env
+++ b/.env
@@ -149,6 +149,11 @@ MAINNET_SEND_MANY_CONTRACT_ID=SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-man
 # message after this time has elapsed.
 # STACKS_API_WS_MESSAGE_TIMEOUT=5
 
+# Web Socket update queue timeout, in seconds. When an update is scheduled (new block, tx update,
+# etc.), we will allow this number of seconds to elapse to allow all subscribed clients to receive
+# new data.
+# STACKS_API_WS_UPDATE_QUEUE_TIMEOUT=5
+
 # Specify max number of STX address to store in an in-memory LRU cache (CPU optimization).
 # Defaults to 50,000, which should result in around 25 megabytes of additional memory usage.
 # STACKS_ADDRESS_CACHE_SIZE=10000

--- a/.env
+++ b/.env
@@ -138,6 +138,17 @@ MAINNET_SEND_MANY_CONTRACT_ID=SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-man
 # IMGIX_DOMAIN=https://<your domain>.imgix.net
 # IMGIX_TOKEN=<your token>
 
+# Web Socket ping interval to determine client availability, in seconds.
+# STACKS_API_WS_PING_INTERVAL=5
+
+# Web Socket ping timeout, in seconds. Clients will be dropped if they do not respond with a pong
+# after this time has elapsed.
+# STACKS_API_WS_PING_TIMEOUT=5
+
+# Web Socket message timeout, in seconds. Clients will be dropped if they do not acknowledge a
+# message after this time has elapsed.
+# STACKS_API_WS_MESSAGE_TIMEOUT=5
+
 # Specify max number of STX address to store in an in-memory LRU cache (CPU optimization).
 # Defaults to 50,000, which should result in around 25 megabytes of additional memory usage.
 # STACKS_ADDRESS_CACHE_SIZE=10000

--- a/docs/socket-io/index.d.ts
+++ b/docs/socket-io/index.d.ts
@@ -24,34 +24,38 @@ export type Topic =
   | NftAssetEventTopic
   | NftCollectionEventTopic;
 
+// Allows timeout callbacks for messages. See
+// https://socket.io/docs/v4/typescript/#emitting-with-a-timeout
+type WithTimeoutAck<isSender extends boolean, args extends any[]> = isSender extends true ? [Error, ...args] : args;
+
 export interface ClientToServerMessages {
   subscribe: (topic: Topic | Topic[], callback: (error: string | null) => void) => void;
   unsubscribe: (...topic: Topic[]) => void;
 }
 
-export interface ServerToClientMessages {
-  block: (block: Block) => void;
-  microblock: (microblock: Microblock) => void;
-  mempool: (transaction: MempoolTransaction) => void;
-  transaction: (transaction: Transaction | MempoolTransaction) => void;
+export interface ServerToClientMessages<isSender extends boolean = false> {
+  block: (block: Block, callback: (...args: WithTimeoutAck<isSender, [string]>) => void) => void;
+  microblock: (microblock: Microblock, callback: (...args: WithTimeoutAck<isSender, [string]>) => void) => void;
+  mempool: (transaction: MempoolTransaction, callback: (...args: WithTimeoutAck<isSender, [string]>) => void) => void;
+  transaction: (transaction: Transaction | MempoolTransaction, callback: (...args: WithTimeoutAck<isSender, [string]>) => void) => void;
 
   // @ts-ignore scheduled for support in TS v4.3 https://github.com/microsoft/TypeScript/pull/26797
-  [key: 'nft-event']: (event: NftEvent) => void;
-  'nft-event': (event: NftEvent) => void;
+  [key: 'nft-event']: (event: NftEvent, callback: (...args: WithTimeoutAck<isSender, [string]>) => void) => void;
+  'nft-event': (event: NftEvent, callback: (...args: WithTimeoutAck<isSender, [string]>) => void) => void;
 
   // @ts-ignore scheduled for support in TS v4.3 https://github.com/microsoft/TypeScript/pull/26797
-  [key: NftAssetEventTopic]: (assetIdentifier: string, value: string, event: NftEvent) => void;
-  'nft-asset-event': (assetIdentifier: string, value: string, event: NftEvent) => void;
+  [key: NftAssetEventTopic]: (assetIdentifier: string, value: string, event: NftEvent, callback: (...args: WithTimeoutAck<isSender, [string]>) => void) => void;
+  'nft-asset-event': (assetIdentifier: string, value: string, event: NftEvent, callback: (...args: WithTimeoutAck<isSender, [string]>) => void) => void;
 
   // @ts-ignore scheduled for support in TS v4.3 https://github.com/microsoft/TypeScript/pull/26797
-  [key: NftCollectionEventTopic]: (assetIdentifier: string, event: NftEvent) => void;
-  'nft-collection-event': (assetIdentifier: string, event: NftEvent) => void;
+  [key: NftCollectionEventTopic]: (assetIdentifier: string, event: NftEvent, callback: (...args: WithTimeoutAck<isSender, [string]>) => void) => void;
+  'nft-collection-event': (assetIdentifier: string, event: NftEvent, callback: (...args: WithTimeoutAck<isSender, [string]>) => void) => void;
 
   // @ts-ignore scheduled for support in TS v4.3 https://github.com/microsoft/TypeScript/pull/26797
-  [key: AddressTransactionTopic]: (address: string, stxBalance: AddressTransactionWithTransfers) => void;
-  'address-transaction': (address: string, tx: AddressTransactionWithTransfers) => void;
+  [key: AddressTransactionTopic]: (address: string, stxBalance: AddressTransactionWithTransfers, callback: (...args: WithTimeoutAck<isSender, [string]>) => void) => void;
+  'address-transaction': (address: string, tx: AddressTransactionWithTransfers, callback: (...args: WithTimeoutAck<isSender, [string]>) => void) => void;
 
   // @ts-ignore scheduled for support in TS v4.3 https://github.com/microsoft/TypeScript/pull/26797
-  [key: AddressStxBalanceTopic]: (address: string, stxBalance: AddressStxBalanceResponse) => void;
-  'address-stx-balance': (address: string, stxBalance: AddressStxBalanceResponse) => void;
+  [key: AddressStxBalanceTopic]: (address: string, stxBalance: AddressStxBalanceResponse, callback: (...args: WithTimeoutAck<isSender, [string]>) => void) => void;
+  'address-stx-balance': (address: string, stxBalance: AddressStxBalanceResponse, callback: (...args: WithTimeoutAck<isSender, [string]>) => void) => void;
 }

--- a/src/api/routes/ws/channels/socket-io-channel.ts
+++ b/src/api/routes/ws/channels/socket-io-channel.ts
@@ -35,6 +35,8 @@ export class SocketIOChannel extends WebSocketChannel {
   connect(): void {
     const io = new SocketIOServer<ClientToServerMessages, ServerToClientMessages>(this.server, {
       cors: { origin: '*' },
+      pingInterval: 5_000,
+      pingTimeout: 5_000,
     });
     this.io = io;
 

--- a/src/api/routes/ws/channels/socket-io-channel.ts
+++ b/src/api/routes/ws/channels/socket-io-channel.ts
@@ -193,7 +193,9 @@ export class SocketIOChannel extends WebSocketChannel {
         const [block] = args as ListenerType<WebSocketPayload['block']>;
         this.prometheus?.sendEvent('block');
         void this.getTopicSockets('block').then(sockets =>
-          sockets?.map(s => s.timeout(timeout).emit('block', block, _ => s.disconnect(true)))
+          sockets?.forEach(socket =>
+            socket.timeout(timeout).emit('block', block, _ => socket.disconnect(true))
+          )
         );
         break;
       }
@@ -201,8 +203,8 @@ export class SocketIOChannel extends WebSocketChannel {
         const [microblock] = args as ListenerType<WebSocketPayload['microblock']>;
         this.prometheus?.sendEvent('microblock');
         void this.getTopicSockets('microblock').then(sockets =>
-          sockets?.map(s =>
-            s.timeout(timeout).emit('microblock', microblock, _ => s.disconnect(true))
+          sockets?.forEach(socket =>
+            socket.timeout(timeout).emit('microblock', microblock, _ => socket.disconnect(true))
           )
         );
         break;
@@ -211,7 +213,9 @@ export class SocketIOChannel extends WebSocketChannel {
         const [tx] = args as ListenerType<WebSocketPayload['mempoolTransaction']>;
         this.prometheus?.sendEvent('mempool');
         void this.getTopicSockets('mempool').then(sockets =>
-          sockets?.map(s => s.timeout(timeout).emit('mempool', tx, _ => s.disconnect(true)))
+          sockets?.forEach(socket =>
+            socket.timeout(timeout).emit('mempool', tx, _ => socket.disconnect(true))
+          )
         );
         break;
       }
@@ -219,7 +223,9 @@ export class SocketIOChannel extends WebSocketChannel {
         const [tx] = args as ListenerType<WebSocketPayload['transaction']>;
         this.prometheus?.sendEvent('transaction');
         void this.getTopicSockets(`transaction:${tx.tx_id}`).then(sockets =>
-          sockets?.map(s => s.timeout(timeout).emit('transaction', tx, _ => s.disconnect(true)))
+          sockets?.forEach(socket =>
+            socket.timeout(timeout).emit('transaction', tx, _ => socket.disconnect(true))
+          )
         );
         break;
       }
@@ -227,7 +233,9 @@ export class SocketIOChannel extends WebSocketChannel {
         const [event] = args as ListenerType<WebSocketPayload['nftEvent']>;
         this.prometheus?.sendEvent('nft-event');
         void this.getTopicSockets(`nft-event`).then(sockets =>
-          sockets?.map(s => s.timeout(timeout).emit('nft-event', event, _ => s.disconnect(true)))
+          sockets?.forEach(socket =>
+            socket.timeout(timeout).emit('nft-event', event, _ => socket.disconnect(true))
+          )
         );
         break;
       }
@@ -237,7 +245,7 @@ export class SocketIOChannel extends WebSocketChannel {
         >;
         this.prometheus?.sendEvent('nft-asset-event');
         void this.getTopicSockets(`nft-event`).then(sockets =>
-          sockets?.map(socket =>
+          sockets?.forEach(socket =>
             socket
               .timeout(timeout)
               .emit('nft-asset-event', assetIdentifier, value, event, _ => socket.disconnect(true))
@@ -251,7 +259,7 @@ export class SocketIOChannel extends WebSocketChannel {
         >;
         this.prometheus?.sendEvent('nft-collection-event');
         void this.getTopicSockets(`nft-event`).then(sockets =>
-          sockets?.map(socket =>
+          sockets?.forEach(socket =>
             socket
               .timeout(timeout)
               .emit('nft-collection-event', assetIdentifier, event, _ => socket.disconnect(true))
@@ -264,9 +272,11 @@ export class SocketIOChannel extends WebSocketChannel {
         const topic: AddressTransactionTopic = `address-transaction:${principal}`;
         this.prometheus?.sendEvent('address-transaction');
         void this.getTopicSockets(topic).then(sockets =>
-          sockets?.map(s => {
-            s.timeout(timeout).emit('address-transaction', principal, tx, _ => s.disconnect(true));
-            s.timeout(timeout).emit(topic, principal, tx, _ => s.disconnect(true));
+          sockets?.forEach(socket => {
+            socket
+              .timeout(timeout)
+              .emit('address-transaction', principal, tx, _ => socket.disconnect(true));
+            socket.timeout(timeout).emit(topic, principal, tx, _ => socket.disconnect(true));
           })
         );
         break;
@@ -276,11 +286,11 @@ export class SocketIOChannel extends WebSocketChannel {
         const topic: AddressStxBalanceTopic = `address-stx-balance:${principal}`;
         this.prometheus?.sendEvent('address-stx-balance');
         void this.getTopicSockets(topic).then(sockets =>
-          sockets?.map(s => {
-            s.timeout(timeout).emit('address-stx-balance', principal, balance, _ =>
-              s.disconnect(true)
-            );
-            s.timeout(timeout).emit(topic, principal, balance, _ => s.disconnect(true));
+          sockets?.forEach(socket => {
+            socket
+              .timeout(timeout)
+              .emit('address-stx-balance', principal, balance, _ => socket.disconnect(true));
+            socket.timeout(timeout).emit(topic, principal, balance, _ => socket.disconnect(true));
           })
         );
         break;

--- a/src/api/routes/ws/channels/socket-io-channel.ts
+++ b/src/api/routes/ws/channels/socket-io-channel.ts
@@ -18,9 +18,9 @@ import {
   WebSocketTopics,
 } from '../web-socket-channel';
 import {
-  getWsMessageTimeout,
-  getWsPingInterval,
-  getWsPingTimeout,
+  getWsMessageTimeoutMs,
+  getWsPingIntervalMs,
+  getWsPingTimeoutMs,
 } from '../web-socket-transmitter';
 
 /**
@@ -42,8 +42,8 @@ export class SocketIOChannel extends WebSocketChannel {
       this.server,
       {
         cors: { origin: '*' },
-        pingInterval: getWsPingInterval(),
-        pingTimeout: getWsPingTimeout(),
+        pingInterval: getWsPingIntervalMs(),
+        pingTimeout: getWsPingTimeoutMs(),
       }
     );
     this.io = io;
@@ -187,7 +187,7 @@ export class SocketIOChannel extends WebSocketChannel {
     }
     // If a client takes more than this number of ms to respond to an event `emit`, it will be
     // disconnected.
-    const timeout = getWsMessageTimeout();
+    const timeout = getWsMessageTimeoutMs();
     switch (payload) {
       case 'block': {
         const [block] = args as ListenerType<WebSocketPayload['block']>;

--- a/src/api/routes/ws/channels/ws-rpc-channel.ts
+++ b/src/api/routes/ws/channels/ws-rpc-channel.ts
@@ -42,6 +42,7 @@ import {
   RpcNftCollectionEventSubscriptionParams,
   NftEvent,
 } from '@stacks/stacks-blockchain-api-types';
+import { getWsMessageTimeout, getWsPingInterval } from '../web-socket-transmitter';
 
 type Subscription =
   | RpcTxUpdateSubscriptionParams
@@ -64,7 +65,7 @@ class SubscriptionManager {
   // Sockets that are responding to ping.
   liveSockets: Set<WebSocket> = new Set();
   heartbeatInterval?: NodeJS.Timeout;
-  readonly heartbeatIntervalMs = 5_000;
+  readonly heartbeatIntervalMs = getWsPingInterval();
 
   addSubscription(client: WebSocket, topicId: string) {
     if (this.subscriptions.size === 0) {
@@ -786,7 +787,7 @@ export class WsRpcChannel extends WebSocketChannel {
     );
     // If the payload takes more than 5 seconds to be processed by the client,
     // it will be disconnected.
-    const successful = await resolveOrTimeout(sendPromise, 5_000);
+    const successful = await resolveOrTimeout(sendPromise, getWsMessageTimeout());
     if (!successful) {
       manager.removeSubscription(client, topicId);
     }

--- a/src/api/routes/ws/channels/ws-rpc-channel.ts
+++ b/src/api/routes/ws/channels/ws-rpc-channel.ts
@@ -1,7 +1,13 @@
 import * as http from 'http';
 import * as WebSocket from 'ws';
 import * as net from 'net';
-import { isProdEnv, isValidPrincipal, logError, normalizeHashString } from '../../../../helpers';
+import {
+  isProdEnv,
+  isValidPrincipal,
+  logError,
+  normalizeHashString,
+  resolveOrTimeout,
+} from '../../../../helpers';
 import { WebSocketPrometheus } from '../web-socket-prometheus';
 import {
   ListenerType,
@@ -567,10 +573,16 @@ export class WsRpcChannel extends WebSocketChannel {
 
   private processTxUpdate(tx: Transaction | MempoolTransaction) {
     try {
-      const subscribers = this.subscriptions.get('transaction')?.subscriptions.get(tx.tx_id);
+      const manager = this.subscriptions.get('transaction');
+      if (!manager) {
+        return;
+      }
+      const subscribers = manager.subscriptions.get(tx.tx_id);
       if (subscribers) {
         const rpcNotificationPayload = jsonRpcNotification('tx_update', tx).serialize();
-        subscribers.forEach(client => client.send(rpcNotificationPayload));
+        subscribers.forEach(client =>
+          this.sendWithTimeout(manager, tx.tx_id, client, rpcNotificationPayload)
+        );
         this.prometheus?.sendEvent('transaction');
       }
     } catch (error) {
@@ -580,9 +592,11 @@ export class WsRpcChannel extends WebSocketChannel {
 
   private processAddressUpdate(principal: string, tx: AddressTransactionWithTransfers) {
     try {
-      const subscribers = this.subscriptions
-        .get('principalTransactions')
-        ?.subscriptions.get(principal);
+      const manager = this.subscriptions.get('principalTransactions');
+      if (!manager) {
+        return;
+      }
+      const subscribers = manager.subscriptions.get(principal);
       if (subscribers) {
         const updateNotification = {
           address: principal,
@@ -595,7 +609,9 @@ export class WsRpcChannel extends WebSocketChannel {
           'address_tx_update',
           updateNotification
         ).serialize();
-        subscribers.forEach(client => client.send(rpcNotificationPayload));
+        subscribers.forEach(client =>
+          this.sendWithTimeout(manager, principal, client, rpcNotificationPayload)
+        );
         this.prometheus?.sendEvent('address-transaction');
       }
     } catch (error) {
@@ -604,7 +620,11 @@ export class WsRpcChannel extends WebSocketChannel {
   }
 
   private processAddressBalanceUpdate(principal: string, balance: AddressStxBalanceResponse) {
-    const subscribers = this.subscriptions.get('principalStxBalance')?.subscriptions.get(principal);
+    const manager = this.subscriptions.get('principalStxBalance');
+    if (!manager) {
+      return;
+    }
+    const subscribers = manager.subscriptions.get(principal);
     if (subscribers) {
       try {
         const balanceNotification = {
@@ -615,7 +635,9 @@ export class WsRpcChannel extends WebSocketChannel {
           'address_balance_update',
           balanceNotification
         ).serialize();
-        subscribers.forEach(client => client.send(rpcNotificationPayload));
+        subscribers.forEach(client =>
+          this.sendWithTimeout(manager, principal, client, rpcNotificationPayload)
+        );
         this.prometheus?.sendEvent('address-stx-balance');
       } catch (error) {
         logError(`error sending websocket stx balance update to ${principal}`, error);
@@ -625,10 +647,16 @@ export class WsRpcChannel extends WebSocketChannel {
 
   private processBlockUpdate(block: Block) {
     try {
-      const subscribers = this.subscriptions.get('block')?.subscriptions.get('block');
+      const manager = this.subscriptions.get('block');
+      if (!manager) {
+        return;
+      }
+      const subscribers = manager.subscriptions.get('block');
       if (subscribers) {
         const rpcNotificationPayload = jsonRpcNotification('block', block).serialize();
-        subscribers.forEach(client => client.send(rpcNotificationPayload));
+        subscribers.forEach(client =>
+          this.sendWithTimeout(manager, 'block', client, rpcNotificationPayload)
+        );
         this.prometheus?.sendEvent('block');
       }
     } catch (error) {
@@ -638,10 +666,16 @@ export class WsRpcChannel extends WebSocketChannel {
 
   private processMicroblockUpdate(microblock: Microblock) {
     try {
-      const subscribers = this.subscriptions.get('microblock')?.subscriptions.get('microblock');
+      const manager = this.subscriptions.get('microblock');
+      if (!manager) {
+        return;
+      }
+      const subscribers = manager.subscriptions.get('microblock');
       if (subscribers) {
         const rpcNotificationPayload = jsonRpcNotification('microblock', microblock).serialize();
-        subscribers.forEach(client => client.send(rpcNotificationPayload));
+        subscribers.forEach(client =>
+          this.sendWithTimeout(manager, 'microblock', client, rpcNotificationPayload)
+        );
         this.prometheus?.sendEvent('microblock');
       }
     } catch (error) {
@@ -651,10 +685,16 @@ export class WsRpcChannel extends WebSocketChannel {
 
   private processMempoolUpdate(transaction: MempoolTransaction) {
     try {
-      const subscribers = this.subscriptions.get('mempool')?.subscriptions.get('mempool');
+      const manager = this.subscriptions.get('mempool');
+      if (!manager) {
+        return;
+      }
+      const subscribers = manager.subscriptions.get('mempool');
       if (subscribers) {
         const rpcNotificationPayload = jsonRpcNotification('mempool', transaction).serialize();
-        subscribers.forEach(client => client.send(rpcNotificationPayload));
+        subscribers.forEach(client =>
+          this.sendWithTimeout(manager, 'mempool', client, rpcNotificationPayload)
+        );
         this.prometheus?.sendEvent('mempool');
       }
     } catch (error) {
@@ -664,10 +704,16 @@ export class WsRpcChannel extends WebSocketChannel {
 
   private processNftEventUpdate(event: NftEvent) {
     try {
-      const subscribers = this.subscriptions.get('nftEvent')?.subscriptions.get('nft_event');
+      const manager = this.subscriptions.get('nftEvent');
+      if (!manager) {
+        return;
+      }
+      const subscribers = manager.subscriptions.get('nft_event');
       if (subscribers) {
         const rpcNotificationPayload = jsonRpcNotification('nft_event', event).serialize();
-        subscribers.forEach(client => client.send(rpcNotificationPayload));
+        subscribers.forEach(client =>
+          this.sendWithTimeout(manager, 'nft_event', client, rpcNotificationPayload)
+        );
         this.prometheus?.sendEvent('nft-event');
       }
     } catch (error) {
@@ -677,12 +723,17 @@ export class WsRpcChannel extends WebSocketChannel {
 
   private processNftAssetEventUpdate(assetIdentifier: string, value: string, event: NftEvent) {
     try {
-      const subscribers = this.subscriptions
-        .get('nftAssetEvent')
-        ?.subscriptions.get(`${assetIdentifier}+${value}`);
+      const manager = this.subscriptions.get('nftAssetEvent');
+      if (!manager) {
+        return;
+      }
+      const topicId = `${assetIdentifier}+${value}`;
+      const subscribers = manager.subscriptions.get(topicId);
       if (subscribers) {
         const rpcNotificationPayload = jsonRpcNotification('nft_asset_event', event).serialize();
-        subscribers.forEach(client => client.send(rpcNotificationPayload));
+        subscribers.forEach(client =>
+          this.sendWithTimeout(manager, topicId, client, rpcNotificationPayload)
+        );
         this.prometheus?.sendEvent('nft-event');
       }
     } catch (error) {
@@ -695,15 +746,19 @@ export class WsRpcChannel extends WebSocketChannel {
 
   private processNftCollectionEventUpdate(assetIdentifier: string, event: NftEvent) {
     try {
-      const subscribers = this.subscriptions
-        .get('nftCollectionEvent')
-        ?.subscriptions.get(assetIdentifier);
+      const manager = this.subscriptions.get('nftCollectionEvent');
+      if (!manager) {
+        return;
+      }
+      const subscribers = manager.subscriptions.get(assetIdentifier);
       if (subscribers) {
         const rpcNotificationPayload = jsonRpcNotification(
           'nft_collection_event',
           event
         ).serialize();
-        subscribers.forEach(client => client.send(rpcNotificationPayload));
+        subscribers.forEach(client =>
+          this.sendWithTimeout(manager, assetIdentifier, client, rpcNotificationPayload)
+        );
         this.prometheus?.sendEvent('nft-event');
       }
     } catch (error) {
@@ -711,6 +766,29 @@ export class WsRpcChannel extends WebSocketChannel {
         `error sending websocket nft-collection-event updates for ${assetIdentifier}`,
         error
       );
+    }
+  }
+
+  private async sendWithTimeout(
+    manager: SubscriptionManager,
+    topicId: string,
+    client: WebSocket,
+    payload: string
+  ) {
+    const sendPromise = new Promise<void>((resolve, reject) =>
+      client.send(payload, err => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      })
+    );
+    // If the payload takes more than 5 seconds to be processed by the client,
+    // it will be disconnected.
+    const successful = await resolveOrTimeout(sendPromise, 5_000);
+    if (!successful) {
+      manager.removeSubscription(client, topicId);
     }
   }
 }

--- a/src/api/routes/ws/channels/ws-rpc-channel.ts
+++ b/src/api/routes/ws/channels/ws-rpc-channel.ts
@@ -770,7 +770,7 @@ export class WsRpcChannel extends WebSocketChannel {
     }
   }
 
-  private async sendWithTimeout(
+  private sendWithTimeout(
     manager: SubscriptionManager,
     topicId: string,
     client: WebSocket,
@@ -785,11 +785,14 @@ export class WsRpcChannel extends WebSocketChannel {
         }
       })
     );
-    // If the payload takes more than 5 seconds to be processed by the client,
+    // If the payload takes more than a set number of seconds to be processed by the client,
     // it will be disconnected.
-    const successful = await resolveOrTimeout(sendPromise, getWsMessageTimeoutMs());
-    if (!successful) {
-      manager.removeSubscription(client, topicId);
-    }
+    resolveOrTimeout(sendPromise, getWsMessageTimeoutMs())
+      .then(successful => {
+        if (!successful) {
+          manager.removeSubscription(client, topicId);
+        }
+      })
+      .catch(_ => manager.removeSubscription(client, topicId));
   }
 }

--- a/src/api/routes/ws/channels/ws-rpc-channel.ts
+++ b/src/api/routes/ws/channels/ws-rpc-channel.ts
@@ -42,7 +42,7 @@ import {
   RpcNftCollectionEventSubscriptionParams,
   NftEvent,
 } from '@stacks/stacks-blockchain-api-types';
-import { getWsMessageTimeout, getWsPingInterval } from '../web-socket-transmitter';
+import { getWsMessageTimeoutMs, getWsPingIntervalMs } from '../web-socket-transmitter';
 
 type Subscription =
   | RpcTxUpdateSubscriptionParams
@@ -65,7 +65,7 @@ class SubscriptionManager {
   // Sockets that are responding to ping.
   liveSockets: Set<WebSocket> = new Set();
   heartbeatInterval?: NodeJS.Timeout;
-  readonly heartbeatIntervalMs = getWsPingInterval();
+  readonly heartbeatIntervalMs = getWsPingIntervalMs();
 
   addSubscription(client: WebSocket, topicId: string) {
     if (this.subscriptions.size === 0) {
@@ -787,7 +787,7 @@ export class WsRpcChannel extends WebSocketChannel {
     );
     // If the payload takes more than 5 seconds to be processed by the client,
     // it will be disconnected.
-    const successful = await resolveOrTimeout(sendPromise, getWsMessageTimeout());
+    const successful = await resolveOrTimeout(sendPromise, getWsMessageTimeoutMs());
     if (!successful) {
       manager.removeSubscription(client, topicId);
     }

--- a/src/api/routes/ws/web-socket-transmitter.ts
+++ b/src/api/routes/ws/web-socket-transmitter.ts
@@ -27,6 +27,10 @@ export function getWsMessageTimeoutMs(): number {
   return parseInt(process.env['STACKS_API_WS_MESSAGE_TIMEOUT'] ?? '5') * 1000;
 }
 
+export function getWsUpdateQueueTimeoutMs(): number {
+  return parseInt(process.env['STACKS_API_WS_UPDATE_QUEUE_TIMEOUT'] ?? '5') * 1000;
+}
+
 /**
  * This object matches real time update `WebSocketTopics` subscriptions with internal
  * `PgStoreEventEmitter` notifications. If a match is found, the relevant data is queried from the
@@ -45,7 +49,7 @@ export class WebSocketTransmitter {
     this.queue = new PQueue({
       autoStart: true,
       concurrency: 1,
-      timeout: 5_000, // 5 seconds
+      timeout: getWsUpdateQueueTimeoutMs(),
       throwOnTimeout: true,
     });
   }

--- a/src/api/routes/ws/web-socket-transmitter.ts
+++ b/src/api/routes/ws/web-socket-transmitter.ts
@@ -33,7 +33,7 @@ export class WebSocketTransmitter {
     this.queue = new PQueue({
       autoStart: true,
       concurrency: 1,
-      timeout: 10_000, // 10 seconds
+      timeout: 5_000, // 5 seconds
       throwOnTimeout: true,
     });
   }

--- a/src/api/routes/ws/web-socket-transmitter.ts
+++ b/src/api/routes/ws/web-socket-transmitter.ts
@@ -15,6 +15,18 @@ import { WsRpcChannel } from './channels/ws-rpc-channel';
 import { parseNftEvent } from '../../../datastore/helpers';
 import { logger } from '../../../helpers';
 
+export function getWsPingInterval(): number {
+  return parseInt(process.env['STACKS_API_WS_PING_INTERVAL'] ?? '5000');
+}
+
+export function getWsPingTimeout(): number {
+  return parseInt(process.env['STACKS_API_WS_PING_TIMEOUT'] ?? '5000');
+}
+
+export function getWsMessageTimeout(): number {
+  return parseInt(process.env['STACKS_API_WS_MESSAGE_TIMEOUT'] ?? '5000');
+}
+
 /**
  * This object matches real time update `WebSocketTopics` subscriptions with internal
  * `PgStoreEventEmitter` notifications. If a match is found, the relevant data is queried from the

--- a/src/api/routes/ws/web-socket-transmitter.ts
+++ b/src/api/routes/ws/web-socket-transmitter.ts
@@ -27,7 +27,7 @@ export function getWsMessageTimeoutMs(): number {
   return parseInt(process.env['STACKS_API_WS_MESSAGE_TIMEOUT'] ?? '5') * 1000;
 }
 
-export function getWsUpdateQueueTimeoutMs(): number {
+function getWsUpdateQueueTimeoutMs(): number {
   return parseInt(process.env['STACKS_API_WS_UPDATE_QUEUE_TIMEOUT'] ?? '5') * 1000;
 }
 

--- a/src/api/routes/ws/web-socket-transmitter.ts
+++ b/src/api/routes/ws/web-socket-transmitter.ts
@@ -15,16 +15,16 @@ import { WsRpcChannel } from './channels/ws-rpc-channel';
 import { parseNftEvent } from '../../../datastore/helpers';
 import { logger } from '../../../helpers';
 
-export function getWsPingInterval(): number {
-  return parseInt(process.env['STACKS_API_WS_PING_INTERVAL'] ?? '5000');
+export function getWsPingIntervalMs(): number {
+  return parseInt(process.env['STACKS_API_WS_PING_INTERVAL'] ?? '5') * 1000;
 }
 
-export function getWsPingTimeout(): number {
-  return parseInt(process.env['STACKS_API_WS_PING_TIMEOUT'] ?? '5000');
+export function getWsPingTimeoutMs(): number {
+  return parseInt(process.env['STACKS_API_WS_PING_TIMEOUT'] ?? '5') * 1000;
 }
 
-export function getWsMessageTimeout(): number {
-  return parseInt(process.env['STACKS_API_WS_MESSAGE_TIMEOUT'] ?? '5000');
+export function getWsMessageTimeoutMs(): number {
+  return parseInt(process.env['STACKS_API_WS_MESSAGE_TIMEOUT'] ?? '5') * 1000;
 }
 
 /**

--- a/src/api/routes/ws/web-socket-transmitter.ts
+++ b/src/api/routes/ws/web-socket-transmitter.ts
@@ -1,4 +1,5 @@
 import * as http from 'http';
+import PQueue from 'p-queue';
 import { AddressStxBalanceResponse, AddressTransactionWithTransfers } from 'docs/generated';
 import {
   getBlockFromDataStore,
@@ -8,7 +9,7 @@ import {
   parseDbTx,
 } from '../../controllers/db-controller';
 import { PgStore } from '../../../datastore/pg-store';
-import { WebSocketChannel } from './web-socket-channel';
+import { ListenerType, WebSocketChannel, WebSocketPayload } from './web-socket-channel';
 import { SocketIOChannel } from './channels/socket-io-channel';
 import { WsRpcChannel } from './channels/ws-rpc-channel';
 import { parseNftEvent } from '../../../datastore/helpers';
@@ -23,23 +24,45 @@ export class WebSocketTransmitter {
   readonly db: PgStore;
   readonly server: http.Server;
   private channels: WebSocketChannel[] = [];
+  private queue: PQueue;
 
   constructor(db: PgStore, server: http.Server) {
     this.db = db;
     this.server = server;
+    // This queue will send all messages through web socket channels, one at a time.
+    this.queue = new PQueue({
+      autoStart: true,
+      concurrency: 1,
+      timeout: 10_000, // 10 seconds
+      throwOnTimeout: true,
+    });
   }
 
   connect() {
-    this.db.eventEmitter.addListener('blockUpdate', blockHash => this.blockUpdate(blockHash));
+    this.db.eventEmitter.addListener('blockUpdate', blockHash =>
+      this.queue
+        .add(() => this.blockUpdate(blockHash))
+        .catch(error => logger.error(`WebSocketTransmitter blockUpdate error: ${error}`))
+    );
     this.db.eventEmitter.addListener('microblockUpdate', microblockHash =>
-      this.microblockUpdate(microblockHash)
+      this.queue
+        .add(() => this.microblockUpdate(microblockHash))
+        .catch(error => logger.error(`WebSocketTransmitter microblockUpdate error: ${error}`))
     );
     this.db.eventEmitter.addListener('nftEventUpdate', (txId, eventIndex) =>
-      this.nftEventUpdate(txId, eventIndex)
+      this.queue
+        .add(() => this.nftEventUpdate(txId, eventIndex))
+        .catch(error => logger.error(`WebSocketTransmitter nftEventUpdate error: ${error}`))
     );
-    this.db.eventEmitter.addListener('txUpdate', txId => this.txUpdate(txId));
+    this.db.eventEmitter.addListener('txUpdate', txId =>
+      this.queue
+        .add(() => this.txUpdate(txId))
+        .catch(error => logger.error(`WebSocketTransmitter txUpdate error: ${error}`))
+    );
     this.db.eventEmitter.addListener('addressUpdate', (address, blockHeight) =>
-      this.addressUpdate(address, blockHeight)
+      this.queue
+        .add(() => this.addressUpdate(address, blockHeight))
+        .catch(error => logger.error(`WebSocketTransmitter addressUpdate error: ${error}`))
     );
 
     this.channels.push(new SocketIOChannel(this.server));
@@ -48,6 +71,8 @@ export class WebSocketTransmitter {
   }
 
   close(callback: (err?: Error | undefined) => void) {
+    this.queue.pause();
+    this.queue.clear();
     Promise.all(
       this.channels.map(
         c =>
@@ -66,6 +91,13 @@ export class WebSocketTransmitter {
       .catch(error => callback(error));
   }
 
+  private send<P extends keyof WebSocketPayload>(
+    payload: P,
+    ...args: ListenerType<WebSocketPayload[P]>
+  ): Promise<void[]> {
+    return Promise.all(this.channels.map(c => c.send(payload, ...args)));
+  }
+
   private async blockUpdate(blockHash: string) {
     if (this.channels.find(c => c.hasListeners('block'))) {
       try {
@@ -74,7 +106,7 @@ export class WebSocketTransmitter {
           db: this.db,
         });
         if (blockQuery.found) {
-          this.channels.forEach(c => c.send('block', blockQuery.result));
+          await this.send('block', blockQuery.result);
         }
       } catch (error) {
         logger.error(error);
@@ -90,7 +122,7 @@ export class WebSocketTransmitter {
           microblockHash: microblockHash,
         });
         if (microblockQuery.found) {
-          this.channels.forEach(c => c.send('microblock', microblockQuery.result));
+          await this.send('microblock', microblockQuery.result);
         }
       } catch (error) {
         logger.error(error);
@@ -106,7 +138,7 @@ export class WebSocketTransmitter {
           includeUnanchored: true,
         });
         if (mempoolTxs.length > 0) {
-          this.channels.forEach(c => c.send('mempoolTransaction', mempoolTxs[0]));
+          await this.send('mempoolTransaction', mempoolTxs[0]);
         }
       } catch (error) {
         logger.error(error);
@@ -135,7 +167,7 @@ export class WebSocketTransmitter {
           }
         });
         if (result) {
-          this.channels.forEach(c => c.send('transaction', result));
+          await this.send('transaction', result);
         }
       } catch (error) {
         logger.error(error);
@@ -154,13 +186,13 @@ export class WebSocketTransmitter {
       const event = parseNftEvent(nftEvent.result);
 
       if (this.channels.find(c => c.hasListeners('nftEvent'))) {
-        this.channels.forEach(c => c.send('nftEvent', event));
+        await this.send('nftEvent', event);
       }
       if (this.channels.find(c => c.hasListeners('nftAssetEvent', assetIdentifier, value))) {
-        this.channels.forEach(c => c.send('nftAssetEvent', assetIdentifier, value, event));
+        await this.send('nftAssetEvent', assetIdentifier, value, event);
       }
       if (this.channels.find(c => c.hasListeners('nftCollectionEvent', assetIdentifier))) {
-        this.channels.forEach(c => c.send('nftCollectionEvent', assetIdentifier, event));
+        await this.send('nftCollectionEvent', assetIdentifier, event);
       }
     } catch (error) {
       logger.error(error);
@@ -193,7 +225,7 @@ export class WebSocketTransmitter {
               };
             }),
           };
-          this.channels.forEach(c => c.send('principalTransaction', address, result));
+          await this.send('principalTransaction', address, result);
         }
       } catch (error) {
         logger.error(error);
@@ -222,7 +254,7 @@ export class WebSocketTransmitter {
           }
           return balance;
         });
-        this.channels.forEach(c => c.send('principalStxBalance', address, balance));
+        await this.send('principalStxBalance', address, balance);
       } catch (error) {
         logger.error(error);
       }


### PR DESCRIPTION
We currently process and send all web socket messages synchronously and in series, which may be causing OOM errors in node.js when a huge anchor block comes that tries to send potentially hundreds of messages to dozens of subscribers.

This PR:
* Adds a priority queue to handle incoming web socket messages from API read-only nodes, with a concurrency of `1` and a max job timeout of 5 seconds (e.g. 5 seconds to send a single `block` update to all block subscribers).
* Adds configurable 5 second timeouts to:
  * Client ping/pong
  * Each message sent to each client
  * Per update enqueued to all clients
* Changes the ws-channel message send operations to be processed in parallel, so we can dispatch one message to all channels immediately and we can better use the 5 seconds we have available.

cc @CharlieC3 

