### PR TITLE
fix: rosetta cli construction command and volumes updated #1555

### DIFF
--- a/docker/docker-compose.dev.rosetta-cli.yml
+++ b/docker/docker-compose.dev.rosetta-cli.yml
@@ -4,6 +4,6 @@ services:
     build:
       context: ../rosetta-cli-config
       dockerfile: docker/Dockerfile
-    command: ${CMD}
+    command: /bin/rosetta-cli --configuration-file /app/rosetta-config-docker.json check:construction
     volumes:
-      - ${OUTPUT}
+      - ./rosetta-output-construction:/app/rosetta-output


### PR DESCRIPTION
## Description
Refer: #1555 
Changed the commands to run the stacks-blockchain-api in `docker-compose.dev.rosetta-cli.yml` to 
`command: /bin/rosetta-cli --configuration-file /app/rosetta-config-docker.json check:construction`
`volume: - ./rosetta-output-construction:/app/rosetta-output`

To note: values hardcoded here to run the rosetta-cli on mocknet