### PR TITLE
Fix bns test

### DIFF
--- a/src/tests-bns/event-server-tests.ts
+++ b/src/tests-bns/event-server-tests.ts
@@ -1067,12 +1067,5 @@ describe('BNS event server tests', () => {
     const configState = await db.getConfigState();
     expect(configState.bns_names_onchain_imported).toBe(false)
     expect(configState.bns_subdomains_imported).toBe(false)
-
-    await new Promise(resolve => setTimeout(async() => {
-      const configState = await db.getConfigState();
-      expect(configState.bns_names_onchain_imported).toBe(true)
-      expect(configState.bns_subdomains_imported).toBe(true)
-      resolve(undefined)
-    }, 2000))
   })
 })

--- a/src/tests-bns/event-server-tests.ts
+++ b/src/tests-bns/event-server-tests.ts
@@ -1052,6 +1052,7 @@ describe('BNS event server tests', () => {
   })
 
   test('BNS middleware is async. /new_block posts return before importing BNS finishes', async () => {
+    jest.useRealTimers();
     process.env.BNS_IMPORT_DIR = 'src/tests-bns/import-test-files';
     const genesisBlock = await getGenesisBlockData('src/tests-event-replay/tsv/mainnet.tsv');
 
@@ -1067,5 +1068,16 @@ describe('BNS event server tests', () => {
     const configState = await db.getConfigState();
     expect(configState.bns_names_onchain_imported).toBe(false)
     expect(configState.bns_subdomains_imported).toBe(false)
+
+    const timeoutId: NodeJS.Timeout = await new Promise(resolve => {
+      const timeoutId = setTimeout(async() => {
+        const configState = await db.getConfigState();
+        expect(configState.bns_names_onchain_imported).toBe(true)
+        expect(configState.bns_subdomains_imported).toBe(true)
+        resolve(timeoutId)
+      }, 2000)
+    })
+
+    clearTimeout(timeoutId);  
   })
 })


### PR DESCRIPTION
Fix bns test that is causing a timeout on build. 

https://github.com/hirosystems/stacks-blockchain-api/actions/runs/3678727169

Test is passing CI, but failing build. Test still confirms that the post request returns before bns import has finished.