### PR TITLE
chore: include error details in `failed to connect to node RPC...`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ async function monitorCoreRpcConnection(): Promise<void> {
       previouslyConnected = true;
     } catch (error) {
       previouslyConnected = false;
-      logger.error(`Warning: failed to connect to node RPC server at ${client.endpoint}`);
+      logger.error(`Warning: failed to connect to node RPC server at ${client.endpoint}`, error);
     }
     await timeout(CORE_RPC_HEARTBEAT_INTERVAL);
   }


### PR DESCRIPTION
Help debug https://github.com/hirosystems/stacks-blockchain-api/issues/1584 by including verbose error details in the `Warning: failed to connect to node RPC server at ...` error message.

Example output:
```
{"code":"ECONNRESET","errno":"ECONNRESET","level":"error","message":"Warning: failed to connect to node RPC server at 127.0.0.1:20443 request to http://127.0.0.1:20443/v2/info failed, reason: socket hang up","stack":"FetchError: request to http://127.0.0.1:20443/v2/info failed, reason: socket hang up\n    at ClientRequest.<anonymous> (/Users/matt/Projects/stacks-blockchain-api3/node_modules/node-fetch/lib/index.js:1491:11)\n    at ClientRequest.emit (node:events:513:28)\n    at ClientRequest.emit (node:domain:489:12)\n    at Socket.socketOnEnd (node:_http_client:518:9)\n    at Socket.emit (node:events:525:35)\n    at Socket.emit (node:domain:489:12)\n    at endReadableNT (node:internal/streams/readable:1359:12)\n    at processTicksAndRejections (node:internal/process/task_queues:82:21)","timestamp":"2023-03-16T16:21:08.082Z","type":"system"}
```

```
{"code":"ECONNREFUSED","errno":"ECONNREFUSED","level":"error","message":"Warning: failed to connect to node RPC server at localhost:20443 request to http://localhost:20443/v2/info failed, reason: connect ECONNREFUSED ::1:20443","stack":"FetchError: request to http://localhost:20443/v2/info failed, reason: connect ECONNREFUSED ::1:20443\n    at ClientRequest.<anonymous> (/Users/matt/Projects/stacks-blockchain-api3/node_modules/node-fetch/lib/index.js:1491:11)\n    at ClientRequest.emit (node:events:513:28)\n    at ClientRequest.emit (node:domain:489:12)\n    at Socket.socketErrorListener (node:_http_client:494:9)\n    at Socket.emit (node:events:513:28)\n    at Socket.emit (node:domain:489:12)\n    at emitErrorNT (node:internal/streams/destroy:151:8)\n    at emitErrorCloseNT (node:internal/streams/destroy:116:3)\n    at processTicksAndRejections (node:internal/process/task_queues:82:21)","timestamp":"2023-03-16T16:25:47.814Z","type":"system"}
```

It looks like the IP address is included in the error message for `ECONNREFUSED` errors, which could help narrow down potential DNS caching issues too.