### PR TITLE
chore: bump bitcoinjs-lib to latest (fixes warnings related to taproot/segwit_v1 addresses)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/ws": "7.4.7",
         "ajv": "6.12.6",
         "bignumber.js": "9.0.2",
-        "bitcoinjs-lib": "6.0.2",
+        "bitcoinjs-lib": "6.1.0",
         "bluebird": "3.7.2",
         "c32check": "1.1.3",
         "chokidar": "3.5.3",
@@ -3697,20 +3697,20 @@
       "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
     },
     "node_modules/bip174": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.0.1.tgz",
-      "integrity": "sha512-i3X26uKJOkDTAalYAp0Er+qGMDhrbbh2o93/xiPyAN2s25KrClSpe3VXo/7mNJoqA5qfko8rLS2l3RWZgYmjKQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.0.tgz",
+      "integrity": "sha512-lkc0XyiX9E9KiVAS1ZiOqK1xfiwvf4FXDDdkDq5crcDzOq+xGytY+14qCsqz7kCiy8rpN1CRNfacRhf9G3JNSA==",
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/bitcoinjs-lib": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.0.2.tgz",
-      "integrity": "sha512-I994pGt9cL5s5OA6mkv1e8IuYcsKN2ORXnWbkqAXLNGvEnOHBhKBSvCjFl7YC2uVoJnfr/iwq7JMrq575SYO5w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.0.tgz",
+      "integrity": "sha512-eupi1FBTJmPuAZdChnzTXLv2HBqFW2AICpzXZQLniP0V9FWWeeUQSMKES6sP8isy/xO0ijDexbgkdEyFVrsuJw==",
       "dependencies": {
         "bech32": "^2.0.0",
-        "bip174": "^2.0.1",
+        "bip174": "^2.1.0",
         "bs58check": "^2.1.2",
         "create-hash": "^1.1.0",
         "ripemd160": "^2.0.2",
@@ -14887,17 +14887,17 @@
       "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
     },
     "bip174": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.0.1.tgz",
-      "integrity": "sha512-i3X26uKJOkDTAalYAp0Er+qGMDhrbbh2o93/xiPyAN2s25KrClSpe3VXo/7mNJoqA5qfko8rLS2l3RWZgYmjKQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.0.tgz",
+      "integrity": "sha512-lkc0XyiX9E9KiVAS1ZiOqK1xfiwvf4FXDDdkDq5crcDzOq+xGytY+14qCsqz7kCiy8rpN1CRNfacRhf9G3JNSA=="
     },
     "bitcoinjs-lib": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.0.2.tgz",
-      "integrity": "sha512-I994pGt9cL5s5OA6mkv1e8IuYcsKN2ORXnWbkqAXLNGvEnOHBhKBSvCjFl7YC2uVoJnfr/iwq7JMrq575SYO5w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.0.tgz",
+      "integrity": "sha512-eupi1FBTJmPuAZdChnzTXLv2HBqFW2AICpzXZQLniP0V9FWWeeUQSMKES6sP8isy/xO0ijDexbgkdEyFVrsuJw==",
       "requires": {
         "bech32": "^2.0.0",
-        "bip174": "^2.0.1",
+        "bip174": "^2.1.0",
         "bs58check": "^2.1.2",
         "create-hash": "^1.1.0",
         "ripemd160": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "@types/ws": "7.4.7",
     "ajv": "6.12.6",
     "bignumber.js": "9.0.2",
-    "bitcoinjs-lib": "6.0.2",
+    "bitcoinjs-lib": "6.1.0",
     "bluebird": "3.7.2",
     "c32check": "1.1.3",
     "chokidar": "3.5.3",

--- a/src/btc-faucet.ts
+++ b/src/btc-faucet.ts
@@ -1,5 +1,6 @@
 import { RPCClient } from 'rpc-bitcoin';
 import * as btc from 'bitcoinjs-lib';
+import * as ecc from 'tiny-secp256k1';
 import * as Bluebird from 'bluebird';
 import { parsePort, time, logger, logError } from './helpers';
 import * as coinselect from 'coinselect';
@@ -70,6 +71,7 @@ const MIN_TX_CONFIRMATIONS = 1;
 
 function isValidBtcAddress(network: btc.Network, address: string): boolean {
   try {
+    btc.initEccLib(ecc);
     btc.address.toOutputScript(address, network);
     return true;
   } catch (error) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -7,6 +7,7 @@ import * as stream from 'stream';
 import * as http from 'http';
 import * as winston from 'winston';
 import { isValidStacksAddress, stacksToBitcoinAddress } from 'stacks-encoding-native-js';
+import * as ecc from 'tiny-secp256k1';
 import * as btc from 'bitcoinjs-lib';
 import {
   BufferCV,
@@ -243,6 +244,7 @@ export function microStxToStx(microStx: bigint | BigNumber): string {
  * @param address - A bitcoin address.
  */
 export function isValidBitcoinAddress(address: string): boolean {
+  btc.initEccLib(ecc);
   try {
     btc.address.toOutputScript(address, btc.networks.bitcoin);
     return true;

--- a/src/tests/helpers-tests.ts
+++ b/src/tests/helpers-tests.ts
@@ -114,6 +114,17 @@ test('bitcoin<->stacks address', () => {
       'tb1qwvwagx5f24farha0fzfmxr48lgr7sly7t5tsyh',
       'tb1qqruv3zxqtmaxqa8uxaychtm0szfazeay63j9yu',
     ],
+    // bech32m / segwit_V1 / p2tr / taproot
+    p2tr_mainnet: [
+      'bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297',
+      'bc1p2wsldez5mud2yam29q22wgfh9439spgduvct83k3pm50fcxa5dps59h4z5',
+      'bc1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5sspknck9',
+    ],
+    // bech32m / segwit_V1 / p2tr / taproot
+    p2tr_testnet: [
+      'tb1p6h5fuzmnvpdthf5shf0qqjzwy7wsqc5rhmgq2ks9xrak4ry6mtrscsqvzp',
+      'tb1p8dlmzllfah294ntwatr8j5uuvcj7yg0dete94ck2krrk0ka2c9qqex96hv',
+    ],
     bip141_p2wpkh_mainnet: [
       'bc1q86agjesjeu33mq7uwxsfgdxpe5uxwd0z9ttke9',
       'bc1qlq3xlzgun9x92hd4hrfqkqs6uh78tjleqsc2u2',


### PR DESCRIPTION
* Fixes bug where taproot/segwit_v1 BTC addresses were not reported as a valid BTC address.
* Fixes warning logs about using taproot addresses which had only partial support prior to this lib update.