### PR TITLE
fix: add block_height index to contract_logs

### DIFF
--- a/src/migrations/1674838340313_contract_logs_block_height_index.ts
+++ b/src/migrations/1674838340313_contract_logs_block_height_index.ts
@@ -1,0 +1,13 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('contract_logs', [
+    { name: 'block_height', sort: 'DESC' },
+    { name: 'microblock_sequence', sort: 'DESC' },
+    { name: 'tx_index', sort: 'DESC' },
+    { name: 'event_index', sort: 'DESC' },
+  ]);
+}


### PR DESCRIPTION
On boot, the Token Metadata Service needs to scan the `contract_logs` table to look for SIP-019 notifications that might have happened between two block heights. This index makes the performance of this query trivial on the API database.