### PR TITLE
fix: bug with finding last block with some large tsv files

### DIFF
--- a/src/event-replay/event-replay.ts
+++ b/src/event-replay/event-replay.ts
@@ -160,7 +160,7 @@ export async function importEventsFromTsv(
       });
       if (rawEvent.event_path === '/new_block') {
         blockHeight = await getDbBlockHeight(db);
-        if (blockHeight % 1000 === 0) {
+        if (blockHeight && blockHeight % 1000 === 0) {
           console.log(`Event file block height reached: ${blockHeight}`);
         }
       }

--- a/src/event-replay/helpers.ts
+++ b/src/event-replay/helpers.ts
@@ -1,8 +1,7 @@
 import { PgWriteStore } from '../datastore/pg-write-store';
 import * as fs from 'fs';
 import * as readline from 'readline';
-import { decodeTransaction, TxPayloadTypeID } from 'stacks-encoding-native-js';
-import { DataStoreBnsBlockData } from '../datastore/common';
+import { DataStoreBnsBlockData, DbTxTypeId } from '../datastore/common';
 import { readLinesReversed } from './reverse-file-stream';
 import { CoreNodeBlockMessage } from '../event-stream/core-node-message';
 
@@ -61,27 +60,28 @@ export async function getGenesisBlockData(filePath: string): Promise<CoreNodeBlo
   throw new Error('Genesis block data not found');
 }
 
-export function getBnsGenesisBlockFromBlockMessage(
-  genesisBlockMessage: CoreNodeBlockMessage
-): BnsGenesisBlock {
-  if (genesisBlockMessage.block_height !== 0 && genesisBlockMessage.block_height !== 1) {
-    throw new Error(
-      `This block message with height ${genesisBlockMessage.block_height} is not the genesis block message`
-    );
+export async function getBnsGenesisBlockFromBlockMessage(
+  db: PgWriteStore
+): Promise<BnsGenesisBlock> {
+  const genesisBlock = await db.getBlock({ height: 1 });
+  if (!genesisBlock.found) {
+    throw new Error('Could not find genesis block');
   }
-  const txs = genesisBlockMessage.transactions;
-  for (const tx of txs) {
-    const decodedTx = decodeTransaction(tx.raw_tx);
+  const txs = await db.getTxsFromBlock({ hash: genesisBlock.result.block_hash }, 100, 0);
+  if (!txs.found) {
+    throw new Error('Could not find genesis transactions');
+  }
+  for (const tx of txs.result.results) {
     // Look for the only token transfer transaction in the genesis block. This is the one
     // that contains all the events, including all BNS name registrations.
-    if (decodedTx.payload.type_id === TxPayloadTypeID.TokenTransfer) {
+    if (tx.type_id === DbTxTypeId.TokenTransfer) {
       return {
-        index_block_hash: genesisBlockMessage.index_block_hash,
-        parent_index_block_hash: genesisBlockMessage.parent_index_block_hash,
-        microblock_hash: genesisBlockMessage.parent_microblock,
-        microblock_sequence: genesisBlockMessage.parent_microblock_sequence,
+        index_block_hash: genesisBlock.result.index_block_hash,
+        parent_index_block_hash: genesisBlock.result.parent_index_block_hash,
+        microblock_hash: genesisBlock.result.parent_microblock_hash,
+        microblock_sequence: genesisBlock.result.parent_microblock_sequence,
         microblock_canonical: true,
-        tx_id: decodedTx.tx_id,
+        tx_id: tx.tx_id,
         tx_index: tx.tx_index,
       };
     }

--- a/src/event-replay/helpers.ts
+++ b/src/event-replay/helpers.ts
@@ -26,8 +26,11 @@ export async function findTsvBlockHeight(filePath: string): Promise<number> {
     const columns = data.split('\t');
     const eventName = columns[2];
     if (eventName === '/new_block') {
-      const payload = columns[3];
-      blockHeight = JSON.parse(payload).block_height;
+      const payload: { block_height?: number } = JSON.parse(columns[3]);
+      if (!payload.block_height || payload.block_height === 0) {
+        continue;
+      }
+      blockHeight = payload.block_height;
       break;
     }
   }

--- a/src/event-replay/helpers.ts
+++ b/src/event-replay/helpers.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as readline from 'readline';
 import { decodeTransaction, TxPayloadTypeID } from 'stacks-encoding-native-js';
 import { DataStoreBnsBlockData } from '../datastore/common';
-import { ReverseFileStream } from './reverse-file-stream';
+import { readLinesReversed } from './reverse-file-stream';
 import { CoreNodeBlockMessage } from '../event-stream/core-node-message';
 
 export type BnsGenesisBlock = DataStoreBnsBlockData & {
@@ -21,7 +21,7 @@ export type BnsGenesisBlock = DataStoreBnsBlockData & {
  */
 export async function findTsvBlockHeight(filePath: string): Promise<number> {
   let blockHeight = 0;
-  const reverseStream = new ReverseFileStream(filePath);
+  const reverseStream = readLinesReversed(filePath);
   for await (const data of reverseStream) {
     const columns = data.split('\t');
     const eventName = columns[2];

--- a/src/event-replay/reverse-file-stream.ts
+++ b/src/event-replay/reverse-file-stream.ts
@@ -1,69 +1,145 @@
 import * as stream from 'stream';
 import * as fs from 'fs';
 
-/**
- * Streams lines from a text file in reverse, starting from the end of the file.
- * Modernized version of https://www.npmjs.com/package/fs-reverse
- */
-export class ReverseFileStream extends stream.Readable {
-  private fileDescriptor: number;
-  private position: number;
-
-  private lineBuffer: string[] = [];
-  private remainder: string = '';
-
-  public readonly fileLength: number;
-  public bytesRead: number = 0;
-
-  constructor(filePath: string, opts?: stream.ReadableOptions) {
-    super({
-      ...{
-        // `objectMode` avoids the `Buffer->utf8->Buffer->utf8` conversions when pushing strings
-        objectMode: true,
-        // Restore default size for byte-streams, since objectMode sets it to 16
-        highWaterMark: 16384,
-        autoDestroy: true,
-      },
-      ...opts,
-    });
-    this.fileLength = fs.statSync(filePath).size;
-    this.position = this.fileLength;
-    this.fileDescriptor = fs.openSync(filePath, 'r', 0o666);
-  }
-
-  _read(size: number): void {
-    while (this.lineBuffer.length === 0 && this.position > 0) {
-      // Read `size` bytes from the end of the file.
-      const length = Math.min(size, this.position);
-      const buffer = Buffer.alloc(length);
-      this.position = this.position - length;
-      this.bytesRead += fs.readSync(this.fileDescriptor, buffer, 0, length, this.position);
-
-      // Split into lines to fill the `lineBuffer`
-      this.remainder = buffer.toString('utf8') + this.remainder;
-      this.lineBuffer = this.remainder.split(/\r?\n/);
-
-      // Ignore empty/trailing lines, `readable.push('')` is not recommended
-      this.lineBuffer = this.lineBuffer.filter(line => line.length > 0);
-      const remainderHasPrefixEnding = this.remainder.startsWith('\n');
-      this.remainder = this.lineBuffer.shift() ?? '';
-
-      // Preserve the line-ending char for the remainder if one was at the read boundary
-      if (remainderHasPrefixEnding) {
-        this.remainder = '\n' + this.remainder;
-      }
-    }
-    if (this.lineBuffer.length) {
-      this.push(this.lineBuffer.pop());
-    } else if (this.remainder.length) {
-      this.push(this.remainder);
-      this.remainder = '';
+function splitBuffer(input: Buffer, matcher: number): Buffer[] {
+  const chunks: Buffer[] = [];
+  let position = 0;
+  let matchIndex: number;
+  do {
+    matchIndex = input.indexOf(matcher, position);
+    if (matchIndex === -1) {
+      chunks.push(input.subarray(position));
     } else {
-      this.push(null);
+      chunks.push(input.subarray(position, matchIndex));
     }
-  }
+    position = matchIndex + 1;
+  } while (matchIndex !== -1);
+  return chunks;
+}
 
-  _destroy(error: Error | null, callback: (error?: Error | null) => void): void {
-    fs.closeSync(this.fileDescriptor);
-  }
+interface ReadableFileStream extends stream.Readable {
+  getFileSize(): number;
+  getBytesRead(): number;
+}
+
+function createReverseFileReadStream(
+  filePath: fs.PathLike,
+  readBufferSize = 1_000_000
+): ReadableFileStream {
+  let fileDescriptor: number;
+  let fileSize: number;
+  let filePosition: number;
+  const reverseReadStream = new stream.Readable({
+    highWaterMark: readBufferSize,
+    construct: callback => {
+      fs.open(filePath, 'r', (error, fd) => {
+        if (error) {
+          callback(error);
+          return;
+        }
+        fileDescriptor = fd;
+        fs.fstat(fd, (error, stats) => {
+          if (error) {
+            callback(error);
+            return;
+          }
+          fileSize = stats.size;
+          filePosition = fileSize;
+          callback();
+        });
+      });
+    },
+    read: size => {
+      if (filePosition === 0) {
+        reverseReadStream.push(null);
+        return;
+      }
+      const readSize = Math.min(size, filePosition);
+      const buff = Buffer.allocUnsafe(readSize);
+      fs.read(fileDescriptor, buff, 0, readSize, filePosition - readSize, (error, bytesRead) => {
+        if (error) {
+          reverseReadStream.destroy(error);
+          return;
+        }
+        filePosition -= bytesRead;
+        if (bytesRead > 0) {
+          reverseReadStream.push(buff.slice(0, bytesRead));
+        } else {
+          reverseReadStream.push(null);
+        }
+      });
+    },
+    destroy: (error, callback) => {
+      if (fileDescriptor) {
+        fs.close(fileDescriptor, closeError => callback(closeError || error));
+      } else {
+        callback(error);
+      }
+    },
+  });
+  return Object.assign(reverseReadStream, {
+    getFileSize: () => fileSize,
+    getBytesRead: () => fileSize - filePosition,
+  });
+}
+
+/**
+ * @param filePath - Path to the file to read.
+ * @param readBufferSize - Defaults to ~1 megabytes
+ */
+export function readLinesReversed(
+  filePath: fs.PathLike,
+  readBufferSize = 1_000_000
+): ReadableFileStream {
+  let last: Buffer | undefined = undefined;
+  const matcher = '\n'.charCodeAt(0);
+
+  const reverseReadStream = createReverseFileReadStream(filePath, readBufferSize);
+
+  const transformStream = new stream.Transform({
+    autoDestroy: true,
+    readableObjectMode: true,
+    writableHighWaterMark: readBufferSize,
+    flush: callback => {
+      if (last) {
+        try {
+          transformStream.push(last.toString('utf8'));
+        } catch (error: any) {
+          callback(error);
+          return;
+        }
+      }
+      callback();
+    },
+    transform: (chunk: Buffer, _encoding, callback) => {
+      if (last !== undefined) {
+        last = Buffer.concat([chunk, last]);
+      } else {
+        last = chunk;
+      }
+      const list = splitBuffer(last, matcher);
+      last = list.shift();
+
+      for (let i = list.length - 1; i >= 0; i--) {
+        try {
+          transformStream.push(list[i].toString('utf8'));
+        } catch (error: any) {
+          callback(error);
+          return;
+        }
+      }
+
+      callback();
+    },
+    destroy: (error, callback) => {
+      reverseReadStream.destroy(error || undefined);
+      callback(error);
+    },
+  });
+
+  const pipelineResult = reverseReadStream.pipe(transformStream);
+  return Object.assign(pipelineResult, {
+    getFileSize: () => reverseReadStream.getFileSize(),
+    getBytesRead: () => reverseReadStream.getBytesRead(),
+  });
 }

--- a/src/event-replay/reverse-file-stream.ts
+++ b/src/event-replay/reverse-file-stream.ts
@@ -132,6 +132,10 @@ export function readLinesReversed(
       callback();
     },
     destroy: (error, callback) => {
+      if ((error as Error)?.name === 'AbortError') {
+        // Ignore "AbortError", it means the stream was intentionally destroyed (e.g. a `break` statement in an async iterator)
+        error = null;
+      }
       reverseReadStream.destroy(error || undefined);
       callback(error);
     },

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -68,7 +68,7 @@ import {
   createDbTxFromCoreMsg,
   getTxDbStatus,
 } from '../datastore/helpers';
-import { importV1BnsNames, importV1BnsSubdomains } from '../import-v1';
+import { handleBnsImport, importV1BnsNames, importV1BnsSubdomains } from '../import-v1';
 import { getBnsGenesisBlockFromBlockMessage } from '../event-replay/helpers';
 import { Pox2ContractIdentifer } from '../pox-helpers';
 import { decodePox2PrintEvent } from './pox2-event-parsing';
@@ -734,24 +734,6 @@ export type EventStreamServer = net.Server & {
   closeAsync: () => Promise<void>;
 };
 
-export const bnsImportMiddleware = (db: PgWriteStore) => {
-  return asyncHandler(async (req, res, next) => {
-    const blockMessage: CoreNodeBlockMessage = req.body;
-    const bnsDir = process.env.BNS_IMPORT_DIR;
-    if ((blockMessage.block_height === 0 || blockMessage.block_height === 1) && bnsDir) {
-      const configState = await db.getConfigState();
-      if (!configState.bns_names_onchain_imported || !configState.bns_subdomains_imported) {
-        const bnsGenesisBlock = getBnsGenesisBlockFromBlockMessage(blockMessage);
-        logger.verbose('Starting V1 BNS names import');
-        await importV1BnsNames(db, bnsDir, bnsGenesisBlock);
-        logger.verbose('Starting V1 BNS subdomains import');
-        await importV1BnsSubdomains(db, bnsDir, bnsGenesisBlock);
-      }
-    }
-    next();
-  });
-};
-
 export async function startEventServer(opts: {
   datastore: PgWriteStore;
   chainId: ChainID;
@@ -843,6 +825,9 @@ export async function startEventServer(opts: {
       try {
         const blockMessage: CoreNodeBlockMessage = req.body;
         await messageHandler.handleBlockMessage(opts.chainId, blockMessage, db);
+        if (blockMessage.block_height === 1) {
+          await handleBnsImport(db);
+        }
         res.status(200).json({ result: 'ok' });
         next();
       } catch (error) {
@@ -850,7 +835,6 @@ export async function startEventServer(opts: {
         res.status(500).json({ error: error });
       }
     }),
-    bnsImportMiddleware(db),
     handleRawEventRequest
   );
 

--- a/src/import-v1/index.ts
+++ b/src/import-v1/index.ts
@@ -550,18 +550,19 @@ export async function importV1TokenOfferingData(db: PgWriteStore) {
 export async function handleBnsImport(db: PgWriteStore) {
   const bnsDir = process.env.BNS_IMPORT_DIR;
   if (!bnsDir) {
-    logger.warn(`BNS_IMPORT_DIR not configured, will not import BNS data`);
+    console.log(`BNS_IMPORT_DIR not configured, will not import BNS data`);
     return;
   }
   const configState = await db.getConfigState();
   if (configState.bns_names_onchain_imported && configState.bns_subdomains_imported) {
-    logger.warn('Skipping V1 BNS import, already imported');
+    console.log('Skipping V1 BNS import, already imported');
     return;
   }
 
   const bnsGenesisBlock = await getBnsGenesisBlockFromBlockMessage(db);
-  logger.warn('Starting V1 BNS names import');
+  console.log('Starting V1 BNS names import');
   await importV1BnsNames(db, bnsDir, bnsGenesisBlock);
-  logger.warn('Starting V1 BNS subdomains import');
+  console.log('Starting V1 BNS subdomains import');
   await importV1BnsSubdomains(db, bnsDir, bnsGenesisBlock);
+  console.log('BNS import completed');
 }

--- a/src/import-v1/index.ts
+++ b/src/import-v1/index.ts
@@ -22,7 +22,7 @@ import {
   logger,
   REPO_DIR,
 } from '../helpers';
-import { BnsGenesisBlock } from '../event-replay/helpers';
+import { BnsGenesisBlock, getBnsGenesisBlockFromBlockMessage } from '../event-replay/helpers';
 import { PgSqlClient } from '../datastore/connection';
 import { PgWriteStore } from '../datastore/pg-write-store';
 
@@ -545,4 +545,23 @@ export async function importV1TokenOfferingData(db: PgWriteStore) {
     await db.updateConfigState(updatedConfigState, sql);
   });
   logger.info('Stacks 1.0 token offering data import completed');
+}
+
+export async function handleBnsImport(db: PgWriteStore) {
+  const bnsDir = process.env.BNS_IMPORT_DIR;
+  if (!bnsDir) {
+    logger.warn(`BNS_IMPORT_DIR not configured, will not import BNS data`);
+    return;
+  }
+  const configState = await db.getConfigState();
+  if (configState.bns_names_onchain_imported && configState.bns_subdomains_imported) {
+    logger.warn('Skipping V1 BNS import, already imported');
+    return;
+  }
+
+  const bnsGenesisBlock = await getBnsGenesisBlockFromBlockMessage(db);
+  logger.warn('Starting V1 BNS names import');
+  await importV1BnsNames(db, bnsDir, bnsGenesisBlock);
+  logger.warn('Starting V1 BNS subdomains import');
+  await importV1BnsSubdomains(db, bnsDir, bnsGenesisBlock);
 }

--- a/src/tests-bns/event-server-tests.ts
+++ b/src/tests-bns/event-server-tests.ts
@@ -1,6 +1,6 @@
 import { ChainID } from '@stacks/transactions';
 import { bnsNameCV, httpPostRequest } from '../helpers';
-import { bnsImportMiddleware, EventStreamServer, startEventServer } from '../event-stream/event-server';
+import { EventStreamServer, startEventServer } from '../event-stream/event-server';
 import { TestBlockBuilder, TestMicroblockStreamBuilder } from '../test-utils/test-builders';
 import { DbAssetEventTypeId, DbBnsZoneFile } from '../datastore/common';
 import { PgWriteStore } from '../datastore/pg-write-store';
@@ -1033,21 +1033,5 @@ describe('BNS event server tests', () => {
     });
     expect(namespaceList.results.length).toBe(1);
     expect(namespaceList.results).toStrictEqual(['ape.mega']);
-  });
-
-  test('BNS middleware imports bns when it receives the genesis block', async () => {
-    process.env.BNS_IMPORT_DIR = 'src/tests-bns/import-test-files';
-    const genesisBlock = await getGenesisBlockData('src/tests-event-replay/tsv/mainnet.tsv');
-    const bnsImportMiddlewareInitialized = bnsImportMiddleware(db);
-    let mockRequest = {
-      body: genesisBlock
-    } as unknown as Partial<Request>;
-    let mockResponse: Partial<Response> = {};
-    let nextFunction: NextFunction = jest.fn();
-    await bnsImportMiddlewareInitialized(mockRequest as any, mockResponse as any, nextFunction)
-
-    const configState = await db.getConfigState();
-    expect(configState.bns_names_onchain_imported).toBe(true)
-    expect(configState.bns_subdomains_imported).toBe(true)
   });
 })

--- a/src/tests-event-replay/helper-tests.ts
+++ b/src/tests-event-replay/helper-tests.ts
@@ -1,9 +1,5 @@
 import * as fs from 'fs';
-import {
-  findTsvBlockHeight,
-  getBnsGenesisBlockFromBlockMessage,
-  getGenesisBlockData,
-} from '../event-replay/helpers';
+import { findTsvBlockHeight } from '../event-replay/helpers';
 import { readLinesReversed } from '../event-replay/reverse-file-stream';
 
 describe('helper tests', () => {
@@ -124,19 +120,5 @@ line4`;
     } finally {
       fs.unlinkSync(testFilePath);
     }
-  });
-
-  test('BNS genesis block data is found', async () => {
-    const genesisBlockMessage = await getGenesisBlockData('src/tests-event-replay/tsv/mainnet.tsv');
-    const genesisBlock = getBnsGenesisBlockFromBlockMessage(genesisBlockMessage);
-    expect(genesisBlock).toEqual({
-      index_block_hash: '0x918697ef63f9d8bdf844c3312b299e72a231cde542f3173f7755bb8c1cdaf3a7',
-      parent_index_block_hash: '0x55c9861be5cff984a20ce6d99d4aa65941412889bdc665094136429b84f8c2ee',
-      microblock_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-      microblock_sequence: 0,
-      microblock_canonical: true,
-      tx_id: '0x2f079994c9bd92b2272258b9de73e278824d76efe1b5a83a3b00941f9559de8a',
-      tx_index: 7,
-    });
   });
 });

--- a/src/tests-event-replay/helper-tests.ts
+++ b/src/tests-event-replay/helper-tests.ts
@@ -4,7 +4,7 @@ import {
   getBnsGenesisBlockFromBlockMessage,
   getGenesisBlockData,
 } from '../event-replay/helpers';
-import { ReverseFileStream } from '../event-replay/reverse-file-stream';
+import { readLinesReversed } from '../event-replay/reverse-file-stream';
 
 describe('helper tests', () => {
   function writeTmpFile(fileName: string, contents: string): string {
@@ -26,7 +26,7 @@ describe('helper tests', () => {
     const testFilePath = writeTmpFile('test1.txt', contents);
     try {
       // Default stream buffer is 64KB, set to 300 bytes so file is larger than memory buffer
-      const reverseStream = new ReverseFileStream(testFilePath, { highWaterMark: 300 });
+      const reverseStream = readLinesReversed(testFilePath, 300);
       const output: string[] = [];
       let linesStreamed = 0;
       for await (const data of reverseStream) {
@@ -38,10 +38,10 @@ describe('helper tests', () => {
       }
       expect(linesStreamed).toEqual(4);
       expect(output).toEqual(['line1000', 'line999', 'line998', 'line997']);
-      expect(reverseStream.bytesRead).toBeLessThan(reverseStream.fileLength);
+      expect(reverseStream.getBytesRead()).toBeLessThan(reverseStream.getFileSize());
 
       // Read whole file
-      const reverseStream2 = new ReverseFileStream(testFilePath, { highWaterMark: 300 });
+      const reverseStream2 = readLinesReversed(testFilePath, 300);
       const output2: string[] = [];
       let linesStreamed2 = 0;
       for await (const data of reverseStream2) {
@@ -51,7 +51,7 @@ describe('helper tests', () => {
       expect(linesStreamed2).toEqual(1000);
       expect(output2[0]).toBe('line1000');
       expect(output2[output2.length - 1]).toBe('line1');
-      expect(reverseStream2.bytesRead).toBe(reverseStream2.fileLength);
+      expect(reverseStream2.getBytesRead()).toBe(reverseStream2.getFileSize());
     } finally {
       fs.unlinkSync(testFilePath);
     }
@@ -64,7 +64,7 @@ line3
 line4`;
     const testFilePath = writeTmpFile('test1.txt', contents);
     try {
-      const reverseStream = new ReverseFileStream(testFilePath);
+      const reverseStream = readLinesReversed(testFilePath);
       const output: string[] = [];
       let linesStreamed = 0;
       for await (const data of reverseStream) {
@@ -82,7 +82,7 @@ line4`;
     const contents = ['line1', 'line2', 'line3', 'line4'].join('\r\n');
     const testFilePath = writeTmpFile('test1.txt', contents);
     try {
-      const reverseStream = new ReverseFileStream(testFilePath);
+      const reverseStream = readLinesReversed(testFilePath);
       const output: string[] = [];
       let linesStreamed = 0;
       for await (const data of reverseStream) {

--- a/src/tests-event-replay/helper-tests.ts
+++ b/src/tests-event-replay/helper-tests.ts
@@ -23,6 +23,8 @@ describe('helper tests', () => {
     for (let i = 1; i <= 1000; i++) {
       contents += `line${i}\n`;
     }
+    // trim tailing \n char
+    contents = contents.substring(0, contents.length - 1);
     const testFilePath = writeTmpFile('test1.txt', contents);
     try {
       // Default stream buffer is 64KB, set to 300 bytes so file is larger than memory buffer
@@ -79,7 +81,7 @@ line4`;
   });
 
   test('ReverseFileStream streams file in reverse', async () => {
-    const contents = ['line1', 'line2', 'line3', 'line4'].join('\r\n');
+    const contents = ['line1', 'line2', 'line3', 'line4'].join('\n');
     const testFilePath = writeTmpFile('test1.txt', contents);
     try {
       const reverseStream = readLinesReversed(testFilePath);

--- a/src/tests-event-replay/import-export-tests.ts
+++ b/src/tests-event-replay/import-export-tests.ts
@@ -246,7 +246,6 @@ describe('IBD', () => {
     );
     let hitIbdRoute = false;
     for (const response of responses) {
-      console.log({ response });
       if (response.response === 'IBD mode active.') {
         hitIbdRoute = true;
         expect(

--- a/src/tests-event-replay/import-export-tests.ts
+++ b/src/tests-event-replay/import-export-tests.ts
@@ -1,5 +1,6 @@
 import { ChainID } from '@stacks/transactions';
 import * as fs from 'fs';
+import { getBnsGenesisBlockFromBlockMessage, getGenesisBlockData } from '../event-replay/helpers';
 import { PgSqlClient } from '../datastore/connection';
 import { getPgClientConfig } from '../datastore/connection-legacy';
 import { databaseHasData, getRawEventRequests } from '../datastore/event-requests';
@@ -104,9 +105,22 @@ describe('import/export tests', () => {
     await expect(databaseHasData({ ignoreMigrationTables: true })).resolves.toBe(false);
   });
 
-  test('Bns import occurs', async () => {
+  test('Bns import occurs (block 1 genesis)', async () => {
     process.env.BNS_IMPORT_DIR = 'src/tests-bns/import-test-files';
     await importEventsFromTsv('src/tests-event-replay/tsv/mocknet.tsv', 'archival', true, true);
+    const configState = await db.getConfigState();
+    expect(configState.bns_names_onchain_imported).toBe(true);
+    expect(configState.bns_subdomains_imported).toBe(true);
+  });
+
+  test('Bns import occurs (block 0 genesis)', async () => {
+    process.env.BNS_IMPORT_DIR = 'src/tests-bns/import-test-files';
+    await importEventsFromTsv(
+      'src/tests-event-replay/tsv/mainnet-block0.tsv',
+      'archival',
+      true,
+      true
+    );
     const configState = await db.getConfigState();
     expect(configState.bns_names_onchain_imported).toBe(true);
     expect(configState.bns_subdomains_imported).toBe(true);


### PR DESCRIPTION
### Event-replay bug
Fixes a bug during event-replay where the "find last block from tsv file" code isn't working with the large mainnet tsv files we've been testing. 

I swapped that code out for a more optimized version implemented earlier for PR https://github.com/hirosystems/stacks-blockchain-api/pull/1166, which fixes the bug. 

I'm not able to reproduce the bug with small unit-testable input, but I've tested locally with a mainnet tsv file synced on my machine, and one synced from @wileyj. 

### BNS import bug
There was a race condition that caused the BNS import process to be started multiple times for both block-0 and block-1. This has also been fixed.