### PR TITLE
fix: fixed the order of microblocks_streamed

### DIFF
--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -319,7 +319,7 @@ export class PgStore {
           WHERE parent_index_block_hash
             IN ${sql([block.result.index_block_hash, block.result.parent_index_block_hash])}
           AND microblock_canonical = true
-          ORDER BY microblock_sequence DESC
+          ORDER BY microblock_sequence ASC
         `;
         for (const mb of microblocksQuery) {
           const parsedMicroblock = parseMicroblockQueryResult(mb);

--- a/src/tests/block-tests.ts
+++ b/src/tests/block-tests.ts
@@ -312,8 +312,8 @@ describe('block tests', () => {
       height: 1,
       microblocks_accepted: [],
       microblocks_streamed: [
-        microblock2.microblocks[0].microblock_hash,
         microblock1.microblocks[0].microblock_hash,
+        microblock2.microblocks[0].microblock_hash,
       ],
       miner_txid: '0x4321',
       parent_block_hash: '0x',


### PR DESCRIPTION
## Description
The endpoint for retrieving blocks was returning the microblocks_streamed field in reverse order. This commit changes the sorting from descending to ascending to match the expected behavior.

For details refer to issue #1524

## Type of Change
- [ ] Bug fix

## Checklist
- [ ] Unit test modified to check ascending order of microblocks_streamed
- [ ] `npm run test` passes
