### PR TITLE
fix: option to skip RPC request during init which may avoid startup deadlocks

### DIFF
--- a/.env
+++ b/.env
@@ -87,6 +87,9 @@ STACKS_CORE_RPC_PORT=20443
 ## configure the chainID/networkID; testnet: 0x80000000, mainnet: 0x00000001
 STACKS_CHAIN_ID=0x00000001
 
+# If enabled, the API will skip the startup validation request to the stacks-node /v2/info RPC endpoint
+# SKIP_STACKS_CHAIN_ID_CHECK=1
+
 # Seconds to allow API components to shut down gracefully before force-killing them, defaults to 60
 # STACKS_SHUTDOWN_FORCE_KILL_TIMEOUT=60
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,10 @@ async function monitorCoreRpcConnection(): Promise<void> {
       previouslyConnected = true;
     } catch (error) {
       previouslyConnected = false;
-      logger.error(`Warning: failed to connect to node RPC server at ${client.endpoint}`, error);
+      logger.warn(
+        `[Non-critical] notice: failed to connect to node RPC server at ${client.endpoint}`,
+        error
+      );
     }
     await timeout(CORE_RPC_HEARTBEAT_INTERVAL);
   }
@@ -139,16 +142,20 @@ async function init(): Promise<void> {
       forceKillable: false,
     });
 
-    const networkChainId = await getStacksNodeChainID();
-    if (networkChainId !== configuredChainID) {
-      const chainIdConfig = numberToHex(configuredChainID);
-      const chainIdNode = numberToHex(networkChainId);
-      const error = new Error(
-        `The configured STACKS_CHAIN_ID does not match, configured: ${chainIdConfig}, stacks-node: ${chainIdNode}`
-      );
-      logError(error.message, error);
-      throw error;
+    const skipChainIdCheck = parseArgBoolean(process.env['SKIP_STACKS_CHAIN_ID_CHECK']);
+    if (!skipChainIdCheck) {
+      const networkChainId = await getStacksNodeChainID();
+      if (networkChainId !== configuredChainID) {
+        const chainIdConfig = numberToHex(configuredChainID);
+        const chainIdNode = numberToHex(networkChainId);
+        const error = new Error(
+          `The configured STACKS_CHAIN_ID does not match, configured: ${chainIdConfig}, stacks-node: ${chainIdNode}`
+        );
+        logError(error.message, error);
+        throw error;
+      }
     }
+
     monitorCoreRpcConnection().catch(error => {
       logger.error(`Error monitoring RPC connection: ${error}`, error);
     });


### PR DESCRIPTION
May close https://github.com/hirosystems/stacks-blockchain-api/issues/1584

For context, see comment https://github.com/hirosystems/stacks-blockchain-api/issues/1584#issuecomment-1530010417