### PR TITLE
Fix: make query limits backwards compatible

### DIFF
--- a/src/api/pagination.ts
+++ b/src/api/pagination.ts
@@ -65,23 +65,24 @@ const pagingQueryLimits: Record<ResourceType, { defaultLimit: number; maxLimit: 
     defaultLimit: 50,
     maxLimit: 200,
   },
-  [ResourceType.Token]: {
-    defaultLimit: 50,
-    maxLimit: 200,
-  },
   [ResourceType.Pox2Event]: {
     defaultLimit: 96,
     maxLimit: 200,
   },
 };
 
-export function getPagingQueryLimit(resourceType: ResourceType, limitOverride?: any) {
+export function getPagingQueryLimit(
+  resourceType: ResourceType,
+  limitOverride?: any,
+  maxLimitOverride?: number
+) {
   const pagingQueryLimit = pagingQueryLimits[resourceType];
   if (!limitOverride) {
     return pagingQueryLimit.defaultLimit;
   }
   const newLimit = parsePagingQueryInput(limitOverride);
-  if (newLimit > pagingQueryLimit.maxLimit) {
+  const maxLimit = maxLimitOverride ?? pagingQueryLimit.maxLimit;
+  if (newLimit > maxLimit) {
     throw new InvalidRequestError(
       `'limit' must be equal to or less than ${pagingQueryLimit.maxLimit}`,
       InvalidRequestErrorType.invalid_query

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -442,7 +442,7 @@ export function createAddressRouter(db: PgStore, chainId: ChainID): express.Rout
             blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
           }
 
-          const limit = getPagingQueryLimit(ResourceType.Tx, req.query.limit, 500);
+          const limit = getPagingQueryLimit(ResourceType.Tx, req.query.limit);
           const offset = parsePagingQueryInput(req.query.offset ?? 0);
           const { results, total } = await db.getInboundTransfers({
             stxAddress,

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -442,7 +442,7 @@ export function createAddressRouter(db: PgStore, chainId: ChainID): express.Rout
             blockHeight = await getBlockHeight(untilBlock, req, res, next, db);
           }
 
-          const limit = getPagingQueryLimit(ResourceType.Tx, req.query.limit);
+          const limit = getPagingQueryLimit(ResourceType.Tx, req.query.limit, 500);
           const offset = parsePagingQueryInput(req.query.offset ?? 0);
           const { results, total } = await db.getInboundTransfers({
             stxAddress,

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -43,7 +43,7 @@ export function createTxRouter(db: PgStore): express.Router {
     '/',
     cacheHandler,
     asyncHandler(async (req, res, next) => {
-      const limit = getPagingQueryLimit(ResourceType.Tx, req.query.limit, 200);
+      const limit = getPagingQueryLimit(ResourceType.Tx, req.query.limit);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
 
       const typeQuery = req.query.type;
@@ -85,7 +85,7 @@ export function createTxRouter(db: PgStore): express.Router {
         req.query.tx_id = [req.query.tx_id];
       }
       const txList: string[] = req.query.tx_id as string[];
-      const eventLimit = getPagingQueryLimit(ResourceType.Tx, req.query['event_limit'], 200);
+      const eventLimit = getPagingQueryLimit(ResourceType.Tx, req.query['event_limit']);
       const eventOffset = parsePagingQueryInput(req.query['event_offset'] ?? 0);
       const includeUnanchored = isUnanchoredRequest(req, res, next);
       txList.forEach(tx => validateRequestHexInput(tx));
@@ -110,7 +110,7 @@ export function createTxRouter(db: PgStore): express.Router {
     '/mempool',
     mempoolCacheHandler,
     asyncHandler(async (req, res, next) => {
-      const limit = getPagingQueryLimit(ResourceType.Tx, req.query.limit, 200);
+      const limit = getPagingQueryLimit(ResourceType.Tx, req.query.limit);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
 
       let addrParams: (string | undefined)[];
@@ -171,7 +171,7 @@ export function createTxRouter(db: PgStore): express.Router {
     '/mempool/dropped',
     mempoolCacheHandler,
     asyncHandler(async (req, res) => {
-      const limit = getPagingQueryLimit(ResourceType.Tx, req.query.limit, 200);
+      const limit = getPagingQueryLimit(ResourceType.Tx, req.query.limit);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
       const { results: txResults, total } = await db.getDroppedTxs({
         offset,
@@ -198,7 +198,7 @@ export function createTxRouter(db: PgStore): express.Router {
     '/events',
     cacheHandler,
     asyncHandler(async (req, res, next) => {
-      const limit = getPagingQueryLimit(ResourceType.Tx, req.query['limit'], 200);
+      const limit = getPagingQueryLimit(ResourceType.Tx, req.query['limit'], 100);
       const offset = parsePagingQueryInput(req.query['offset'] ?? 0);
 
       const principalOrTxId = parseAddressOrTxId(req, res, next);
@@ -227,7 +227,7 @@ export function createTxRouter(db: PgStore): express.Router {
         return res.redirect('/extended/v1/tx/0x' + tx_id + url.search);
       }
 
-      const eventLimit = getPagingQueryLimit(ResourceType.Tx, req.query['event_limit'], 200);
+      const eventLimit = getPagingQueryLimit(ResourceType.Tx, req.query['event_limit'], 100);
       const eventOffset = parsePagingQueryInput(req.query['event_offset'] ?? 0);
       const includeUnanchored = isUnanchoredRequest(req, res, next);
       validateRequestHexInput(tx_id);
@@ -308,7 +308,7 @@ export function createTxRouter(db: PgStore): express.Router {
     cacheHandler,
     asyncHandler(async (req, res, next) => {
       const height = getBlockHeightPathParam(req, res, next);
-      const limit = getPagingQueryLimit(ResourceType.Tx, req.query['limit'], 200);
+      const limit = getPagingQueryLimit(ResourceType.Tx, req.query['limit']);
       const offset = parsePagingQueryInput(req.query['offset'] ?? 0);
       const result = await db.getTxsFromBlock({ height: height }, limit, offset);
       if (!result.found) {

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -198,7 +198,7 @@ export function createTxRouter(db: PgStore): express.Router {
     '/events',
     cacheHandler,
     asyncHandler(async (req, res, next) => {
-      const limit = getPagingQueryLimit(ResourceType.Tx, req.query['limit']);
+      const limit = getPagingQueryLimit(ResourceType.Tx, req.query['limit'], 200);
       const offset = parsePagingQueryInput(req.query['offset'] ?? 0);
 
       const principalOrTxId = parseAddressOrTxId(req, res, next);

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -43,7 +43,7 @@ export function createTxRouter(db: PgStore): express.Router {
     '/',
     cacheHandler,
     asyncHandler(async (req, res, next) => {
-      const limit = getPagingQueryLimit(ResourceType.Tx, req.query.limit);
+      const limit = getPagingQueryLimit(ResourceType.Tx, req.query.limit, 200);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
 
       const typeQuery = req.query.type;
@@ -85,7 +85,7 @@ export function createTxRouter(db: PgStore): express.Router {
         req.query.tx_id = [req.query.tx_id];
       }
       const txList: string[] = req.query.tx_id as string[];
-      const eventLimit = getPagingQueryLimit(ResourceType.Tx, req.query['event_limit']);
+      const eventLimit = getPagingQueryLimit(ResourceType.Tx, req.query['event_limit'], 200);
       const eventOffset = parsePagingQueryInput(req.query['event_offset'] ?? 0);
       const includeUnanchored = isUnanchoredRequest(req, res, next);
       txList.forEach(tx => validateRequestHexInput(tx));
@@ -110,7 +110,7 @@ export function createTxRouter(db: PgStore): express.Router {
     '/mempool',
     mempoolCacheHandler,
     asyncHandler(async (req, res, next) => {
-      const limit = getPagingQueryLimit(ResourceType.Tx, req.query.limit);
+      const limit = getPagingQueryLimit(ResourceType.Tx, req.query.limit, 200);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
 
       let addrParams: (string | undefined)[];
@@ -171,7 +171,7 @@ export function createTxRouter(db: PgStore): express.Router {
     '/mempool/dropped',
     mempoolCacheHandler,
     asyncHandler(async (req, res) => {
-      const limit = getPagingQueryLimit(ResourceType.Tx, req.query.limit);
+      const limit = getPagingQueryLimit(ResourceType.Tx, req.query.limit, 200);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
       const { results: txResults, total } = await db.getDroppedTxs({
         offset,
@@ -227,7 +227,7 @@ export function createTxRouter(db: PgStore): express.Router {
         return res.redirect('/extended/v1/tx/0x' + tx_id + url.search);
       }
 
-      const eventLimit = getPagingQueryLimit(ResourceType.Tx, req.query['event_limit']);
+      const eventLimit = getPagingQueryLimit(ResourceType.Tx, req.query['event_limit'], 200);
       const eventOffset = parsePagingQueryInput(req.query['event_offset'] ?? 0);
       const includeUnanchored = isUnanchoredRequest(req, res, next);
       validateRequestHexInput(tx_id);
@@ -276,7 +276,7 @@ export function createTxRouter(db: PgStore): express.Router {
     cacheHandler,
     asyncHandler(async (req, res) => {
       const { block_hash } = req.params;
-      const limit = getPagingQueryLimit(ResourceType.Tx, req.query['limit']);
+      const limit = getPagingQueryLimit(ResourceType.Tx, req.query['limit'], 200);
       const offset = parsePagingQueryInput(req.query['offset'] ?? 0);
       validateRequestHexInput(block_hash);
       const result = await db.getTxsFromBlock({ hash: block_hash }, limit, offset);
@@ -308,7 +308,7 @@ export function createTxRouter(db: PgStore): express.Router {
     cacheHandler,
     asyncHandler(async (req, res, next) => {
       const height = getBlockHeightPathParam(req, res, next);
-      const limit = getPagingQueryLimit(ResourceType.Tx, req.query['limit']);
+      const limit = getPagingQueryLimit(ResourceType.Tx, req.query['limit'], 200);
       const offset = parsePagingQueryInput(req.query['offset'] ?? 0);
       const result = await db.getTxsFromBlock({ height: height }, limit, offset);
       if (!result.found) {

--- a/src/tests/pagination-tests.ts
+++ b/src/tests/pagination-tests.ts
@@ -25,4 +25,7 @@ describe('getPagingQueryLimit()', () => {
   test('Error is thrown when value is larger than input', () => {
     expect(() => getPagingQueryLimit(ResourceType.Block, 31)).toThrowError();
   });
+  test('Error is NOT thrown when value is larger than input but a maxLimitOverride has been provided', () => {
+    expect(() => getPagingQueryLimit(ResourceType.Tx, 100, 200)).not.toThrowError();
+  });
 });


### PR DESCRIPTION
Addressing https://github.com/hirosystems/stacks-blockchain-api/issues/1507

Max paging query limits were lowered causing backward compatibility issues with the explorer.

I am adding a max limit override to getPagingQueryLimit so that we can keep the new paging query limit categorization system without adding additional micro-categories that ostensibly only serve to raise the max limits of a few endpoints to create backwards compatibility. This approach also provides additional flexibility in the future to override query limits on endpoints that need to differ from their natural category query limits.

Added a test for the new override functionality.

The changes that were made to the query limits are below, copied from the PR that introduced them. I am override the max query limit for all those endpoints whose max query limit was changed (in bold).

const pagingQueryLimits: Record<ResourceType, { defaultLimit: number; maxLimit: number }> = {
[ResourceType.Block]: {
defaultLimit: 20,
maxLimit: 30,
},
// '/block'
[ResourceType.Tx]: {
defaultLimit: 20,
maxLimit: 50,
},
// '/address/:principal/transactions'
// '/address/:stx_address/transactions_with_transfers'
// '/address/:address/mempool'
// '/address/:address/mempool'
// '/address/:stx_address/stx_inbound' **Changed max from 500 to 50**
// '/tx' **Changed max from 200 to 50**, Changed default from 96 to 20
// '/tx/mempool/dropped' **Changed max from 200 to 50**, Changed default from 96 to 20
// '/tx/mempool' **Changed max from 200 to 50**, Changed default from 96 to 20
// '/tx/multiple' **Changed max from 200 to 50**, Changed default from 96 to 20
// '/tx/events' **Changed max from 200 to 50**, Changed default from 96 to 20
// '/tx/:tx_id' **Changed max from 200 to 50**, Changed default from 96 to 20
// '/tx/block/:block_hash' **Changed max from 200 to 50**, Changed default from 96 to 20
// '/tx/block_height/:height' **Changed max from 200 to 50**, Changed default from 96 to 20
// '/tx/mempool' **Changed max from 200 to 50 (duplicate)**, Changed default from 96 to 20
[ResourceType.Event]: {
defaultLimit: 20,
maxLimit: 50,
},
// '/address/:stx_address/assets'
// '/address/:stx_address/nft_events' Deprecated?
[ResourceType.Burnchain]: {
defaultLimit: 96,
maxLimit: 250,
},
// '/burnchain/reward_slot_holders'
// '/burnchain/reward_slot_holders/:address'
// '/burnchain/rewards'
// '/burnchain/rewards/:address'
[ResourceType.Contract]: {
defaultLimit: 20,
maxLimit: 50,
},
// '/contract/by_trait'
// '/contract/:contract_id/events'
[ResourceType.Microblock]: {
defaultLimit: 20,
maxLimit: 200,
},
//'/microblock': {
[ResourceType.Token]: {
defaultLimit: 50,
maxLimit: 200,
},
// '/tokens/nft/holdings'
// '/tokens/nft/history'
// '/tokens/nft/mints'
// '/tokens/ft/metadata' Changed default from 96 to 50
// '/tokens/nft/metadata' Changed default from 96 to 50
};