### PR TITLE
Fix: `/stx_supply` caching

### DIFF
--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -2346,7 +2346,7 @@ export class PgStore {
       if (result.length < 1) {
         throw new Error(`No rows returned from total supply query`);
       }
-      return { stx: BigInt(result[0].amount), blockHeight: atBlockHeight };
+      return { stx: BigInt(result[0]?.amount ?? 0), blockHeight: atBlockHeight };
     });
   }
 


### PR DESCRIPTION
Fixes https://github.com/hirosystems/stacks-blockchain-api/issues/1590

Adds chaintip-based etag caching for the `/stx_supply` endpoints. This makes it so the pg query generally only needs to be ran once per block.

If the we still run into performance issues with this endpoint then we can add materialized view for it.