### PR TITLE
OpenAPI: Get mempool transations - Removed default value and updated max and example values

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -268,9 +268,8 @@ paths:
           required: false
           schema:
             type: integer
-            default: 96
-            maximum: 200
-            example: 100
+            maximum: 50
+            example: 20
         - name: offset
           in: query
           description: index of first mempool transaction to fetch

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -268,6 +268,7 @@ paths:
           required: false
           schema:
             type: integer
+            default: 20
             maximum: 50
             example: 20
         - name: offset


### PR DESCRIPTION
Updated maximum and example values for the Get mempool transitions.
Removed default value.

The openAPI.yaml file is updated.