### PR TITLE
fix: ensure transactions are never reported as both pending and confirmed

### DIFF
--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -1526,3 +1526,10 @@ export interface SmartContractInsertValues {
   microblock_sequence: number;
   microblock_canonical: boolean;
 }
+
+export interface DbChainTip {
+  blockHeight: number;
+  blockHash: string;
+  indexBlockHash: string;
+  burnBlockHeight: number;
+}

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -61,6 +61,7 @@ import {
   Pox2EventInsertValues,
   DbTxRaw,
   DbMempoolTxRaw,
+  DbChainTip,
 } from './common';
 import { ClarityAbi } from '@stacks/transactions';
 import {
@@ -152,15 +153,7 @@ export class PgWriteStore extends PgStore {
     return super.sqlTransaction(callback, false);
   }
 
-  async getChainTip(
-    sql: PgSqlClient,
-    useMaterializedView = true
-  ): Promise<{
-    blockHeight: number;
-    blockHash: string;
-    indexBlockHash: string;
-    burnBlockHeight: number;
-  }> {
+  async getChainTip(sql: PgSqlClient, useMaterializedView = true): Promise<DbChainTip> {
     if (!this.isEventReplay && useMaterializedView) {
       return super.getChainTip(sql);
     }
@@ -452,9 +445,7 @@ export class PgWriteStore extends PgStore {
 
       if (!this.isEventReplay) {
         await this.reconcileMempoolStatus(sql);
-      }
 
-      if (!this.isEventReplay) {
         const mempoolStats = await this.getMempoolStatsInternal({ sql });
         this.eventEmitter.emit('mempoolStatsUpdate', mempoolStats);
       }
@@ -733,9 +724,7 @@ export class PgWriteStore extends PgStore {
 
       if (!this.isEventReplay) {
         await this.reconcileMempoolStatus(sql);
-      }
 
-      if (!this.isEventReplay) {
         const mempoolStats = await this.getMempoolStatsInternal({ sql });
         this.eventEmitter.emit('mempoolStatsUpdate', mempoolStats);
       }
@@ -1548,61 +1537,75 @@ export class PgWriteStore extends PgStore {
     return result.count;
   }
 
+  async insertDbMempoolTx(
+    tx: DbMempoolTxRaw,
+    chainTip: DbChainTip,
+    sql: PgSqlClient
+  ): Promise<boolean> {
+    const values: MempoolTxInsertValues = {
+      pruned: tx.pruned,
+      tx_id: tx.tx_id,
+      raw_tx: tx.raw_tx,
+      type_id: tx.type_id,
+      anchor_mode: tx.anchor_mode,
+      status: tx.status,
+      receipt_time: tx.receipt_time,
+      receipt_block_height: chainTip.blockHeight,
+      post_conditions: tx.post_conditions,
+      nonce: tx.nonce,
+      fee_rate: tx.fee_rate,
+      sponsored: tx.sponsored,
+      sponsor_nonce: tx.sponsor_nonce ?? null,
+      sponsor_address: tx.sponsor_address ?? null,
+      sender_address: tx.sender_address,
+      origin_hash_mode: tx.origin_hash_mode,
+      token_transfer_recipient_address: tx.token_transfer_recipient_address ?? null,
+      token_transfer_amount: tx.token_transfer_amount ?? null,
+      token_transfer_memo: tx.token_transfer_memo ?? null,
+      smart_contract_clarity_version: tx.smart_contract_clarity_version ?? null,
+      smart_contract_contract_id: tx.smart_contract_contract_id ?? null,
+      smart_contract_source_code: tx.smart_contract_source_code ?? null,
+      contract_call_contract_id: tx.contract_call_contract_id ?? null,
+      contract_call_function_name: tx.contract_call_function_name ?? null,
+      contract_call_function_args: tx.contract_call_function_args ?? null,
+      poison_microblock_header_1: tx.poison_microblock_header_1 ?? null,
+      poison_microblock_header_2: tx.poison_microblock_header_2 ?? null,
+      coinbase_payload: tx.coinbase_payload ?? null,
+      coinbase_alt_recipient: tx.coinbase_alt_recipient ?? null,
+    };
+    const result = await sql`
+      INSERT INTO mempool_txs ${sql(values)}
+      ON CONFLICT ON CONSTRAINT unique_tx_id DO NOTHING
+    `;
+    if (result.count !== 1) {
+      const errMsg = `A duplicate transaction was attempted to be inserted into the mempool_txs table: ${tx.tx_id}`;
+      logger.warn(errMsg);
+      return false;
+    } else {
+      return true;
+    }
+  }
+
   async updateMempoolTxs({ mempoolTxs: txs }: { mempoolTxs: DbMempoolTxRaw[] }): Promise<void> {
-    const updatedTxs: DbMempoolTx[] = [];
+    const updatedTxIds: string[] = [];
     await this.sqlWriteTransaction(async sql => {
       const chainTip = await this.getChainTip(sql, false);
       for (const tx of txs) {
-        const values: MempoolTxInsertValues = {
-          pruned: tx.pruned,
-          tx_id: tx.tx_id,
-          raw_tx: tx.raw_tx,
-          type_id: tx.type_id,
-          anchor_mode: tx.anchor_mode,
-          status: tx.status,
-          receipt_time: tx.receipt_time,
-          receipt_block_height: chainTip.blockHeight,
-          post_conditions: tx.post_conditions,
-          nonce: tx.nonce,
-          fee_rate: tx.fee_rate,
-          sponsored: tx.sponsored,
-          sponsor_nonce: tx.sponsor_nonce ?? null,
-          sponsor_address: tx.sponsor_address ?? null,
-          sender_address: tx.sender_address,
-          origin_hash_mode: tx.origin_hash_mode,
-          token_transfer_recipient_address: tx.token_transfer_recipient_address ?? null,
-          token_transfer_amount: tx.token_transfer_amount ?? null,
-          token_transfer_memo: tx.token_transfer_memo ?? null,
-          smart_contract_clarity_version: tx.smart_contract_clarity_version ?? null,
-          smart_contract_contract_id: tx.smart_contract_contract_id ?? null,
-          smart_contract_source_code: tx.smart_contract_source_code ?? null,
-          contract_call_contract_id: tx.contract_call_contract_id ?? null,
-          contract_call_function_name: tx.contract_call_function_name ?? null,
-          contract_call_function_args: tx.contract_call_function_args ?? null,
-          poison_microblock_header_1: tx.poison_microblock_header_1 ?? null,
-          poison_microblock_header_2: tx.poison_microblock_header_2 ?? null,
-          coinbase_payload: tx.coinbase_payload ?? null,
-          coinbase_alt_recipient: tx.coinbase_alt_recipient ?? null,
-        };
-        const result = await sql`
-          INSERT INTO mempool_txs ${sql(values)}
-          ON CONFLICT ON CONSTRAINT unique_tx_id DO NOTHING
-        `;
-        if (result.count !== 1) {
-          const errMsg = `A duplicate transaction was attempted to be inserted into the mempool_txs table: ${tx.tx_id}`;
-          logger.warn(errMsg);
-        } else {
-          updatedTxs.push(tx);
+        const inserted = await this.insertDbMempoolTx(tx, chainTip, sql);
+        if (inserted) {
+          updatedTxIds.push(tx.tx_id);
         }
       }
       if (!this.isEventReplay) {
+        await this.reconcileMempoolStatus(sql);
+
         const mempoolStats = await this.getMempoolStatsInternal({ sql });
         this.eventEmitter.emit('mempoolStatsUpdate', mempoolStats);
       }
     });
     await this.refreshMaterializedView('mempool_digest');
-    for (const tx of updatedTxs) {
-      await this.notifier?.sendTx({ txId: tx.tx_id });
+    for (const txId of updatedTxIds) {
+      await this.notifier?.sendTx({ txId: txId });
     }
   }
 

--- a/src/tests/mempool-tests.ts
+++ b/src/tests/mempool-tests.ts
@@ -1405,4 +1405,125 @@ describe('mempool tests', () => {
     // txs 4 and 5 should be reorged from txs to mempool txs
     expect(mempoolTxIdsAfterReOrg).toEqual(['0x04bb', '0x05bb']);
   });
+
+  test('Reconcile mempool pruned status', async () => {
+    const senderAddress = 'SP25YGP221F01S9SSCGN114MKDAK9VRK8P3KXGEMB';
+    const txId = '0x521234';
+    const dbBlock1: DbBlock = {
+      block_hash: '0x0123',
+      index_block_hash: '0x1234',
+      parent_index_block_hash: '0x5678',
+      parent_block_hash: '0x5678',
+      parent_microblock_hash: '',
+      parent_microblock_sequence: 0,
+      block_height: 1,
+      burn_block_time: 39486,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
+      canonical: true,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
+    };
+    const dbBlock2: DbBlock = {
+      block_hash: '0x2123',
+      index_block_hash: '0x2234',
+      parent_index_block_hash: dbBlock1.index_block_hash,
+      parent_block_hash: dbBlock1.block_hash,
+      parent_microblock_hash: '',
+      parent_microblock_sequence: 0,
+      block_height: 2,
+      burn_block_time: 39486,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
+      canonical: true,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
+    };
+    const mempoolTx: DbMempoolTxRaw = {
+      tx_id: txId,
+      anchor_mode: 3,
+      nonce: 0,
+      raw_tx: bufferToHexPrefixString(Buffer.from('test-raw-mempool-tx')),
+      type_id: DbTxTypeId.Coinbase,
+      status: 1,
+      post_conditions: '0x01f5',
+      fee_rate: 1234n,
+      sponsored: false,
+      sponsor_address: undefined,
+      sender_address: senderAddress,
+      origin_hash_mode: 1,
+      coinbase_payload: bufferToHexPrefixString(Buffer.from('hi')),
+      pruned: false,
+      receipt_time: 1616063078,
+    };
+    const dbTx1: DbTxRaw = {
+      ...mempoolTx,
+      ...dbBlock1,
+      parent_burn_block_time: 1626122935,
+      tx_index: 4,
+      status: DbTxStatus.Success,
+      raw_result: '0x0100000000000000000000000000000001', // u1
+      canonical: true,
+      microblock_canonical: true,
+      microblock_sequence: I32_MAX,
+      microblock_hash: '',
+      parent_index_block_hash: '',
+      event_count: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
+    };
+
+    // Simulate the bug with a txs being in the mempool at confirmed at the same time by
+    // directly inserting the mempool-tx and mined-tx, bypassing the normal update functions.
+    await db.updateBlock(db.sql, dbBlock1);
+    await db.updateMempoolTxs({ mempoolTxs: [mempoolTx] });
+    await db.updateTx(db.sql, dbTx1);
+
+    // Verify tx shows up in mempool (non-pruned)
+    const mempoolResult1 = await supertest(api.server).get(
+      `/extended/v1/address/${mempoolTx.sender_address}/mempool`
+    );
+    expect(mempoolResult1.body.results[0].tx_id).toBe(txId);
+    const mempoolResult2 = await supertest(api.server).get(
+      `/extended/v1/tx/mempool?sender_address=${senderAddress}`
+    );
+    expect(mempoolResult2.body.results[0].tx_id).toBe(txId);
+
+    // Verify tx also shows up as confirmed
+    const txResult1 = await supertest(api.server).get(`/extended/v1/tx/${txId}`);
+    expect(txResult1.body.tx_status).toBe('success');
+
+    // Insert next block using regular update function to trigger the mempool reconcile function
+    await db.update({
+      block: dbBlock2,
+      microblocks: [],
+      minerRewards: [],
+      txs: [],
+    });
+
+    // Verify tx pruned from mempool
+    const mempoolResult3 = await supertest(api.server).get(
+      `/extended/v1/address/${mempoolTx.sender_address}/mempool`
+    );
+    expect(mempoolResult3.body.results).toHaveLength(0);
+    const mempoolResult4 = await supertest(api.server).get(
+      `/extended/v1/tx/mempool?sender_address=${senderAddress}`
+    );
+    expect(mempoolResult4.body.results).toHaveLength(0);
+
+    // Verify tx still shows up as confirmed
+    const txResult2 = await supertest(api.server).get(`/extended/v1/tx/${txId}`);
+    expect(txResult2.body.tx_status).toBe('success');
+  });
 });

--- a/src/tests/mempool-tests.ts
+++ b/src/tests/mempool-tests.ts
@@ -1487,7 +1487,8 @@ describe('mempool tests', () => {
     // Simulate the bug with a txs being in the mempool at confirmed at the same time by
     // directly inserting the mempool-tx and mined-tx, bypassing the normal update functions.
     await db.updateBlock(db.sql, dbBlock1);
-    await db.updateMempoolTxs({ mempoolTxs: [mempoolTx] });
+    const chainTip = await db.getChainTip(db.sql);
+    await db.insertDbMempoolTx(mempoolTx, chainTip, db.sql);
     await db.updateTx(db.sql, dbTx1);
 
     // Verify tx shows up in mempool (non-pruned)


### PR DESCRIPTION
Fixes https://github.com/hirosystems/stacks-blockchain-api/issues/1557, related to https://github.com/hirosystems/stacks-blockchain-api/issues/1428

This adds a function which detects any transactions that are erroneously marked as both pending in the mempool table and also confirmed in the mined txs table.

The function is called after all other sql writes during block & microblock ingestion, but before any reads or view refreshes that depend on the mempool table.

This should be a safe work-around for whatever bug is causing the underlying problem.