### PR TITLE
fix: generate synthetic `stx_unlock` rosetta operations for all locked accounts after pox2 force unlock

### DIFF
--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -4090,7 +4090,6 @@ export class PgStore {
             burnchain_unlock_height < ${current_burn_height})
         )
         ORDER BY stacker, block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
-        LIMIT 1
       `;
       for (const row of pox2EventQuery) {
         const pox2Event = parseDbPox2Event(row);


### PR DESCRIPTION
Fixes https://github.com/hirosystems/stacks-blockchain-api/issues/1639