### PR TITLE
fix: update total STX supply to the year 2050 projected amount

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1841,7 +1841,9 @@ paths:
         - Info
       operationId: get_stx_supply
       summary: Get total and unlocked STX supply
-      description: Retrieves the total and unlocked STX supply. More information on Stacking can be found [here] (https://docs.stacks.co/understand-stacks/stacking).
+      description: |
+        Retrieves the total and unlocked STX supply. More information on Stacking can be found [here] (https://docs.stacks.co/understand-stacks/stacking).
+        **Note:** this uses the estimated future total supply for the year 2050.
       parameters:
         - in: query
           name: height
@@ -1866,7 +1868,9 @@ paths:
         - Info
       operationId: get_stx_supply_total_supply_plain
       summary: Get total STX supply in plain text format
-      description: Retrieves the total supply for STX tokens as plain text.
+      description: |
+        Retrieves the total supply for STX tokens as plain text.
+        **Note:** this uses the estimated future total supply for the year 2050.
       responses:
         200:
           description: success
@@ -1898,7 +1902,9 @@ paths:
         - Info
       operationId: get_total_stx_supply_legacy_format
       summary: Get total and unlocked STX supply (results formatted the same as the legacy 1.0 API)
-      description: Retrieves total supply of STX tokens including those currently in circulation that have been unlocked.
+      description: |
+        Retrieves total supply of STX tokens including those currently in circulation that have been unlocked.
+        **Note:** this uses the estimated future total supply for the year 2050.
       parameters:
         - in: query
           name: height

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -217,9 +217,18 @@ export function formatMapToObject<TKey extends string, TValue, TFormatted>(
   return obj;
 }
 
-export const TOTAL_STACKS = new BigNumber(1320000000)
-  .plus(322146 * 100 + 5 * 50000) // air drop
-  .toString();
+// Note: this is the legacy amount defined in the Stacks 1.0 codebase:
+// export const TOTAL_STACKS /* 1352464600000000 */ = new BigNumber(1320000000)
+//   .plus(322146 * 100 + 5 * 50000) // air drop
+//   .toString();
+
+// See the Stacks 2.0 whitepaper: https://cloudflare-ipfs.com/ipfs/QmaGgiVHymeDjAc3aF1AwyhiFFwN97pme5m536cHT4FsAW
+//   > The Stacks cryptocurrency has a predefined future supply that reaches approx 1,818M STX by year 2050
+//   > Block reward: 1000 STX/block for first 4 yrs;
+//   > 500 STX/block for following 4 yrs;
+//   > 250 for the 4 yrs after that; and then 125 STX/block in perpetuity after that.
+// We are going to use the year 2050 projected supply because "125 STX/block in perpetuity" means the total supply is infinite.
+export const TOTAL_STACKS = new BigNumber(1_818_000_000n.toString());
 
 const MICROSTACKS_IN_STACKS = 1_000_000n;
 export const STACKS_DECIMAL_PLACES = 6;

--- a/src/tests/other-tests.ts
+++ b/src/tests/other-tests.ts
@@ -128,8 +128,8 @@ describe('other tests', () => {
     expect(result1.status).toBe(200);
     expect(result1.type).toBe('application/json');
     const expectedResp1 = {
-      unlocked_percent: '17.38',
-      total_stx: '1352464600.000000',
+      unlocked_percent: '12.93',
+      total_stx: '1818000000.000000',
       unlocked_stx: microStxToStx(expectedTotalStx1),
       block_height: dbBlock1.block_height,
     };
@@ -153,8 +153,8 @@ describe('other tests', () => {
     expect(result2.status).toBe(200);
     expect(result2.type).toBe('application/json');
     const expectedResp2 = {
-      unlocked_percent: '16.64',
-      total_stx: '1352464600.000000',
+      unlocked_percent: '12.38',
+      total_stx: '1818000000.000000',
       unlocked_stx: microStxToStx(expectedTotalStx2),
       block_height: dbBlock1.block_height,
     };
@@ -183,8 +183,8 @@ describe('other tests', () => {
     expect(result3.status).toBe(200);
     expect(result3.type).toBe('application/json');
     const expectedResp3 = {
-      unlocked_percent: '17.75',
-      total_stx: '1352464600.000000',
+      unlocked_percent: '13.20',
+      total_stx: '1818000000.000000',
       unlocked_stx: microStxToStx(expectedTotalStx3),
       block_height: dbBlock1.block_height,
     };
@@ -193,7 +193,7 @@ describe('other tests', () => {
     const result4 = await supertest(api.server).get(`/extended/v1/stx_supply/total/plain`);
     expect(result4.status).toBe(200);
     expect(result4.type).toBe('text/plain');
-    expect(result4.text).toEqual('1352464600.000000');
+    expect(result4.text).toEqual('1818000000.000000');
 
     const result5 = await supertest(api.server).get(`/extended/v1/stx_supply/circulating/plain`);
     expect(result5.status).toBe(200);
@@ -205,9 +205,9 @@ describe('other tests', () => {
     expect(result6.status).toBe(200);
     expect(result6.type).toBe('application/json');
     const expectedResp6 = {
-      unlockedPercent: '17.75',
-      totalStacks: '1352464600.000000',
-      totalStacksFormatted: '1,352,464,600.000000',
+      unlockedPercent: '13.20',
+      totalStacks: '1818000000.000000',
+      totalStacksFormatted: '1,818,000,000.000000',
       unlockedSupply: microStxToStx(expectedTotalStx3),
       unlockedSupplyFormatted: new Intl.NumberFormat('en', {
         minimumFractionDigits: STACKS_DECIMAL_PLACES,


### PR DESCRIPTION
Fixes https://github.com/hirosystems/explorer/issues/973

The liquid stx amount that is calculated from the postgres db is accurate (or at least it matches the `total_liquid_supply_ustx` value reported by the stacks-node):

* `/extended/v1/stx_supply - unlocked_stx: 1357774888442244` matches:
* `/v2/pox - total_liquid_supply_ustx: 1357774888442244`

However, the `total_stx` value is incorrect, and is currently _greater_ than the liquid stx supply.

The `total_stx` value is a constant that was copied from the Stacks 1.0 codebase, see https://github.com/hirosystems/stacks-blockchain-api/pull/466
> This was copied from the legacy 1.0 API codebase.

https://github.com/hirosystems/stacks-blockchain-api/blob/b6018dc06ae2dabccc85e93090fccc267e054b8f/src/helpers.ts#L220-L222

Here's what the [Stacks 2.0 whitepaper](https://cloudflare-ipfs.com/ipfs/QmaGgiVHymeDjAc3aF1AwyhiFFwN97pme5m536cHT4FsAW) states about about the STX supply:

> Block reward: 1000 STX/block for first 4 yrs; 500 STX/block for following 4 yrs; 250 for the 4 yrs after that; and then 125 STX/block in perpetuity after that.
...
> The Stacks cryptocurrency has a predefined future supply that reaches approx 1,818M STX by year 2050 ...

This PR changes the `total_stx` value to the year 2050 projected STX amount, because "125 STX/block in perpetuity" means the total supply is not a constant. 