### PR TITLE
Enable requests logging

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -20,7 +20,6 @@ const loggingConfiguration = {
     }
     return 'info';
   },
-  autoLogging: false,
 };
 
 // ad-hoc logger


### PR DESCRIPTION
Auto logging configuration was set to `false`. Every received request need to be logged.