### PR TITLE
ci: workflow to build and publish the stacks-node image used internally for integration tests

### DIFF
--- a/.github/workflows/stacks-node-image.yml
+++ b/.github/workflows/stacks-node-image.yml
@@ -1,0 +1,81 @@
+name: Publish stacks-node testing image
+
+on:
+  workflow_dispatch:
+    inputs:
+      stacks_blockchain_branch:
+        description: 'stacks-blockchain git branch or tag'
+        required: true
+        type: string
+
+env:
+  STACKS_BLOCKCHAIN_BRANCH: ${{ inputs.stacks_blockchain_branch || 'next' }}
+
+jobs:
+  build-stacks-node:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Fetch Stacks node repo
+        run: |
+          mkdir stacks-blockchain-repo && cd stacks-blockchain-repo
+          git clone --depth 1 --branch "$STACKS_BLOCKCHAIN_BRANCH" https://github.com/stacks-network/stacks-blockchain.git .
+          STACKS_BLOCKCHAIN_COMMIT=$(git rev-parse HEAD)
+          echo "stacks-blockchain branch: $STACKS_BLOCKCHAIN_BRANCH, commit: $STACKS_BLOCKCHAIN_COMMIT"
+          echo "STACKS_BLOCKCHAIN_COMMIT=$STACKS_BLOCKCHAIN_COMMIT" >> $GITHUB_ENV
+          echo "STACKS_BLOCKCHAIN_COMMIT_SHORT=$(head -c 7 <<< $STACKS_BLOCKCHAIN_COMMIT)" >> $GITHUB_ENV
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu
+      - name: Install compilation tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-aarch64-linux-gnu libc6-dev-arm64-cross gcc-aarch64-linux-gnu
+      - name: Cargo fetch
+        working-directory: stacks-blockchain-repo
+        run: |
+          cargo fetch --manifest-path testnet/stacks-node/Cargo.toml --target x86_64-unknown-linux-gnu --target aarch64-unknown-linux-gnu
+      - name: Build Stacks node
+        working-directory: stacks-blockchain-repo
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+          CXX_aarch64_unknown_linux_gnu: aarch64-linux-gnu-g++
+          AR_aarch64_unknown_linux_gnu: aarch64-linux-gnu-ar
+        run: |
+          cargo build --package stacks-node --bin stacks-node --release --target x86_64-unknown-linux-gnu --target aarch64-unknown-linux-gnu
+          mkdir -p ../docker/stacks-blockchain-binaries/x86_64-unknown-linux-gnu
+          mkdir -p ../docker/stacks-blockchain-binaries/aarch64-unknown-linux-gnu
+          cp target/x86_64-unknown-linux-gnu/release/stacks-node ../docker/stacks-blockchain-binaries/x86_64-unknown-linux-gnu
+          cp target/aarch64-unknown-linux-gnu/release/stacks-node ../docker/stacks-blockchain-binaries/aarch64-unknown-linux-gnu
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: hirosystems/${{ github.event.repository.name }}-test-node
+          tags: |
+            type=raw,value=latest,enable=false
+            type=raw,value=${{ env.STACKS_BLOCKCHAIN_COMMIT_SHORT }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          file: docker/stacks-test-node.Dockerfile
+          context: ./docker
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=hirosystems/${{ github.event.repository.name }}-test-node
+          cache-to: type=inline

--- a/docker/stacks-test-node.Dockerfile
+++ b/docker/stacks-test-node.Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+
+FROM debian:bullseye-slim
+
+ARG TARGETPLATFORM
+
+# Use pre-build binaries from context directory
+COPY *stacks-blockchain-binaries /stacks-blockchain-binaries
+
+SHELL ["/bin/bash", "-ce"]
+RUN <<EOF
+  STACKS_NODE_BIN_ARM64=/stacks-blockchain-binaries/aarch64-unknown-linux-gnu/stacks-node
+  STACKS_NODE_BIN_AMD64=/stacks-blockchain-binaries/x86_64-unknown-linux-gnu/stacks-node
+  if [ "$TARGETPLATFORM" = "linux/arm64" ] && [ -f "$STACKS_NODE_BIN_ARM64" ]; then
+    echo "Using existing stacks-node binary: $STACKS_NODE_BIN_ARM64"
+    mkdir -p target/release && mv "$STACKS_NODE_BIN_ARM64" /usr/bin/stacks-node
+    exit 0
+  elif [ "$TARGETPLATFORM" = "linux/amd64" ] && [ -f "$STACKS_NODE_BIN_AMD64" ]; then
+    echo "Using existing stacks-node binary: $STACKS_NODE_BIN_AMD64"
+    mkdir -p target/release && mv "$STACKS_NODE_BIN_AMD64" /usr/bin/stacks-node
+    exit 0
+  else
+    echo "No stacks-node binary available for $TARGETPLATFORM"
+    exit 1
+  fi
+  rm -rf /stacks-blockchain-binaries
+EOF
+
+CMD ["/usr/bin/stacks-node"]


### PR DESCRIPTION
PR against master branch so that the github "run workflow" UI is available.

The API pulls a pre-built image for the stacks-node, used for both local development and in CI tests. Currently, it's pulling from another repo:

https://github.com/hirosystems/stacks-blockchain-api/blob/5ee9d34f5ba0757fb91ec355304fc8df5ceb80d8/stacks-blockchain/docker/Dockerfile#L2

This PR creates a workflow dispatch to build and publish the testing stacks-node docker image. Once merged, a follow-up PR will change the above code to use the image produced by this repo.

Cross-compilation optimizations are implemented to build both x86 and arm64 images.

Image tags use the short git commit hash -- this can be improved later once the stacks-blockchain `next` branch stabilizes (e.g. with an RC).

See demo run here: https://github.com/hirosystems/stacks-blockchain-api/actions/runs/3759601436/jobs/6389358450