### PR TITLE
fix: postgres should not be required in `STACKS_API_MODE=offline` mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -112,6 +112,34 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Launch: mocknet offline-mode",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "runtimeArgs": [
+        "-r",
+        "ts-node/register/transpile-only",
+        "-r",
+        "tsconfig-paths/register"
+      ],
+      "args": [
+        "${workspaceFolder}/src/index.ts"
+      ],
+      "outputCapture": "std",
+      "internalConsoleOptions": "openOnSessionStart",
+      "preLaunchTask": "stacks-node:start-mocknet",
+      "postDebugTask": "stacks-node:stop-mocknet",
+      "env": {
+        "STACKS_CHAIN_ID": "0x80000000",
+        "NODE_ENV": "development",
+        "STACKS_API_MODE": "offline",
+        "TS_NODE_SKIP_IGNORE": "true"
+      },
+      "killBehavior": "polite",
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Launch: read-only",
       "skipFiles": [
         "<node_internals>/**"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,6 +23,28 @@
       "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "dedicated", "clear": false }
     },
     {
+      "label": "stacks-node:start-mocknet",
+      "type": "shell",
+      "command": "docker compose -f docker/docker-compose.dev.stacks-blockchain.yml up --force-recreate -V",
+      "isBackground": true,
+      "problemMatcher": {
+        "pattern": { "regexp": ".", "file": 1, "location": 2, "message": 3, },
+        "background": { "activeOnStart": true, "beginsPattern": ".", "endsPattern": "." }
+      },
+      "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "dedicated", "clear": false }
+    },
+    {
+      "label": "stacks-node:stop-mocknet",
+      "type": "shell",
+      "command": "docker compose -f docker/docker-compose.dev.stacks-blockchain.yml down -v -t 0",
+      "isBackground": true,
+      "problemMatcher": {
+        "pattern": { "regexp": ".", "file": 1, "location": 2, "message": 3, },
+        "background": { "activeOnStart": true, "beginsPattern": ".", "endsPattern": "." }
+      },
+      "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "dedicated", "clear": false }
+    },
+    {
       "label": "deploy:krypton",
       "type": "shell",
       "command": "docker compose -f docker/docker-compose.dev.postgres.yml -f docker/docker-compose.dev.stacks-krypton.yml up",

--- a/src/datastore/offline-dummy-store.ts
+++ b/src/datastore/offline-dummy-store.ts
@@ -1,17 +1,20 @@
 import { EventEmitter } from 'events';
 import { PgStoreEventEmitter } from './pg-store-event-emitter';
-import { PgStore } from './pg-store';
+import { PgWriteStore } from './pg-write-store';
 
-export const OfflineDummyStore: PgStore = new Proxy(new EventEmitter() as PgStoreEventEmitter, {
-  get(target: any, propKey) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    if (propKey === 'eventEmitter') return target;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    if (propKey in target) return target[propKey];
-    return function () {
-      throw new Error(
-        `Cannot call function on the Dummy datastore. Check if the application is running in offline mode.`
-      );
-    };
-  },
-});
+export const OfflineDummyStore: PgWriteStore = new Proxy(
+  new EventEmitter() as PgStoreEventEmitter,
+  {
+    get(target: any, propKey) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      if (propKey === 'eventEmitter') return target;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      if (propKey in target) return target[propKey];
+      return function () {
+        throw new Error(
+          `Cannot call function on the Dummy datastore. Check if the application is running in offline mode.`
+        );
+      };
+    },
+  }
+);


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/1391

The dummy storage instance was not being used when initializing in offline mode, which was causing the postgres connection to retry forever. 