### PR TITLE
fix: prevent token metadata processor from blocking api launch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -163,8 +163,8 @@ async function init(): Promise<void> {
         handler: () => tokenMetadataProcessor.close(),
         forceKillable: true,
       });
-      // check if db has any non-processed token queues and await them all here
-      await tokenMetadataProcessor.drainDbQueue();
+      // Enqueue a batch of pending token metadata processors, if any.
+      await tokenMetadataProcessor.checkDbQueue();
     }
   }
 

--- a/src/token-metadata/tokens-processor-queue.ts
+++ b/src/token-metadata/tokens-processor-queue.ts
@@ -109,8 +109,7 @@ export class TokensProcessorQueue {
   }
 
   async blockNotificationHandler(_: string) {
-    // Every block, check if we have entries we still need to process.
-    await this.drainDbQueue();
+    await this.checkDbQueue();
   }
 
   async queueHandler(queueEntry: TokenMetadataUpdateInfo) {


### PR DESCRIPTION
The current call to `drainDbQueue` on the token processor during boot sequence waits for the `queue.onEmpty` promise to resolve before continuing to launch the API server.

This promise is supposed to wait until every token is processed, so if the token queue has a lot of work (and especially if it has `STACKS_API_TOKEN_METADATA_STRICT_MODE` enabled) this could lead to a very long (or infinite) wait time for the token metadata work to conclude, preventing the API server from ever launching.

This PR only changes the call so the first few tokens are enqueued and the API launch can proceed as expected. The rest of the token queue will be processed automatically afterwards in a non-blocking way.

Fixes #1482 