### PR TITLE
fix: add contract_identifier index on contract_logs table

### DIFF
--- a/src/migrations/1673895089997_contract_logs_contract_identifier_index.ts
+++ b/src/migrations/1673895089997_contract_logs_contract_identifier_index.ts
@@ -1,0 +1,8 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('contract_logs', 'contract_identifier');
+}


### PR DESCRIPTION
For SIP-013 SFT support, the Token Metadata Service needs to scan the `contract_logs` table to look for `sft_mint` events emitted by a SIP-013 contract so it can determine the number of tokens declared in the contract. https://github.com/hirosystems/token-metadata-service/issues/56

This index optimizes queries that use `contract_identifier` as the main filter column for this table.