### PR TITLE
Merge subnets into develop

### DIFF
--- a/docker/docker-compose.dev.subnets.yml
+++ b/docker/docker-compose.dev.subnets.yml
@@ -2,7 +2,7 @@
 version: '3.7'
 services:
   stacks-blockchain:
-    image: "hirosystems/stacks-api-e2e:stacks2.1-ecb1872"
+    image: "hirosystems/stacks-api-e2e:stacks2.1-a50d830"
     command: |
       bash -c "rm /event-log.ndjson && /root/run.sh"
     ports:
@@ -19,8 +19,9 @@ services:
       - "host.docker.internal:host-gateway" # fixes `host.docker.internal` on linux hosts
   stacks-subnet:
     # restart: on-failure
-    #image: "hirosystems/stacks-subnets:206-merge-stretch"
-    image: "hirosystems/stacks-subnets@sha256:7e296cd319f81b87b5a9c11f4c478dafb122c114dc805d832d68f39be150af49"
+    image: "hirosystems/stacks-subnets:7012d22"
+    # build:
+    #   dockerfile: ./subnet-node.Dockerfile
     command: subnet-node start --config=/app/config/Stacks-subnet.toml
     ports:
       - "30443:30443" # subnet-node RPC interface

--- a/docker/subnet-node.Dockerfile
+++ b/docker/subnet-node.Dockerfile
@@ -1,0 +1,25 @@
+FROM rust:bullseye as build
+
+ARG STACKS_NODE_VERSION="No Version Info"
+ARG GIT_BRANCH='No Branch Info'
+ARG GIT_COMMIT='No Commit Info'
+
+WORKDIR /src
+
+RUN git clone https://github.com/hirosystems/stacks-subnets.git .
+RUN git checkout 77c6625947cdf66ab02acc5c03c08e5142911494
+
+RUN mkdir /out /contracts
+
+RUN cd testnet/stacks-node && cargo build --features monitoring_prom,slog_json --release
+
+RUN cp target/release/subnet-node /out
+
+FROM debian:bullseye-backports
+
+COPY --from=build /out/ /bin/
+# Add the core contracts to the image, so that clarinet can retrieve them.
+COPY --from=build /src/core-contracts/contracts/subnet.clar /contracts/subnet.clar
+COPY --from=build /src/core-contracts/contracts/helper/subnet-traits.clar /contracts/subnet-traits.clar
+
+CMD ["subnet-node", "start"]

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -148,6 +148,28 @@ interface FtBurnEvent extends CoreNodeEventBase {
   };
 }
 
+interface BurnchainOpRegisterAssetNft {
+  register_asset: {
+    asset_type: 'nft';
+    burn_header_hash: string;
+    l1_contract_id: string;
+    l2_contract_id: string;
+    txid: string;
+  };
+}
+
+interface BurnchainOpRegisterAssetFt {
+  register_asset: {
+    asset_type: 'ft';
+    burn_header_hash: string;
+    l1_contract_id: string;
+    l2_contract_id: string;
+    txid: string;
+  };
+}
+
+export type BurnchainOp = BurnchainOpRegisterAssetNft | BurnchainOpRegisterAssetFt;
+
 export type CoreNodeEvent =
   | SmartContractEvent
   | StxTransferEvent
@@ -174,6 +196,7 @@ export interface CoreNodeTxMessage {
   microblock_sequence: number | null;
   microblock_hash: string | null;
   microblock_parent_hash: string | null;
+  burnchain_op?: BurnchainOp | null;
 }
 
 export interface CoreNodeMicroblockTxMessage extends CoreNodeTxMessage {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1074,6 +1074,11 @@ export function getBnsSmartContractId(chainId: ChainID): string {
     : 'ST000000000000000000002AMW42H.bns::names';
 }
 
+export const enum SubnetContractIdentifer {
+  mainnet = 'SP000000000000000000002Q6VF78.subnet',
+  testnet = 'ST000000000000000000002AMW42H.subnet',
+}
+
 export function getSendManyContract(chainId: ChainID) {
   const contractId =
     chainId === ChainID.Mainnet

--- a/src/tests-subnets/l1-contracts/simple-ft-l1.clar
+++ b/src/tests-subnets/l1-contracts/simple-ft-l1.clar
@@ -1,3 +1,5 @@
+;; https://github.com/hirosystems/stacks-subnets/blob/master/core-contracts/contracts/helper/simple-ft.clar
+
 (define-constant ERR_NOT_AUTHORIZED (err u1001))
 
 (impl-trait 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP.sip-traits.ft-trait)
@@ -7,8 +9,7 @@
 
 ;; get the token balance of owner
 (define-read-only (get-balance (owner principal))
-  (begin
-    (ok (ft-get-balance ft-token owner))))
+    (ok (ft-get-balance ft-token owner)))
 
 ;; returns the total number of tokens
 (define-read-only (get-total-supply)
@@ -49,9 +50,9 @@
 (define-read-only (get-token-uri)
   (ok none))
 
-(define-public (gift-tokens (recipient principal))
+(define-public (gift-tokens (amount uint) (recipient principal))
   (begin
     (asserts! (is-eq tx-sender recipient) ERR_NOT_AUTHORIZED)
-    (ft-mint? ft-token u1 recipient)
+    (ft-mint? ft-token amount recipient)
   )
 )

--- a/src/tests-subnets/l1-contracts/simple-nft-l1.clar
+++ b/src/tests-subnets/l1-contracts/simple-nft-l1.clar
@@ -1,9 +1,11 @@
+;; https://github.com/hirosystems/stacks-subnets/blob/master/core-contracts/contracts/helper/simple-nft.clar
+
 (define-constant CONTRACT_OWNER tx-sender)
 (define-constant CONTRACT_ADDRESS (as-contract tx-sender))
 
 (define-constant ERR_NOT_AUTHORIZED (err u1001))
 
-(impl-trait 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP.nft-trait.nft-trait)
+(impl-trait 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP.sip-traits.nft-trait)
 (impl-trait 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP.subnet-traits.mint-from-subnet-trait)
 
 (define-data-var lastId uint u0)

--- a/src/tests-subnets/l1-contracts/sip-traits.clar
+++ b/src/tests-subnets/l1-contracts/sip-traits.clar
@@ -1,3 +1,5 @@
+;; https://github.com/hirosystems/stacks-subnets/blob/master/core-contracts/contracts/helper/sip-traits.clar
+
 (define-trait nft-trait
    (
      ;; Last token ID, limited to uint range

--- a/src/tests-subnets/l1-contracts/subnet-traits.clar
+++ b/src/tests-subnets/l1-contracts/subnet-traits.clar
@@ -1,3 +1,5 @@
+;; https://github.com/hirosystems/stacks-subnets/blob/master/core-contracts/contracts/helper/subnet-traits.clar
+
 ;; In order to process deposits and withdrawals to a subnet, an asset
 ;; contract must implement this trait.
 (define-trait mint-from-subnet-trait

--- a/src/tests-subnets/l2-contracts/simple-ft-l2.clar
+++ b/src/tests-subnets/l2-contracts/simple-ft-l2.clar
@@ -1,3 +1,5 @@
+;; https://github.com/hirosystems/stacks-subnets/blob/master/core-contracts/contracts/helper/simple-ft-l2.clar
+
 (define-constant ERR_NOT_AUTHORIZED (err u1001))
 
 (impl-trait 'ST000000000000000000002AMW42H.subnet.ft-trait)
@@ -6,8 +8,7 @@
 
 ;; get the token balance of owner
 (define-read-only (get-balance (owner principal))
-  (begin
-    (ok (ft-get-balance ft-token owner))))
+    (ok (ft-get-balance ft-token owner)))
 
 ;; returns the total number of tokens
 (define-read-only (get-total-supply)
@@ -38,8 +39,11 @@
   (ok none)
 )
 
-(define-read-only (get-token-balance (user principal))
-  (ft-get-balance ft-token user)
+(define-public (gift-tokens (amount uint) (recipient principal))
+  (begin
+    (asserts! (is-eq tx-sender recipient) ERR_NOT_AUTHORIZED)
+    (ft-mint? ft-token amount recipient)
+  )
 )
 
 (impl-trait 'ST000000000000000000002AMW42H.subnet.subnet-asset)

--- a/src/tests-subnets/l2-contracts/simple-nft-l2.clar
+++ b/src/tests-subnets/l2-contracts/simple-nft-l2.clar
@@ -1,3 +1,5 @@
+;; https://github.com/hirosystems/stacks-subnets/blob/master/core-contracts/contracts/helper/simple-nft-l2.clar
+
 (define-constant CONTRACT_OWNER tx-sender)
 (define-constant CONTRACT_ADDRESS (as-contract tx-sender))
 

--- a/src/tests-subnets/subnet-tests.ts
+++ b/src/tests-subnets/subnet-tests.ts
@@ -272,6 +272,96 @@ describe('Subnets tests', () => {
       }
     });
 
+    test('Step 2b: Validate register-asset-contract synthetic tx', async () => {
+      while (true) {
+        const expectedContractID = `ST000000000000000000002AMW42H.subnet`;
+        const resp = await supertest(testEnv.api.server)
+          .get(`/extended/v1/tx?limit=1&type=contract_call`)
+          .expect(200);
+        const txListResp = resp.body as TransactionResults;
+        const tx = txListResp.results[0] as ContractCallTransaction;
+        if (
+          txListResp.total === 0 ||
+          tx.contract_call.contract_id !== expectedContractID ||
+          tx.contract_call.function_name !== 'register-asset-contract'
+        ) {
+          await timeout(200);
+          continue;
+        }
+        expect(tx).toEqual(
+          expect.objectContaining({
+            anchor_mode: 'any',
+            canonical: true,
+            contract_call: {
+              contract_id: expectedContractID,
+              function_args: [
+                expect.objectContaining({
+                  name: 'asset-type',
+                  repr: '"nft"',
+                  type: '(string-ascii 3)',
+                }),
+                {
+                  hex: '0x061a43596b5386f466863e25658ddf94bd0fadab00480d73696d706c652d6e66742d6c31',
+                  name: 'l1-contract',
+                  repr: `'${accounts.USER.addr}.simple-nft-l1`,
+                  type: 'principal',
+                },
+                {
+                  hex: '0x061a43596b5386f466863e25658ddf94bd0fadab00480d73696d706c652d6e66742d6c32',
+                  name: 'l2-contract',
+                  repr: `'${accounts.USER.addr}.simple-nft-l2`,
+                  type: 'principal',
+                },
+                expect.objectContaining({
+                  name: 'burnchain-txid',
+                  type: '(buff 32)',
+                }),
+              ],
+              function_name: 'register-asset-contract',
+              function_signature:
+                '(define-public (register-asset-contract (asset-type (string-ascii 3)) (l1-contract principal) (l2-contract principal) (burnchain-txid (buff 32))))',
+            },
+            event_count: 1,
+            events: [],
+            fee_rate: '0',
+            post_condition_mode: 'allow',
+            post_conditions: [],
+            sender_address: 'ST000000000000000000002AMW42H',
+            sponsored: false,
+            tx_index: 0,
+            tx_result: {
+              hex: '0x0703',
+              repr: '(ok true)',
+            },
+            tx_status: 'success',
+            tx_type: 'contract_call',
+          })
+        );
+
+        const respEvents = await supertest(testEnv.api.server)
+          .get(`/extended/v1/tx/events?tx_id=${tx.tx_id}`)
+          .expect(200);
+        const txEvents = respEvents.body.events as TransactionEventsResponse['results'];
+        expect(txEvents).toEqual([
+          {
+            contract_log: {
+              contract_id: 'ST000000000000000000002AMW42H.subnet',
+              topic: 'print',
+              value: expect.objectContaining({
+                repr: expect.stringContaining(
+                  `(l1-contract '${accounts.USER.addr}.simple-nft-l1) (l2-contract '${accounts.USER.addr}.simple-nft-l2)`
+                ),
+              }),
+            },
+            event_index: 0,
+            event_type: 'smart_contract_log',
+            tx_id: tx.tx_id,
+          },
+        ]);
+        break;
+      }
+    });
+
     test('Step 3: Mint an NFT on the L1 chain', async () => {
       const tx = await makeContractCall({
         contractAddress: accounts.USER.addr,
@@ -617,12 +707,100 @@ describe('Subnets tests', () => {
       }
     });
 
+    test('Step 2b: Validate register-asset-contract synthetic tx', async () => {
+      while (true) {
+        const expectedContractID = `ST000000000000000000002AMW42H.subnet`;
+        const resp = await supertest(testEnv.api.server)
+          .get(`/extended/v1/tx?limit=1&type=contract_call`)
+          .expect(200);
+        const txListResp = resp.body as TransactionResults;
+        const tx = txListResp.results[0] as ContractCallTransaction;
+        if (
+          txListResp.total === 0 ||
+          tx.contract_call.contract_id !== expectedContractID ||
+          tx.contract_call.function_name !== 'register-asset-contract'
+        ) {
+          await timeout(200);
+          continue;
+        }
+        expect(tx).toEqual(
+          expect.objectContaining({
+            anchor_mode: 'any',
+            canonical: true,
+            contract_call: {
+              contract_id: expectedContractID,
+              function_args: [
+                expect.objectContaining({
+                  name: 'asset-type',
+                  repr: '"ft"',
+                  type: '(string-ascii 3)',
+                }),
+                expect.objectContaining({
+                  name: 'l1-contract',
+                  repr: `'${accounts.USER.addr}.simple-ft-l1`,
+                  type: 'principal',
+                }),
+                expect.objectContaining({
+                  name: 'l2-contract',
+                  repr: `'${accounts.USER.addr}.simple-ft-l2`,
+                  type: 'principal',
+                }),
+                expect.objectContaining({
+                  name: 'burnchain-txid',
+                  type: '(buff 32)',
+                }),
+              ],
+              function_name: 'register-asset-contract',
+              function_signature:
+                '(define-public (register-asset-contract (asset-type (string-ascii 3)) (l1-contract principal) (l2-contract principal) (burnchain-txid (buff 32))))',
+            },
+            event_count: 1,
+            events: [],
+            fee_rate: '0',
+            post_condition_mode: 'allow',
+            post_conditions: [],
+            sender_address: 'ST000000000000000000002AMW42H',
+            sponsored: false,
+            tx_index: 0,
+            tx_result: {
+              hex: '0x0703',
+              repr: '(ok true)',
+            },
+            tx_status: 'success',
+            tx_type: 'contract_call',
+          })
+        );
+
+        const respEvents = await supertest(testEnv.api.server)
+          .get(`/extended/v1/tx/events?tx_id=${tx.tx_id}`)
+          .expect(200);
+        const txEvents = respEvents.body.events as TransactionEventsResponse['results'];
+        expect(txEvents).toEqual([
+          {
+            contract_log: {
+              contract_id: 'ST000000000000000000002AMW42H.subnet',
+              topic: 'print',
+              value: expect.objectContaining({
+                repr: expect.stringContaining(
+                  `(l1-contract '${accounts.USER.addr}.simple-ft-l1) (l2-contract '${accounts.USER.addr}.simple-ft-l2)`
+                ),
+              }),
+            },
+            event_index: 0,
+            event_type: 'smart_contract_log',
+            tx_id: tx.tx_id,
+          },
+        ]);
+        break;
+      }
+    });
+
     test('Step 3: Mint FT on the L1 chain', async () => {
       const tx = await makeContractCall({
         contractAddress: accounts.USER.addr,
         contractName: 'simple-ft-l1',
         functionName: 'gift-tokens',
-        functionArgs: [standardPrincipalCV(accounts.USER.addr)],
+        functionArgs: [uintCV(1), standardPrincipalCV(accounts.USER.addr)],
         senderKey: accounts.USER.key,
         validateWithAbi: false,
         network: l1Network,
@@ -804,7 +982,7 @@ describe('Subnets tests', () => {
         withdrawal_root: string;
         sibling_hashes: string;
       }>(
-        `v2/withdrawal/ft/${withdrawalBlockHeight}/${accounts.ALT_USER.addr}/${withdrawalId}/${accounts.USER.addr}/simple-ft-l2/5`
+        `v2/withdrawal/ft/${withdrawalBlockHeight}/${accounts.ALT_USER.addr}/${withdrawalId}/${accounts.USER.addr}/simple-ft-l2/1`
       );
       console.log(json_merkle_entry);
       const cv_merkle_entry = {
@@ -843,8 +1021,8 @@ describe('Subnets tests', () => {
         const result = await callReadOnlyFunction({
           contractAddress: accounts.USER.addr,
           contractName: 'simple-ft-l1',
-          functionName: 'get-owner',
-          functionArgs: [uintCV(5)],
+          functionName: 'get-balance',
+          functionArgs: [standardPrincipalCV(accounts.ALT_USER.addr)],
           network: l1Network,
           senderAddress: accounts.ALT_USER.addr,
         });
@@ -860,7 +1038,7 @@ describe('Subnets tests', () => {
     });
   });
 
-  describe.skip('STX use-case test', () => {
+  describe('STX use-case test', () => {
     test('Step 1: Publish STX contract to L2', async () => {
       const curBlock = await l2Client.getInfo();
       await standByUntilBlock(curBlock.stacks_tip_height + 1);


### PR DESCRIPTION
An initial subnet-support PR had accidentally already been merged into the develop branch a while ago, and is difficult to revert.

So, we might as well merge in the latest subnet support into develop. This means the next release cut from develop will support subnets. 


Note: if additional API changes related to subnets are needed, then those will continue to go only into the `subnets` branch of the API.