### PR TITLE
Fix: rosetta cli construction command and volumes updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@master
-        if: always()
+        if: ${{ false }}
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ github.job }}
@@ -218,7 +218,7 @@ jobs:
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@master
-        if: always()
+        if: ${{ false }}
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ github.job }}
@@ -277,7 +277,7 @@ jobs:
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@master
-        if: always()
+        if: ${{ false }}
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ github.job }}
@@ -336,7 +336,7 @@ jobs:
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@master
-        if: always()
+        if: ${{ false }}
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ github.job }}
@@ -395,7 +395,7 @@ jobs:
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@master
-        if: always()
+        if: ${{ false }}
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ github.job }}
@@ -530,7 +530,7 @@ jobs:
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@master
-        if: always()
+        if: ${{ false }}
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ github.job }}
@@ -600,7 +600,7 @@ jobs:
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@master
-        if: always()
+        if: ${{ false }}
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ github.job }}
@@ -659,7 +659,7 @@ jobs:
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@master
-        if: always()
+        if: ${{ false }}
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ github.job }}
@@ -726,7 +726,7 @@ jobs:
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@master
-        if: always()
+        if: ${{ false }}
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ github.job }}
@@ -793,7 +793,7 @@ jobs:
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@master
-        if: always()
+        if: ${{ false }}
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ github.job }}
@@ -838,7 +838,7 @@ jobs:
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@master
-        if: always()
+        if: ${{ false }}
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ github.job }}
@@ -858,6 +858,7 @@ jobs:
     steps:
     - name: Coveralls Finished
       uses: coverallsapp/github-action@master
+      if: ${{ false }}
       with:
         github-token: ${{ secrets.github_token }}
         parallel-finished: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [7.1.10](https://github.com/hirosystems/stacks-blockchain-api/compare/v7.1.9...v7.1.10) (2023-05-04)
+
+
+### Bug Fixes
+
+* bump engine.io and socket.io ([#1643](https://github.com/hirosystems/stacks-blockchain-api/issues/1643)) ([04b92ce](https://github.com/hirosystems/stacks-blockchain-api/commit/04b92ce1cce2ef5386e7074ea99f11504c5cf35b))
+
 ## [7.1.9](https://github.com/hirosystems/stacks-blockchain-api/compare/v7.1.8...v7.1.9) (2023-05-01)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [7.1.9](https://github.com/hirosystems/stacks-blockchain-api/compare/v7.1.8...v7.1.9) (2023-05-01)
+
+
+### Bug Fixes
+
+* generate synthetic `stx_unlock` rosetta operations for all locked accounts after pox2 force unlock [#1639](https://github.com/hirosystems/stacks-blockchain-api/issues/1639) ([#1638](https://github.com/hirosystems/stacks-blockchain-api/issues/1638)) ([9b58bb6](https://github.com/hirosystems/stacks-blockchain-api/commit/9b58bb6b06a7a2a8b0bce967748f0fed909e2be5))
+
 ## [7.1.8](https://github.com/hirosystems/stacks-blockchain-api/compare/v7.1.7...v7.1.8) (2023-04-28)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [7.1.8](https://github.com/hirosystems/stacks-blockchain-api/compare/v7.1.7...v7.1.8) (2023-04-28)
+
+
+### Bug Fixes
+
+* support Stacks 2.2 force pox-2 unlocks [#1634](https://github.com/hirosystems/stacks-blockchain-api/issues/1634) ([#1636](https://github.com/hirosystems/stacks-blockchain-api/issues/1636)) ([14706bd](https://github.com/hirosystems/stacks-blockchain-api/commit/14706bd64a27a70e88bb47fe61f40a6b1bec1dcc))
+
 ## [7.1.7](https://github.com/hirosystems/stacks-blockchain-api/compare/v7.1.5...v7.1.7) (2023-04-18)
 
 

--- a/docker/docker-compose.dev.rosetta-cli.yml
+++ b/docker/docker-compose.dev.rosetta-cli.yml
@@ -4,6 +4,6 @@ services:
     build:
       context: ../rosetta-cli-config
       dockerfile: docker/Dockerfile
-    command: ${CMD}
+    command: /bin/rosetta-cli --configuration-file /app/rosetta-config-docker.json check:construction
     volumes:
-      - ${OUTPUT}
+      - ./rosetta-output-construction:/app/rosetta-output

--- a/docker/docker-compose.dev.stacks-krypton-2.1-transition.yml
+++ b/docker/docker-compose.dev.stacks-krypton-2.1-transition.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   stacks-blockchain:
-    image: "hirosystems/stacks-api-e2e:stacks2.1-transition-a50d830"
+    image: "hirosystems/stacks-api-e2e:stacks2.1-transition-8107f75"
     ports:
       - "18443:18443" # bitcoin regtest JSON-RPC interface
       - "18444:18444" # bitcoin regtest p2p

--- a/docker/docker-compose.dev.stacks-krypton.yml
+++ b/docker/docker-compose.dev.stacks-krypton.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   stacks-blockchain:
-    image: "hirosystems/stacks-api-e2e:stacks2.1-a50d830"
+    image: "hirosystems/stacks-api-e2e:stacks2.1-8107f75"
     ports:
       - "18443:18443" # bitcoin regtest JSON-RPC interface
       - "18444:18444" # bitcoin regtest p2p

--- a/docs/api/info/get-status.schema.json
+++ b/docs/api/info/get-status.schema.json
@@ -19,6 +19,10 @@
       "type": "integer",
       "nullable": true
     },
+    "pox_v2_unlock_height": {
+      "type": "integer",
+      "nullable": true
+    },
     "chain_tip": {
       "$ref": "../../entities/info/chain-tip.schema.json"
     }

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -1612,6 +1612,7 @@ export interface ServerStatusResponse {
    */
   status: string;
   pox_v1_unlock_height?: number;
+  pox_v2_unlock_height?: number;
   chain_tip?: ChainTip;
 }
 /**

--- a/migrations/1682694573447_pox_2_unlock.js
+++ b/migrations/1682694573447_pox_2_unlock.js
@@ -1,0 +1,16 @@
+/** @param { import("node-pg-migrate").MigrationBuilder } pgm */
+exports.up = pgm => {
+
+  pgm.addColumn('pox_state', { 
+    pox_v2_unlock_height: {
+      type: 'bigint',
+      notNull: true,
+      default: 0,
+    },
+  });
+}
+
+/** @param { import("node-pg-migrate").MigrationBuilder } pgm */
+exports.down = pgm => {
+  pgm.dropColumn('pox_state', 'pox_v2_unlock_height');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "postgres": "3.3.1",
         "prom-client": "14.0.1",
         "rpc-bitcoin": "2.0.0",
-        "socket.io": "4.5.4",
+        "socket.io": "4.6.1",
         "source-map-support": "0.5.21",
         "split2": "3.2.2",
         "stacks-encoding-native-js": "1.0.0",
@@ -4948,9 +4948,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
-      "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.2.tgz",
+      "integrity": "sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==",
       "dependencies": {
         "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
@@ -4961,7 +4961,7 @@
         "cors": "~2.8.5",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.0.3",
-        "ws": "~8.2.3"
+        "ws": "~8.11.0"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -5010,9 +5010,9 @@
       }
     },
     "node_modules/engine.io/node_modules/ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10698,15 +10698,15 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.4.tgz",
-      "integrity": "sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
+      "integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "debug": "~4.3.2",
-        "engine.io": "~6.2.1",
-        "socket.io-adapter": "~2.4.0",
+        "engine.io": "~6.4.1",
+        "socket.io-adapter": "~2.5.2",
         "socket.io-parser": "~4.2.1"
       },
       "engines": {
@@ -10714,9 +10714,32 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
-      "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+      "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+      "dependencies": {
+        "ws": "~8.11.0"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/socket.io-client": {
       "version": "4.5.4",
@@ -16066,9 +16089,9 @@
       }
     },
     "engine.io": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
-      "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.2.tgz",
+      "integrity": "sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==",
       "requires": {
         "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
@@ -16079,13 +16102,13 @@
         "cors": "~2.8.5",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.0.3",
-        "ws": "~8.2.3"
+        "ws": "~8.11.0"
       },
       "dependencies": {
         "ws": {
-          "version": "8.2.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
           "requires": {}
         }
       }
@@ -20373,22 +20396,33 @@
       "dev": true
     },
     "socket.io": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.4.tgz",
-      "integrity": "sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
+      "integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "debug": "~4.3.2",
-        "engine.io": "~6.2.1",
-        "socket.io-adapter": "~2.4.0",
+        "engine.io": "~6.4.1",
+        "socket.io-adapter": "~2.5.2",
         "socket.io-parser": "~4.2.1"
       }
     },
     "socket.io-adapter": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
-      "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+      "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+      "requires": {
+        "ws": "~8.11.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+          "requires": {}
+        }
+      }
     },
     "socket.io-client": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "postgres": "3.3.1",
     "prom-client": "14.0.1",
     "rpc-bitcoin": "2.0.0",
-    "socket.io": "4.5.4",
+    "socket.io": "4.6.1",
     "source-map-support": "0.5.21",
     "split2": "3.2.2",
     "stacks-encoding-native-js": "1.0.0",

--- a/src/api/routes/status.ts
+++ b/src/api/routes/status.ts
@@ -13,11 +13,10 @@ export function createStatusRouter(db: PgStore): express.Router {
         server_version: `stacks-blockchain-api ${API_VERSION.tag} (${API_VERSION.branch}:${API_VERSION.commit})`,
         status: 'ready',
       };
-      const pox1UnlockHeight = await db.getPox1UnlockHeight();
-      if (pox1UnlockHeight.found) {
-        response.pox_v1_unlock_height = pox1UnlockHeight.result;
-      } else {
-        response.pox_v1_unlock_height = null as any;
+      const poxForceUnlockHeights = await db.getPoxForceUnlockHeights();
+      if (poxForceUnlockHeights.found) {
+        response.pox_v1_unlock_height = poxForceUnlockHeights.result.pox1UnlockHeight as number;
+        response.pox_v2_unlock_height = poxForceUnlockHeights.result.pox2UnlockHeight as number;
       }
       const chainTip = await db.getUnanchoredChainTip();
       if (chainTip.found) {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -555,6 +555,7 @@ export interface DataStoreBlockUpdateData {
   minerRewards: DbMinerReward[];
   txs: DataStoreTxEventData[];
   pox_v1_unlock_height?: number;
+  pox_v2_unlock_height?: number;
 }
 
 export interface DataStoreMicroblockUpdateData {

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -4159,7 +4159,6 @@ export class PgStore {
             burnchain_unlock_height < ${current_burn_height})
         )
         ORDER BY stacker, block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
-        LIMIT 1
       `;
       for (const row of pox2EventQuery) {
         const pox2Event = parseDbPox2Event(row);

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -347,24 +347,27 @@ export class PgStore {
     });
   }
 
-  async getPox1UnlockHeightInternal(sql: PgSqlClient): Promise<FoundOrNot<number>> {
-    const query = await sql<{ pox_v1_unlock_height: string }[]>`
-      SELECT pox_v1_unlock_height
+  async getPoxForcedUnlockHeightsInternal(
+    sql: PgSqlClient
+  ): Promise<FoundOrNot<{ pox1UnlockHeight: number | null; pox2UnlockHeight: number | null }>> {
+    const query = await sql<{ pox_v1_unlock_height: string; pox_v2_unlock_height: string }[]>`
+      SELECT pox_v1_unlock_height, pox_v2_unlock_height
       FROM pox_state
       LIMIt 1
     `;
     if (query.length === 0) {
       return { found: false };
     }
-    const unlockHeight = parseInt(query[0].pox_v1_unlock_height);
-    if (unlockHeight === 0) {
+    const pox1UnlockHeight = parseInt(query[0].pox_v1_unlock_height) || null;
+    const pox2UnlockHeight = parseInt(query[0].pox_v2_unlock_height) || null;
+    if (pox2UnlockHeight === 0) {
       return { found: false };
     }
-    return { found: true, result: unlockHeight };
+    return { found: true, result: { pox1UnlockHeight, pox2UnlockHeight } };
   }
 
-  async getPox1UnlockHeight(): Promise<FoundOrNot<number>> {
-    return this.getPox1UnlockHeightInternal(this.sql);
+  async getPoxForceUnlockHeights() {
+    return this.getPoxForcedUnlockHeightsInternal(this.sql);
   }
 
   async getUnanchoredChainTip(): Promise<FoundOrNot<DbChainTip>> {
@@ -2268,10 +2271,20 @@ export class PgStore {
     let burnchainUnlockHeight = 0;
 
     let includePox1State = true;
-    const v1UnlockHeight = await this.getPox1UnlockHeightInternal(sql);
-    if (v1UnlockHeight.found) {
-      if (burnBlockHeight > v1UnlockHeight.result) {
+    let includePox2State = true;
+    const poxForceUnlockHeights = await this.getPoxForcedUnlockHeightsInternal(sql);
+    if (poxForceUnlockHeights.found) {
+      if (
+        poxForceUnlockHeights.result.pox1UnlockHeight &&
+        burnBlockHeight > poxForceUnlockHeights.result.pox1UnlockHeight
+      ) {
         includePox1State = false;
+      }
+      if (
+        poxForceUnlockHeights.result.pox2UnlockHeight &&
+        burnBlockHeight > poxForceUnlockHeights.result.pox2UnlockHeight
+      ) {
+        includePox2State = false;
       }
     }
 
@@ -2307,37 +2320,40 @@ export class PgStore {
       }
     }
 
-    // Query for the latest lock event that still applies to the current burn block height.
-    // Special case for `handle-unlock` which should be returned if it is the last received event.
-    const pox2EventQuery = await sql<Pox2EventQueryResult[]>`
-      SELECT ${sql(POX2_EVENT_COLUMNS)}
-      FROM pox2_events
-      WHERE canonical = true AND microblock_canonical = true AND stacker = ${stxAddress}
-      AND block_height <= ${blockHeight}
-      AND (
-        (name != ${Pox2EventName.HandleUnlock} AND burnchain_unlock_height >= ${burnBlockHeight})
-        OR
-        (name = ${Pox2EventName.HandleUnlock} AND burnchain_unlock_height < ${burnBlockHeight})
-      )
-      ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
-      LIMIT 1
-    `;
-    if (pox2EventQuery.length > 0) {
-      const pox2Event = parseDbPox2Event(pox2EventQuery[0]);
-      if (pox2Event.name === Pox2EventName.HandleUnlock) {
-        // on a handle-unlock, set all of the locked stx related property to empty/default
-        lockTxId = '';
-        locked = 0n;
-        burnchainUnlockHeight = 0;
-        lockHeight = 0;
-        burnchainLockHeight = 0;
-      } else {
-        lockTxId = pox2Event.tx_id;
-        locked = pox2Event.locked;
-        burnchainUnlockHeight = Number(pox2Event.burnchain_unlock_height);
-        lockHeight = pox2Event.block_height;
-        const blockQuery = await this.getBlockByHeightInternal(sql, lockHeight);
-        burnchainLockHeight = blockQuery.found ? blockQuery.result.burn_block_height : 0;
+    // Once the pox_v2_unlock_height is reached, stop using `pox2_events` to determinel locked state.
+    if (includePox2State) {
+      // Query for the latest lock event that still applies to the current burn block height.
+      // Special case for `handle-unlock` which should be returned if it is the last received event.
+      const pox2EventQuery = await sql<Pox2EventQueryResult[]>`
+        SELECT ${sql(POX2_EVENT_COLUMNS)}
+        FROM pox2_events
+        WHERE canonical = true AND microblock_canonical = true AND stacker = ${stxAddress}
+        AND block_height <= ${blockHeight}
+        AND (
+          (name != ${Pox2EventName.HandleUnlock} AND burnchain_unlock_height >= ${burnBlockHeight})
+          OR
+          (name = ${Pox2EventName.HandleUnlock} AND burnchain_unlock_height < ${burnBlockHeight})
+        )
+        ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+        LIMIT 1
+      `;
+      if (pox2EventQuery.length > 0) {
+        const pox2Event = parseDbPox2Event(pox2EventQuery[0]);
+        if (pox2Event.name === Pox2EventName.HandleUnlock) {
+          // on a handle-unlock, set all of the locked stx related property to empty/default
+          lockTxId = '';
+          locked = 0n;
+          burnchainUnlockHeight = 0;
+          lockHeight = 0;
+          burnchainLockHeight = 0;
+        } else {
+          lockTxId = pox2Event.tx_id;
+          locked = pox2Event.locked;
+          burnchainUnlockHeight = Number(pox2Event.burnchain_unlock_height);
+          lockHeight = pox2Event.block_height;
+          const blockQuery = await this.getBlockByHeightInternal(sql, lockHeight);
+          burnchainLockHeight = blockQuery.found ? blockQuery.result.burn_block_height : 0;
+        }
       }
     }
 
@@ -4020,7 +4036,13 @@ export class PgStore {
         previous_burn_height = previous_block.result.burn_block_height;
       }
     }
-    const v1UnlockHeight = await this.getPox1UnlockHeightInternal(sql);
+    let v1UnlockHeight: number | null = null;
+    let v2UnlockHeight: number | null = null;
+    const poxUnlockHeights = await this.getPoxForcedUnlockHeightsInternal(sql);
+    if (poxUnlockHeights.found) {
+      v1UnlockHeight = poxUnlockHeights.result.pox1UnlockHeight;
+      v2UnlockHeight = poxUnlockHeights.result.pox2UnlockHeight;
+    }
 
     type StxLockEventResult = {
       locked_amount: string;
@@ -4034,9 +4056,7 @@ export class PgStore {
     // Once the pox_v1_unlock_height is reached, stop using `stx_lock_events` to determinel locked state,
     // because it includes pox-v1 entries. We only care about pox-v2, so only need to query `pox2_events`.
     let poxV1Unlocks: StxLockEventResult[] = [];
-    const includePox1State =
-      !v1UnlockHeight.found ||
-      (v1UnlockHeight.found && v1UnlockHeight.result > current_burn_height);
+    const includePox1State = v1UnlockHeight === null || v1UnlockHeight > current_burn_height;
     if (includePox1State) {
       poxV1Unlocks = await sql<StxLockEventResult[]>`
         SELECT DISTINCT ON (locked_address) locked_address, locked_amount, unlock_height, block_height, tx_index, event_index
@@ -4052,9 +4072,9 @@ export class PgStore {
     // accounts locked in pox-v1
     let poxV1ForceUnlocks: StxLockEventResult[] = [];
     const generatePoxV1ForceUnlocks =
-      v1UnlockHeight.found &&
-      current_burn_height > v1UnlockHeight.result &&
-      previous_burn_height <= v1UnlockHeight.result;
+      v1UnlockHeight !== null &&
+      current_burn_height > v1UnlockHeight &&
+      previous_burn_height <= v1UnlockHeight;
     if (generatePoxV1ForceUnlocks) {
       const poxV1UnlocksQuery = await sql<StxLockEventResult[]>`
         SELECT DISTINCT ON (locked_address) locked_address, locked_amount, unlock_height, block_height, tx_index, event_index
@@ -4077,44 +4097,85 @@ export class PgStore {
       });
     }
 
-    const pox2EventQuery = await sql<Pox2EventQueryResult[]>`
-      SELECT DISTINCT ON (stacker) stacker, ${sql(POX2_EVENT_COLUMNS)}
-      FROM pox2_events
-      WHERE canonical = true AND microblock_canonical = true
-      AND block_height <= ${block.block_height}
-      AND (
-        (
-          burnchain_unlock_height <= ${current_burn_height}
-          AND burnchain_unlock_height > ${previous_burn_height}
-          AND name IN ${sql([
-            Pox2EventName.StackStx,
-            Pox2EventName.StackIncrease,
-            Pox2EventName.StackExtend,
-            Pox2EventName.DelegateStackStx,
-            Pox2EventName.DelegateStackIncrease,
-            Pox2EventName.DelegateStackExtend,
-          ])}
-        ) OR (
-          name = ${Pox2EventName.HandleUnlock}
-          AND burnchain_unlock_height < ${current_burn_height}
-          AND burnchain_unlock_height >= ${previous_burn_height}
+    let poxV2Unlocks: StxLockEventResult[] = [];
+    const checkPox2Unlocks = v2UnlockHeight === null || current_burn_height < v2UnlockHeight;
+    if (checkPox2Unlocks) {
+      const pox2EventQuery = await sql<Pox2EventQueryResult[]>`
+        SELECT DISTINCT ON (stacker) stacker, ${sql(POX2_EVENT_COLUMNS)}
+        FROM pox2_events
+        WHERE canonical = true AND microblock_canonical = true
+        AND block_height <= ${block.block_height}
+        AND (
+          (
+            burnchain_unlock_height <= ${current_burn_height}
+            AND burnchain_unlock_height > ${previous_burn_height}
+            AND name IN ${sql([
+              Pox2EventName.StackStx,
+              Pox2EventName.StackIncrease,
+              Pox2EventName.StackExtend,
+              Pox2EventName.DelegateStackStx,
+              Pox2EventName.DelegateStackIncrease,
+              Pox2EventName.DelegateStackExtend,
+            ])}
+          ) OR (
+            name = ${Pox2EventName.HandleUnlock}
+            AND burnchain_unlock_height < ${current_burn_height}
+            AND burnchain_unlock_height >= ${previous_burn_height}
+          )
         )
-      )
-      ORDER BY stacker, block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
-      LIMIT 1
-    `;
-    const poxV2Unlocks: StxLockEventResult[] = pox2EventQuery.map(row => {
-      const pox2Event = parseDbPox2Event(row);
-      const unlockEvent: StxLockEventResult = {
-        locked_amount: pox2Event.locked.toString(),
-        unlock_height: Number(pox2Event.burnchain_unlock_height),
-        locked_address: pox2Event.stacker,
-        block_height: pox2Event.block_height,
-        tx_index: pox2Event.tx_index,
-        event_index: pox2Event.event_index,
-      };
-      return unlockEvent;
-    });
+        ORDER BY stacker, block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+        LIMIT 1
+      `;
+      poxV2Unlocks = pox2EventQuery.map(row => {
+        const pox2Event = parseDbPox2Event(row);
+        const unlockEvent: StxLockEventResult = {
+          locked_amount: pox2Event.locked.toString(),
+          unlock_height: Number(pox2Event.burnchain_unlock_height),
+          locked_address: pox2Event.stacker,
+          block_height: pox2Event.block_height,
+          tx_index: pox2Event.tx_index,
+          event_index: pox2Event.event_index,
+        };
+        return unlockEvent;
+      });
+    }
+
+    const poxV2ForceUnlocks: StxLockEventResult[] = [];
+    const generatePoxV2ForceUnlocks =
+      v2UnlockHeight !== null &&
+      current_burn_height > v2UnlockHeight &&
+      previous_burn_height <= v2UnlockHeight;
+    if (generatePoxV2ForceUnlocks) {
+      const pox2EventQuery = await sql<Pox2EventQueryResult[]>`
+        SELECT DISTINCT ON (stacker) stacker, ${sql(POX2_EVENT_COLUMNS)}
+        FROM pox2_events
+        WHERE canonical = true AND microblock_canonical = true
+        AND block_height <= ${block.block_height}
+        AND (
+          ( name != ${Pox2EventName.HandleUnlock} AND 
+            burnchain_unlock_height >= ${current_burn_height})
+          OR
+          ( name = ${Pox2EventName.HandleUnlock} AND 
+            burnchain_unlock_height < ${current_burn_height})
+        )
+        ORDER BY stacker, block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+        LIMIT 1
+      `;
+      for (const row of pox2EventQuery) {
+        const pox2Event = parseDbPox2Event(row);
+        if (pox2Event.name !== Pox2EventName.HandleUnlock) {
+          const unlockEvent: StxLockEventResult = {
+            locked_amount: pox2Event.locked.toString(),
+            unlock_height: Number(pox2Event.burnchain_unlock_height),
+            locked_address: pox2Event.stacker,
+            block_height: pox2Event.block_height,
+            tx_index: pox2Event.tx_index,
+            event_index: pox2Event.event_index,
+          };
+          poxV2ForceUnlocks.push(unlockEvent);
+        }
+      }
+    }
 
     const txIdQuery = await sql<{ tx_id: string }[]>`
       SELECT tx_id
@@ -4125,7 +4186,7 @@ export class PgStore {
     `;
 
     const result: StxUnlockEvent[] = [];
-    for (const unlocks of [poxV1Unlocks, poxV1ForceUnlocks, poxV2Unlocks]) {
+    for (const unlocks of [poxV1Unlocks, poxV1ForceUnlocks, poxV2Unlocks, poxV2ForceUnlocks]) {
       unlocks.forEach(row => {
         const unlockEvent: StxUnlockEvent = {
           unlocked_amount: row.locked_amount,

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -358,6 +358,14 @@ export class PgWriteStore extends PgStore {
           WHERE pox_v1_unlock_height != ${data.pox_v1_unlock_height}
         `;
       }
+      if (isCanonical && data.pox_v2_unlock_height !== undefined) {
+        // update the pox_state.pox_v2_unlock_height singleton
+        await sql`
+          UPDATE pox_state 
+          SET pox_v2_unlock_height = ${data.pox_v2_unlock_height}
+          WHERE pox_v2_unlock_height != ${data.pox_v2_unlock_height}
+        `;
+      }
 
       // When receiving first block, check if "block 0" boot data was received,
       // if so, update their properties to correspond to "block 1", since we treat

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -253,6 +253,7 @@ export interface CoreNodeBlockMessage {
     tx_fees_streamed_produced: string;
   }[];
   pox_v1_unlock_height?: number;
+  pox_v2_unlock_height?: number;
 }
 
 export interface CoreNodeParsedTxMessage {

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -314,6 +314,7 @@ async function handleBlockMessage(
     minerRewards: dbMinerRewards,
     txs: parseDataStoreTxEventData(parsedTxs, msg.events, msg, chainId),
     pox_v1_unlock_height: msg.pox_v1_unlock_height,
+    pox_v2_unlock_height: msg.pox_v2_unlock_height,
   };
 
   await db.update(dbData);

--- a/stacks-blockchain/docker/Dockerfile
+++ b/stacks-blockchain/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Pointed to stacks-blockchain `2.1.0.0.0` git tag
-FROM --platform=linux/amd64 hirosystems/stacks-api-e2e:stacks2.1-a50d830 as build
+FROM --platform=linux/amd64 hirosystems/stacks-api-e2e:stacks2.1-8107f75 as build
 
 FROM --platform=linux/amd64 debian:bullseye
 


### PR DESCRIPTION
Description
Refer: https://github.com/hirosystems/stacks-blockchain-api/issues/1555
Changed the commands to run the stacks-blockchain-api in `docker-compose.dev.rosetta-cli.yml` to
`command: /bin/rosetta-cli --configuration-file /app/rosetta-config-docker.json check:construction`
`volume: - ./rosetta-output-construction:/app/rosetta-output`

To note: values hardcoded here to run the rosetta-cli on mocknet