### PR TITLE
fix: optimize queries to retrieve BNS names

### DIFF
--- a/src/api/routes/bns/names.ts
+++ b/src/api/routes/bns/names.ts
@@ -62,7 +62,7 @@ export function createBnsNamesRouter(db: PgStore, chainId: ChainID): express.Rou
     asyncHandler(async (req, res, next) => {
       const { name } = req.params;
       const includeUnanchored = isUnanchoredRequest(req, res, next);
-      const zonefile = await db.getLatestZoneFile({ name: name, includeUnanchored, chainId });
+      const zonefile = await db.getLatestZoneFile({ name: name, includeUnanchored });
       if (zonefile.found) {
         setETagCacheHeaders(res);
         res.json(zonefile.result);
@@ -131,7 +131,6 @@ export function createBnsNamesRouter(db: PgStore, chainId: ChainID): express.Rou
             const nameQuery = await db.getName({
               name,
               includeUnanchored: includeUnanchored,
-              chainId: chainId,
             });
             if (!nameQuery.found) {
               throw { error: `cannot find name ${name}` };

--- a/src/tests-bns/bns-integration-tests.ts
+++ b/src/tests-bns/bns-integration-tests.ts
@@ -356,7 +356,7 @@ describe('BNS integration tests', () => {
     // testing name import
     await nameImport(namespace, importZonefile, name, testnetKey);
 
-    const importQuery = await db.getName({ name: `${name}.${namespace}`, includeUnanchored: false, chainId: network.chainId });
+    const importQuery = await db.getName({ name: `${name}.${namespace}`, includeUnanchored: false });
     const importQuery1 = await supertest(api.server).get(`/v1/names/${name}.${namespace}`);
     expect(importQuery1.status).toBe(200);
     expect(importQuery1.type).toBe('application/json');
@@ -485,7 +485,7 @@ describe('BNS integration tests', () => {
     const query1 = await supertest(api.server).get(`/v1/names/${name}.${namespace}`);
     expect(query1.status).toBe(200);
     expect(query1.type).toBe('application/json');
-    const query = await db.getName({ name: `${name}.${namespace}`, includeUnanchored: false, chainId: network.chainId });
+    const query = await db.getName({ name: `${name}.${namespace}`, includeUnanchored: false });
     expect(query.found).toBe(true);
     if (query.found) {
       expect(query.result.zonefile).toBe(zonefile);

--- a/src/tests-bns/event-server-tests.ts
+++ b/src/tests-bns/event-server-tests.ts
@@ -181,7 +181,6 @@ describe('BNS event server tests', () => {
     const name1 = await db.getName({
       name: 'dayslikewater.btc',
       includeUnanchored: true,
-      chainId: ChainID.Mainnet
     });
     expect(name1.found).toBe(true);
     expect(name1.result?.namespace_id).toBe('btc');
@@ -290,7 +289,6 @@ describe('BNS event server tests', () => {
     const name2 = await db.getName({
       name: 'dayslikewater.btc',
       includeUnanchored: true,
-      chainId: ChainID.Mainnet
     });
     expect(name2.found).toBe(true);
     expect(name2.result?.namespace_id).toBe('btc');
@@ -343,7 +341,6 @@ describe('BNS event server tests', () => {
     const name1 = await db.getName({
       name: 'friedger.id',
       includeUnanchored: true,
-      chainId: ChainID.Mainnet
     });
     expect(name1.found).toBe(true);
     expect(name1.result?.namespace_id).toBe('id');
@@ -417,7 +414,6 @@ describe('BNS event server tests', () => {
     const name2 = await db.getName({
       name: 'friedger.id',
       includeUnanchored: true,
-      chainId: ChainID.Mainnet
     });
     expect(name2.found).toBe(true);
     expect(name2.result?.namespace_id).toBe('id');
@@ -517,10 +513,9 @@ describe('BNS event server tests', () => {
       throwOnNotOK: true,
     });
 
-    const name = await db.getName({ name: 'jnj.btc', chainId: ChainID.Mainnet, includeUnanchored: true });
+    const name = await db.getName({ name: 'jnj.btc', includeUnanchored: true });
     expect(name.found).toBe(true);
     expect(name.result?.zonefile_hash).toBe('9198e0b61a029671e53bd59aa229e7ae05af35a3');
-    expect(name.result?.index_block_hash).toBe('0x0200');
     expect(name.result?.tx_id).toBe('0x1212');
     expect(name.result?.status).toBe('name-update');
   });
@@ -833,7 +828,6 @@ describe('BNS event server tests', () => {
     const name = await db.getName({
       name: 'cricketwireless.btc',
       includeUnanchored: true,
-      chainId: ChainID.Mainnet
     });
     expect(name.found).toBe(true);
     expect(name.result?.namespace_id).toBe('btc');
@@ -1013,7 +1007,6 @@ describe('BNS event server tests', () => {
     const name = await db.getName({
       name: 'ape.mega',
       includeUnanchored: true,
-      chainId: ChainID.Mainnet
     });
     expect(name.found).toBe(true);
     expect(name.result?.namespace_id).toBe('mega');


### PR DESCRIPTION
This PR attempts to fix #1580 by grouping calls to get BNS names with latest status into a single query. It also optimizes the use of postgres transactions so we don't duplicate calls to get the latest chain tip block height.