### PR TITLE
add mempool nonces to address endpoint JSON response

### DIFF
--- a/docs/entities/address/address-nonces.example.json
+++ b/docs/entities/address/address-nonces.example.json
@@ -2,5 +2,6 @@
   "last_mempool_tx_nonce": 5,
   "last_executed_tx_nonce": 2,
   "possible_next_nonce": 6,
-  "detected_missing_nonces": [3, 4]
+  "detected_missing_nonces": [3, 4],
+  "detected_mempool_nonces": []
 }

--- a/docs/entities/address/address-nonces.schema.json
+++ b/docs/entities/address/address-nonces.schema.json
@@ -30,6 +30,13 @@
       "items": {
         "type": "integer"
       }
+    },
+    "detected_mempool_nonces": {
+      "type": "array",
+      "description": "Nonces currently in mempool for this address.",
+      "items": {
+        "type": "integer"
+      }
     }
   }
 }

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -3348,6 +3348,10 @@ export interface AddressNonces {
    * Nonces that appear to be missing and likely causing a mempool transaction to be stuck.
    */
   detected_missing_nonces: number[];
+  /**
+   * Nonces currently in mempool for this address.
+   */
+  detected_mempool_nonces?: number[];
 }
 /**
  * Total burnchain rewards made to a recipient

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -661,6 +661,7 @@ export function createAddressRouter(db: PgStore, chainId: ChainID): express.Rout
           // Note: OpenAPI type generator doesn't support `nullable: true` so force cast it here
           last_mempool_tx_nonce: (null as unknown) as number,
           detected_missing_nonces: [],
+          detected_mempool_nonces: [],
         };
         setETagCacheHeaders(res);
         res.json(results);
@@ -671,6 +672,7 @@ export function createAddressRouter(db: PgStore, chainId: ChainID): express.Rout
           last_mempool_tx_nonce: nonces.lastMempoolTxNonce as number,
           possible_next_nonce: nonces.possibleNextNonce,
           detected_missing_nonces: nonces.detectedMissingNonces,
+          detected_mempool_nonces: nonces.detectedMempoolNonces,
         };
         setETagCacheHeaders(res);
         res.json(results);

--- a/src/tests/address-tests.ts
+++ b/src/tests/address-tests.ts
@@ -717,6 +717,7 @@ describe('address tests', () => {
     // Chain-tip nonce
     const expectedNonceResults1 = {
       detected_missing_nonces: [],
+      detected_mempool_nonces: [],
       last_executed_tx_nonce: 3,
       last_mempool_tx_nonce: 4,
       possible_next_nonce: 5,
@@ -738,6 +739,7 @@ describe('address tests', () => {
     await db.updateMempoolTxs({ mempoolTxs: [mempoolTx2] });
     const expectedNonceResults2 = {
       detected_missing_nonces: [6, 5],
+      detected_mempool_nonces: [4],
       last_executed_tx_nonce: 3,
       last_mempool_tx_nonce: 7,
       possible_next_nonce: 8,
@@ -752,6 +754,7 @@ describe('address tests', () => {
     // Get nonce at block height
     const expectedNonceResults3 = {
       detected_missing_nonces: [],
+      detected_mempool_nonces: [],
       last_executed_tx_nonce: 2,
       last_mempool_tx_nonce: null,
       possible_next_nonce: 3,
@@ -766,6 +769,7 @@ describe('address tests', () => {
     // Get nonce at block hash
     const expectedNonceResults4 = {
       detected_missing_nonces: [],
+      detected_mempool_nonces: [],
       last_executed_tx_nonce: 2,
       last_mempool_tx_nonce: null,
       possible_next_nonce: 3,
@@ -780,6 +784,7 @@ describe('address tests', () => {
     // Get nonce for account with no transactions
     const expectedNonceResultsNoTxs1 = {
       detected_missing_nonces: [],
+      detected_mempool_nonces: [],
       last_executed_tx_nonce: null,
       last_mempool_tx_nonce: null,
       possible_next_nonce: 0,
@@ -794,6 +799,7 @@ describe('address tests', () => {
     // Get nonce for account with no transactions
     const expectedNonceResultsNoTxs2 = {
       detected_missing_nonces: [],
+      detected_mempool_nonces: [],
       last_executed_tx_nonce: null,
       last_mempool_tx_nonce: null,
       possible_next_nonce: 0,
@@ -2123,6 +2129,7 @@ describe('address tests', () => {
     //sender nonce
     const expectedResp = {
       detected_missing_nonces: [],
+      detected_mempool_nonces: [],
       last_executed_tx_nonce: 0,
       last_mempool_tx_nonce: null,
       possible_next_nonce: 1,
@@ -2137,6 +2144,7 @@ describe('address tests', () => {
     //sponsor_nonce
     const expectedResp2 = {
       detected_missing_nonces: [],
+      detected_mempool_nonces: [],
       last_executed_tx_nonce: 2,
       last_mempool_tx_nonce: null,
       possible_next_nonce: 3,
@@ -2171,6 +2179,7 @@ describe('address tests', () => {
     //mempool sender nonce
     const expectedResp3 = {
       detected_missing_nonces: [],
+      detected_mempool_nonces: [],
       last_executed_tx_nonce: 0,
       last_mempool_tx_nonce: 1,
       possible_next_nonce: 2,
@@ -2185,6 +2194,7 @@ describe('address tests', () => {
     //mempool sponsor_nonce
     const expectedResp4 = {
       detected_missing_nonces: [],
+      detected_mempool_nonces: [],
       last_executed_tx_nonce: 2,
       last_mempool_tx_nonce: 3,
       possible_next_nonce: 4,
@@ -2222,6 +2232,7 @@ describe('address tests', () => {
 
     const expectedResp5 = {
       detected_missing_nonces: [5, 4],
+      detected_mempool_nonces: [3],
       last_executed_tx_nonce: 2,
       last_mempool_tx_nonce: 6,
       possible_next_nonce: 7,


### PR DESCRIPTION
This PR adds mempool nonces to the response of `extended/v1/address/:stx_address/nonces` endpoint.

Issue [1342](https://github.com/hirosystems/stacks-blockchain-api/issues/1342).