### PR TITLE
ci: add workflow dispatch for standalone docker image build

### DIFF
--- a/.github/workflows/regtest-image.yml
+++ b/.github/workflows/regtest-image.yml
@@ -1,0 +1,141 @@
+name: Publish standalone regtest image
+
+on:
+  workflow_dispatch:
+    inputs:
+      stacks_blockchain_commit:
+        description: 'stacks-blockchain git commit'
+        required: true
+        type: string
+
+env:
+  STACKS_API_COMMIT: ${{ github.sha }}
+  STACKS_BLOCKCHAIN_COMMIT: ${{ inputs.stacks_blockchain_commit }}
+
+jobs:
+  build-stacks-node:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Cache stacks-node
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: bin
+          key: cache-stacks-node-${{ env.STACKS_BLOCKCHAIN_COMMIT }}
+      - name: Install Rust - linux/amd64
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-unknown-linux-gnu
+      - name: Install Rust - linux/arm64
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-unknown-linux-gnu
+      - name: Install compilation tooling
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-aarch64-linux-gnu libc6-dev-arm64-cross gcc-aarch64-linux-gnu
+      - name: Fetch Stacks node repo
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          echo "$PWD"
+          mkdir stacks-blockchain-repo && cd stacks-blockchain-repo
+          git init
+          git remote add origin https://github.com/stacks-network/stacks-blockchain.git
+          git -c protocol.version=2 fetch --depth=1 origin $STACKS_BLOCKCHAIN_COMMIT
+          git reset --hard FETCH_HEAD
+      - name: Rust cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "stacks-blockchain-repo"
+          shared-key: rust-cache-stacks-node-${{ env.STACKS_BLOCKCHAIN_COMMIT }}
+      - name: Cargo fetch
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: stacks-blockchain-repo
+        run: |
+          cargo fetch --manifest-path testnet/stacks-node/Cargo.toml --target x86_64-unknown-linux-gnu --target aarch64-unknown-linux-gnu
+      - name: Build Stacks node
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: stacks-blockchain-repo
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+          CXX_aarch64_unknown_linux_gnu: aarch64-linux-gnu-g++
+          AR_aarch64_unknown_linux_gnu: aarch64-linux-gnu-ar
+        run: |
+          cargo build --package stacks-node --bin stacks-node --release --target x86_64-unknown-linux-gnu --target aarch64-unknown-linux-gnu
+          mkdir -p ../bin/x86_64-unknown-linux-gnu ../bin/aarch64-unknown-linux-gnu
+          cp target/x86_64-unknown-linux-gnu/release/stacks-node ../bin/x86_64-unknown-linux-gnu
+          cp target/aarch64-unknown-linux-gnu/release/stacks-node ../bin/aarch64-unknown-linux-gnu
+      - uses: actions/upload-artifact@v3
+        with:
+          name: stacks-node-bin
+          if-no-files-found: error
+          path: |
+            bin/*/stacks-node
+
+  build-push-docker:
+    needs: build-stacks-node
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: stacks-node-bin
+          path: docker/stacks-blockchain-binaries
+      - name: Process of downloaded artifacts
+        working-directory: docker/stacks-blockchain-binaries
+        run: |
+          ls -R
+          chmod +x x86_64-unknown-linux-gnu/stacks-node
+          chmod +x aarch64-unknown-linux-gnu/stacks-node
+      - name: Create tag labels
+        run: |
+          api_short=$(head -c 7 <<< "$STACKS_API_COMMIT")
+          blockchain_short=$(head -c 7 <<< "$STACKS_BLOCKCHAIN_COMMIT")
+          echo "GIT_SHORTS=${api_short}-${blockchain_short}" >> $GITHUB_ENV
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: hirosystems/${{ github.event.repository.name }}-standalone-regtest
+          tags: |
+            type=raw,value=latest,enable=false
+            type=raw,value={{date 'YYYYMMDDHH'}}-${{ env.GIT_SHORTS }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          config-inline: |
+            [worker.oci]
+              max-parallelism = 1
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          file: docker/standalone-regtest.Dockerfile
+          context: ./docker
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=hirosystems/${{ github.event.repository.name }}-standalone-regtest
+          cache-to: type=inline
+          build-args: |
+            STACKS_API_VERSION=${{ github.head_ref || github.ref_name }}
+            API_GIT_COMMIT=${{ env.STACKS_API_COMMIT }}
+            BLOCKCHAIN_GIT_COMMIT=${{ env.STACKS_BLOCKCHAIN_COMMIT }}


### PR DESCRIPTION
Add workflow_dispatch config for building the standalone regtest docker image. This needs to be in master for it to show up in the github "Run workflow" UI.