### PR TITLE
fix npm publish CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -882,6 +882,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
+
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2.7.0
         id: semantic


### PR DESCRIPTION
Try to fix [issue](https://github.com/hirosystems/stacks-blockchain-api/issues/1593).

Lock `build-publish` action to the node version present on `.nvmrc` file.

1. Using an old Node (v12) version the issue is reproduced.

```
❯ nvm use 12
Now using node v12.22.12 (npm v6.14.16)

❯ npx rimraf ./lib && npm run generate-openapi && npm run build:node && npm run build:browser
Unexpected token '('
```

2. Using the `.nvmrc` Node (v16) version the issue is fixed.
```
❯ nvm use
Found '/Users/chris/dev/hiro/stacks-blockchain-api/.nvmrc' with version <v16>
Now using node v16.20.0 (npm v8.19.4)

❯ npx rimraf ./lib && npm run generate-openapi && npm run build:node && npm run build:browser

> @stacks/blockchain-api-client@0.1.2 generate-openapi
> npm run prep-openapi && openapi-generator-cli generate --skip-validate-spec -g typescript-fetch --additional-properties=withInterfaces=true,typescriptThreePlus=true,supportsES6=true,legacyDiscriminatorBehavior=false,enumPropertyNaming=original,modelPropertyNaming=original -i ./.tmp/openapi.json -o ./src/generated > ./.tmp/gen.log


> @stacks/blockchain-api-client@0.1.2 prep-openapi
> rimraf ./.tmp && rimraf ./src/generated && swagger-cli bundle --dereference -o ./.tmp/openapi-temp.json ../docs/openapi.yaml && shx sed -i '^.*\$schema.*$' '' ./.tmp/openapi-temp.json > ./.tmp/openapi.json

Created .tmp/openapi-temp.json from ../docs/openapi.yaml

> @stacks/blockchain-api-client@0.1.2 build:node
> tsc


> @stacks/blockchain-api-client@0.1.2 build:browser
> microbundle -i src/index.ts -o lib/index.umd.js --no-pkg-main -f umd --external none --globals none --no-compress --tsconfig tsconfig.browser.json --name StacksBlockchainApiClient

```