### PR TITLE
Publish standalone regtest image

### DIFF
--- a/.github/workflows/regtest-image.yml
+++ b/.github/workflows/regtest-image.yml
@@ -1,0 +1,141 @@
+name: Publish standalone regtest image
+
+on:
+  workflow_dispatch:
+    inputs:
+      stacks_blockchain_commit:
+        description: 'stacks-blockchain git commit'
+        required: true
+        type: string
+
+env:
+  STACKS_API_COMMIT: ${{ github.sha }}
+  STACKS_BLOCKCHAIN_COMMIT: ${{ inputs.stacks_blockchain_commit }}
+
+jobs:
+  build-stacks-node:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Cache stacks-node
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: bin
+          key: cache-stacks-node-${{ env.STACKS_BLOCKCHAIN_COMMIT }}
+      - name: Install Rust - linux/amd64
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-unknown-linux-gnu
+      - name: Install Rust - linux/arm64
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-unknown-linux-gnu
+      - name: Install compilation tooling
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-aarch64-linux-gnu libc6-dev-arm64-cross gcc-aarch64-linux-gnu
+      - name: Fetch Stacks node repo
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          echo "$PWD"
+          mkdir stacks-blockchain-repo && cd stacks-blockchain-repo
+          git init
+          git remote add origin https://github.com/stacks-network/stacks-blockchain.git
+          git -c protocol.version=2 fetch --depth=1 origin $STACKS_BLOCKCHAIN_COMMIT
+          git reset --hard FETCH_HEAD
+      - name: Rust cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "stacks-blockchain-repo"
+          shared-key: rust-cache-stacks-node-${{ env.STACKS_BLOCKCHAIN_COMMIT }}
+      - name: Cargo fetch
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: stacks-blockchain-repo
+        run: |
+          cargo fetch --manifest-path testnet/stacks-node/Cargo.toml --target x86_64-unknown-linux-gnu --target aarch64-unknown-linux-gnu
+      - name: Build Stacks node
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: stacks-blockchain-repo
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+          CXX_aarch64_unknown_linux_gnu: aarch64-linux-gnu-g++
+          AR_aarch64_unknown_linux_gnu: aarch64-linux-gnu-ar
+        run: |
+          cargo build --package stacks-node --bin stacks-node --release --target x86_64-unknown-linux-gnu --target aarch64-unknown-linux-gnu
+          mkdir -p ../bin/x86_64-unknown-linux-gnu ../bin/aarch64-unknown-linux-gnu
+          cp target/x86_64-unknown-linux-gnu/release/stacks-node ../bin/x86_64-unknown-linux-gnu
+          cp target/aarch64-unknown-linux-gnu/release/stacks-node ../bin/aarch64-unknown-linux-gnu
+      - uses: actions/upload-artifact@v3
+        with:
+          name: stacks-node-bin
+          if-no-files-found: error
+          path: |
+            bin/*/stacks-node
+
+  build-push-docker:
+    needs: build-stacks-node
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: stacks-node-bin
+          path: docker/stacks-blockchain-binaries
+      - name: Process of downloaded artifacts
+        working-directory: docker/stacks-blockchain-binaries
+        run: |
+          ls -R
+          chmod +x x86_64-unknown-linux-gnu/stacks-node
+          chmod +x aarch64-unknown-linux-gnu/stacks-node
+      - name: Create tag labels
+        run: |
+          api_short=$(head -c 7 <<< "$STACKS_API_COMMIT")
+          blockchain_short=$(head -c 7 <<< "$STACKS_BLOCKCHAIN_COMMIT")
+          echo "GIT_SHORTS=${api_short}-${blockchain_short}" >> $GITHUB_ENV
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: hirosystems/${{ github.event.repository.name }}-standalone-regtest
+          tags: |
+            type=raw,value=latest,enable=false
+            type=raw,value={{date 'YYYYMMDDHH'}}-${{ env.GIT_SHORTS }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          config-inline: |
+            [worker.oci]
+              max-parallelism = 1
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          file: docker/standalone-regtest.Dockerfile
+          context: ./docker
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=hirosystems/${{ github.event.repository.name }}-standalone-regtest
+          cache-to: type=inline
+          build-args: |
+            STACKS_API_VERSION=${{ github.head_ref || github.ref_name }}
+            API_GIT_COMMIT=${{ env.STACKS_API_COMMIT }}
+            BLOCKCHAIN_GIT_COMMIT=${{ env.STACKS_BLOCKCHAIN_COMMIT }}

--- a/docker/standalone-regtest.Dockerfile
+++ b/docker/standalone-regtest.Dockerfile
@@ -2,7 +2,9 @@
 
 FROM node:16-bullseye as api-builder
 
-ARG API_GIT_COMMIT=5d76760f2757a3b284e684b8cdcb5c2bcb04269c
+ARG API_GIT_COMMIT
+ARG STACKS_API_VERSION
+
 ENV DEBIAN_FRONTEND noninteractive
 
 WORKDIR /api
@@ -20,7 +22,7 @@ EOF
 
 # Build API
 RUN rm ".env" && \
-    git describe --tags --abbrev=0 || git -c user.name='user' -c user.email='email' tag vNext && \
+    git describe --tags --abbrev=0 || git -c user.name='user' -c user.email='email' tag "${STACKS_API_VERSION:-vNext}" && \
     echo "GIT_TAG=$(git tag --points-at HEAD)" >> .env && \
     npm config set update-notifier false && \
     npm config set unsafe-perm true && \
@@ -30,7 +32,7 @@ RUN rm ".env" && \
 
 FROM rust:bullseye as blockchain-builder
 
-ARG BLOCKCHAIN_GIT_COMMIT=b16e121d94306887f21c3d3ed7da1d980c5f3454
+ARG BLOCKCHAIN_GIT_COMMIT
 ENV DEBIAN_FRONTEND noninteractive
 ARG TARGETPLATFORM
 


### PR DESCRIPTION
Follow up to the standalone regtest image implemented in https://github.com/hirosystems/stacks-blockchain-api/pull/1476

> ... new standalone regtest dockerfile which is epoch 2.1 capable. This is intended to be used in CI/local testing as an alternative to the existing standalone docker image (which uses a mocknet stacks-node that is non-functional for epoch 2.1 testing).

This PR adds a workflow_dispatch (manually triggered CI) config to build the new image. 
* Multi-platform images are built (for both arm64 and x86).
* This currently uses git commit SHAs for building both the API and stacks-node, so the git tag-based version reporting (`/v2/info` and `/extended/v1/status`) will show the commit hashes but the branch/version will be stubbed. This can be fixed once the Stacks 2.1 related branches on the blockchain repo and API repo become more stabilized. 
* The docker image tag is currently `${date YYYYMMDDHH}-${STACKS_API_SHA}-${BLOCKCHAIN_SHA}` -- this can also be improved later once the repo branches stabilize. 
  * The datetime is included to give a human readable idea of a "version", until actual version tags are stable and ready to use.
* Several techniques are used to reduce docker build time, which otherwise would take several hours for multi-platform stacks-node and API building:
  * The stacks-node binary is cross-compiled on the runner host and then copied into the docker image during build.
  * Cargo's new multi-target build feature is used.
  * A rust-specific github caching action is used.
  * Docker-registry caching is enabled.
* Despite the above speedups, a "cold build" (no cache hits) can take ~1 hour, so later on, this workflow should probably only be enabled on merge to a release branch.

Currently, this workflow must be ran with this blockchain commit: https://github.com/stacks-network/stacks-blockchain/pull/3409/commits/b16e121d94306887f21c3d3ed7da1d980c5f3454

See example of running this workflow: https://github.com/hirosystems/stacks-blockchain-api/actions/runs/3648003869/jobs/6161211248

And the image it published: https://hub.docker.com/layers/hirosystems/stacks-blockchain-api-standalone-regtest/2022120812-88f446b-b16e121/images/sha256-726d8b52bdea017ed3f46f1341da755f288b4a94caace5a017a2799a56914bc0?context=explore