### PR TITLE
fix(subnets): use boot address for burnchain-tx signer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - master
       - develop
       - beta
+      - subnets
     tags-ignore:
       - '**'
     paths-ignore:

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1038,6 +1038,15 @@ export function bnsHexValueToName(hex: string): string {
   )}`;
 }
 
+export const enum BootAddress {
+  mainnet = 'SP000000000000000000002Q6VF78',
+  testnet = 'ST000000000000000000002AMW42H',
+}
+
+export function getBootAddressForChain(chainId: ChainID): BootAddress {
+  return chainId === ChainID.Mainnet ? BootAddress.mainnet : BootAddress.testnet;
+}
+
 /**
  * Returns the parent BNS name from a subdomain.
  * @param subdomain - Fully qualified subdomain
@@ -1048,9 +1057,7 @@ export function bnsNameFromSubdomain(subdomain: string): string {
 }
 
 export function getBnsSmartContractId(chainId: ChainID): string {
-  return chainId === ChainID.Mainnet
-    ? 'SP000000000000000000002Q6VF78.bns::names'
-    : 'ST000000000000000000002AMW42H.bns::names';
+  return `${getBootAddressForChain(chainId)}.bns::names`;
 }
 
 export const enum SubnetContractIdentifer {

--- a/src/tests-subnets/subnet-tests.ts
+++ b/src/tests-subnets/subnet-tests.ts
@@ -455,7 +455,7 @@ describe('Subnets tests', () => {
             fee_rate: '0',
             post_condition_mode: 'allow',
             post_conditions: [],
-            sender_address: accounts.USER.addr,
+            sender_address: 'ST000000000000000000002AMW42H',
             sponsored: false,
             tx_index: 0,
             tx_result: {
@@ -889,7 +889,7 @@ describe('Subnets tests', () => {
             fee_rate: '0',
             post_condition_mode: 'allow',
             post_conditions: [],
-            sender_address: accounts.USER.addr,
+            sender_address: 'ST000000000000000000002AMW42H',
             sponsored: false,
             tx_index: 0,
             tx_result: {


### PR DESCRIPTION
Fixes #1616

Use the boot address as the tx signer for synthetic subnet burnchain-tx parsing. Previously it was using the address associated with the asset transfer, which would cause other queries to view those addresses as having issued nonce-incrementing txs.