### PR TITLE
fix: allow negative fee value in Rosetta tx construction

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -741,6 +741,12 @@ function intMax(args: bigint[] | number[]): any {
 }
 export { intMax };
 
+export class BigIntMath {
+  static abs(a: bigint): bigint {
+    return a < 0n ? -a : a;
+  }
+}
+
 export function getOrAdd<K, V>(map: Map<K, V>, key: K, create: () => V): V {
   let val = map.get(key);
   if (val === undefined) {


### PR DESCRIPTION
A previous version of the API used a version of stacks.js that happened to work with negative stx amount values. In the latest version, this triggers an error. 

Some consumers of the Rosetta layer were depending on negative STX amounts for the `fee` value in tx construction. This PR uses a `Math.abs(fee)` so that both negative and positive STX amounts should work.

Error report:
> upgrade @stack/transactions from "2.0.1" to "6.0.0", which change the implementation of intToBytes conversion
Before this commit, the intToBytes(condition.fee, false, 8) [here](https://github.com/hirosystems/stacks.js/blob/v2.0.1/packages/transactions/src/authorization.ts#L276) can handle negative value, and after this commit, this line will throw exactly the same exception we saw.  And at the same time,  custody use negative value for fee (e.g. -250000 for the failed custody tx this morning)
> From `/construction/payloads`:
```
rosetta: generate payloads failed: received http error code 500 Internal Server Error. Error: { "error": "Error: Invalid byte sequence", "stack": "Error: Invalid byte sequence
 at hexToBytes (/stacks-blockchain-api/node_modules/@stacks/common/src/utils.ts:513:47)
 at bigIntToBytes (/stacks-blockchain-api/node_modules/@stacks/common/src/utils.ts:426:10)
 at intToBytes (/stacks-blockchain-api/node_modules/@stacks/common/src/utils.ts:321:10)
```