### PR TITLE
add check for stacks node type before BNS import

### DIFF
--- a/.env
+++ b/.env
@@ -106,6 +106,10 @@ MAINNET_SEND_MANY_CONTRACT_ID=SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-man
 # Directory containing Stacks 1.0 BNS data extracted from https://storage.googleapis.com/blockstack-v1-migration-data/export-data.tar.gz
 # BNS_IMPORT_DIR=/extracted/export-data-dir/
 
+# Stacks blockchain node type (L1 or subnet). L1 by default.
+# If STACKS_NODE_TYPE is set to subnet, BNS importer is skipped.
+STACKS_NODE_TYPE=L1
+
 # Override the default file path for the proxy cache control file
 # STACKS_API_PROXY_CACHE_CONTROL_FILE=/path/to/.proxy-cache-control.json
 

--- a/src/import-v1/index.ts
+++ b/src/import-v1/index.ts
@@ -35,8 +35,8 @@ const SUBDOMAIN_BATCH_SIZE = 2000;
 const STX_VESTING_BATCH_SIZE = 2000;
 
 const enum StacksNodeType {
-  L1 = 'l1',
-  Subnet = 'subnet'
+  L1 = 'L1',
+  Subnet = 'subnet',
 }
 
 class LineReaderStream extends stream.Duplex {
@@ -554,8 +554,8 @@ export async function importV1TokenOfferingData(db: PgWriteStore) {
 
 export async function handleBnsImport(db: PgWriteStore) {
   const stacksNodeType = process.env.STACKS_NODE_TYPE;
-  if (stackNodeType === StacksNodeType.Subnet) {
-    logger.error('BNS imports should not be enabled for a Subnet');
+  if (stacksNodeType === StacksNodeType.Subnet) {
+    logger.warn('BNS imports should not be enabled for a Subnet. Skipping...');
     return;
   }
 

--- a/src/import-v1/index.ts
+++ b/src/import-v1/index.ts
@@ -34,6 +34,11 @@ const readFile = util.promisify(fs.readFile);
 const SUBDOMAIN_BATCH_SIZE = 2000;
 const STX_VESTING_BATCH_SIZE = 2000;
 
+const enum StacksNodeType {
+  L1 = 'l1',
+  Subnet = 'subnet'
+}
+
 class LineReaderStream extends stream.Duplex {
   asyncGen: AsyncGenerator<string, void, unknown>;
   readlineInstance: readline.Interface;
@@ -548,6 +553,12 @@ export async function importV1TokenOfferingData(db: PgWriteStore) {
 }
 
 export async function handleBnsImport(db: PgWriteStore) {
+  const stacksNodeType = process.env.STACKS_NODE_TYPE;
+  if (stackNodeType === StacksNodeType.Subnet) {
+    logger.error('BNS imports should not be enabled for a Subnet');
+    return;
+  }
+
   const bnsDir = process.env.BNS_IMPORT_DIR;
   if (!bnsDir) {
     console.log(`BNS_IMPORT_DIR not configured, will not import BNS data`);

--- a/src/tests-event-replay/import-export-tests.ts
+++ b/src/tests-event-replay/import-export-tests.ts
@@ -125,6 +125,15 @@ describe('import/export tests', () => {
     expect(configState.bns_names_onchain_imported).toBe(true);
     expect(configState.bns_subdomains_imported).toBe(true);
   });
+
+  test('BNS import should be skipped for Stacks subnet nodes', async () => {
+    process.env.STACKS_NODE_TYPE = 'subnet';
+    process.env.BNS_IMPORT_DIR = 'src/tests-bns/import-test-files';
+    await importEventsFromTsv('src/tests-event-replay/tsv/mocknet.tsv', 'archival', true, true);
+    const configState = await db.getConfigState();
+    expect(configState.bns_names_onchain_imported).toBe(false);
+    expect(configState.bns_subdomains_imported).toBe(false);
+  });
 });
 
 describe('IBD', () => {


### PR DESCRIPTION
Issue: #1602 .

Summary: BNS imports are mean to run for L1 stacks node. When running for Subnets the node sync is not starting.

Solution: Create an environment variable that explicits the underlying node type. And check for the node type before starting the BNS importer.