### PR TITLE
fix: use pg bigint for `pox_v1_unlock_height` column

### DIFF
--- a/migrations/1673632140730_pox_state_fix.js
+++ b/migrations/1673632140730_pox_state_fix.js
@@ -1,0 +1,8 @@
+/** @param { import("node-pg-migrate").MigrationBuilder } pgm */
+exports.up = pgm => {
+
+  pgm.alterColumn('pox_state', 'pox_v1_unlock_height', {
+    type: 'bigint'
+  });
+
+}

--- a/migrations/1673632140730_pox_state_fix.js
+++ b/migrations/1673632140730_pox_state_fix.js
@@ -6,3 +6,10 @@ exports.up = pgm => {
   });
 
 }
+
+/** @param { import("node-pg-migrate").MigrationBuilder } pgm */
+exports.down = pgm => {
+  pgm.alterColumn('pox_state', 'pox_v1_unlock_height', {
+    type: 'integer'
+  });
+}

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -351,7 +351,7 @@ export class PgStore {
   }
 
   async getPox1UnlockHeightInternal(sql: PgSqlClient): Promise<FoundOrNot<number>> {
-    const query = await sql<{ pox_v1_unlock_height: number }[]>`
+    const query = await sql<{ pox_v1_unlock_height: string }[]>`
       SELECT pox_v1_unlock_height
       FROM pox_state
       LIMIt 1
@@ -359,7 +359,7 @@ export class PgStore {
     if (query.length === 0) {
       return { found: false };
     }
-    const unlockHeight = query[0].pox_v1_unlock_height;
+    const unlockHeight = parseInt(query[0].pox_v1_unlock_height);
     if (unlockHeight === 0) {
       return { found: false };
     }


### PR DESCRIPTION
Fixes bug with the `pox_v1_unlock_height` pg column being too small (int32 vs int64)

Error report:
```
{"level":"error","message":"error processing core-node /new_block: PostgresError: value \"4294967285\" is out of range for type integer value \"4294967285\" is out of range for type integer","stack":"PostgresError: value \"4294967285\" is out of range for type integer\n    at ErrorResponse (/home/admin/stacks-blockchain-api/node_modules/postgres/cjs/src/connection.js:765:26)\n    at handle (/home/admin/stacks-blockchain-api/node_modules/postgres/cjs/src/connection.js:468:6)\n    at Socket.data (/home/admin/stacks-blockchain-api/node_modules/postgres/cjs/src/connection.js:312:9)\n    at Socket.emit (node:events:513:28)\n    at addChunk (node:internal/streams/readable:315:12)\n    at readableAddChunk (node:internal/streams/readable:289:9)\n    at Socket.Readable.push (node:internal/streams/readable:228:10)\n    at TCP.onStreamRead (node:internal/stream_base_commons:190:23)\n    at TCP.callbackTrampoline (node:internal/async_hooks:130:17)\n    at cachedError (/home/admin/stacks-blockchain-api/node_modules/postgres/cjs/src/query.js:171:23)\n    at new Query (/home/admin/stacks-blockchain-api/node_modules/postgres/cjs/src/query.js:36:24)\n    at sql (/home/admin/stacks-blockchain-api/node_modules/postgres/cjs/src/index.js:111:11)\n    at /home/admin/stacks-blockchain-api/src/datastore/pg-write-store.ts:357:18","timestamp":"2023-01-13T17:01:59.139Z"}
{"level":"error","message":"HTTP POST /new_block","req":{"headers":{"content-length":"1801","content-type":"application/json","host":"localhost:3700"},"httpVersion":"1.1","method":"POST","originalUrl":"/new_block","query":{},"url":"/new_block"},"res":{"statusCode":500},"responseTime":3,"timestamp":"2023-01-13T17:01:59.139Z"}
```