### PR TITLE
Fix/subnet latest

### DIFF
--- a/docker/docker-compose.dev.subnets.yml
+++ b/docker/docker-compose.dev.subnets.yml
@@ -19,7 +19,7 @@ services:
       - "host.docker.internal:host-gateway" # fixes `host.docker.internal` on linux hosts
   stacks-subnet:
     # restart: on-failure
-    image: "hirosystems/stacks-subnets:7012d22"
+    image: "hirosystems/stacks-subnets:0.4.3-alpha-3"
     # build:
     #   dockerfile: ./subnet-node.Dockerfile
     command: subnet-node start --config=/app/config/Stacks-subnet.toml

--- a/docker/subnet-node.Dockerfile
+++ b/docker/subnet-node.Dockerfile
@@ -7,7 +7,7 @@ ARG GIT_COMMIT='No Commit Info'
 WORKDIR /src
 
 RUN git clone https://github.com/hirosystems/stacks-subnets.git .
-RUN git checkout 77c6625947cdf66ab02acc5c03c08e5142911494
+RUN git checkout 135de42ef37fe4976a2335825ae4004bc433d874
 
 RUN mkdir /out /contracts
 

--- a/package.json
+++ b/package.json
@@ -83,6 +83,11 @@
         "prerelease": true
       },
       {
+        "name": "subnets",
+        "channel": "subnets",
+        "prerelease": true
+      },
+      {
         "name": "stacks-2.1",
         "channel": "stacks-2.1",
         "prerelease": true


### PR DESCRIPTION
* Bumped to latest subnet-node version in integration tests
* Renamed existing `beta` branch to `subnets`
* Add semantic-release config for publishing beta releases from the `subnets` branch