### PR TITLE
feat: support custom chain_id (e.g. for subnets)

### DIFF
--- a/.env
+++ b/.env
@@ -87,6 +87,12 @@ STACKS_CORE_RPC_PORT=20443
 ## configure the chainID/networkID; testnet: 0x80000000, mainnet: 0x00000001
 STACKS_CHAIN_ID=0x00000001
 
+# configure custom testnet and mainnet chainIDs for other networks such as subnets,
+# multiple values can be set using comma-separated key-value pairs.
+# TODO: currently configured with the default subnet testnet ID, the mainnet values
+# are placeholders that should be replaced with the actual subnet mainnet chainID
+CUSTOM_CHAIN_IDS=testnet=0x55005500,mainnet=12345678,mainnet=0xdeadbeaf
+
 # Seconds to allow API components to shut down gracefully before force-killing them, defaults to 60
 # STACKS_SHUTDOWN_FORCE_KILL_TIMEOUT=60
 

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -1,6 +1,5 @@
 import {
   abiFunctionToString,
-  ChainID,
   ClarityAbi,
   ClarityAbiFunction,
   getTypeString,
@@ -61,7 +60,7 @@ import {
   StxUnlockEvent,
   DbPox2Event,
 } from '../../datastore/common';
-import { unwrapOptional, FoundOrNot, unixEpochToIso, EMPTY_HASH_256 } from '../../helpers';
+import { unwrapOptional, FoundOrNot, unixEpochToIso, EMPTY_HASH_256, ChainID } from '../../helpers';
 import { serializePostCondition, serializePostConditionMode } from '../serializers/post-conditions';
 import { getOperations, parseTransactionMemo } from '../../rosetta-helpers';
 import { PgStore } from '../../datastore/pg-store';

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -19,16 +19,13 @@ import { createRosettaMempoolRouter } from './routes/rosetta/mempool';
 import { createRosettaBlockRouter } from './routes/rosetta/block';
 import { createRosettaAccountRouter } from './routes/rosetta/account';
 import { createRosettaConstructionRouter } from './routes/rosetta/construction';
-import { apiDocumentationUrl, isProdEnv, waiter } from '../helpers';
+import { ChainID, apiDocumentationUrl, getChainIDNetwork, isProdEnv, waiter } from '../helpers';
 import { InvalidRequestError } from '../errors';
 import { createBurnchainRouter } from './routes/burnchain';
 import { createBnsNamespacesRouter } from './routes/bns/namespaces';
 import { createBnsPriceRouter } from './routes/bns/pricing';
 import { createBnsNamesRouter } from './routes/bns/names';
 import { createBnsAddressesRouter } from './routes/bns/addresses';
-
-import { ChainID } from '@stacks/transactions';
-
 import * as pathToRegex from 'path-to-regexp';
 import * as expressListEndpoints from 'express-list-endpoints';
 import { createMiddleware as createPrometheusMiddleware } from '@promster/express';
@@ -214,7 +211,7 @@ export async function startApiServer(opts: {
       router.use('/fee_rate', createFeeRateRouter(datastore));
       router.use('/tokens', createTokenRouter(datastore));
       router.use('/pox2_events', createPox2EventsRouter(datastore));
-      if (chainId !== ChainID.Mainnet && writeDatastore) {
+      if (getChainIDNetwork(chainId) === 'testnet' && writeDatastore) {
         router.use('/faucets', createFaucetRouter(writeDatastore));
       }
       return router;

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -1,6 +1,6 @@
 import * as T from '@stacks/stacks-blockchain-api-types';
 import { RosettaErrorNoDetails } from '@stacks/stacks-blockchain-api-types';
-import { ChainID } from '@stacks/transactions';
+import { ChainID, getChainIDNetwork } from '../helpers';
 
 export const RosettaNetworks = {
   testnet: 'testnet',
@@ -20,9 +20,9 @@ export const RosettaConstants = {
 };
 
 export function getRosettaNetworkName(chainId: ChainID): string {
-  if (chainId === ChainID.Mainnet) {
+  if (getChainIDNetwork(chainId) === 'mainnet') {
     return RosettaNetworks.mainnet;
-  } else if (chainId === ChainID.Testnet) {
+  } else if (getChainIDNetwork(chainId) === 'testnet') {
     return RosettaNetworks.testnet;
   } else {
     throw new Error(`Cannot get rosetta network for unexpected chainID "${chainId}"`);

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -10,6 +10,7 @@ import {
   validatePrincipal,
 } from '../query-helpers';
 import {
+  ChainID,
   formatMapToObject,
   getSendManyContract,
   has0xPrefix,
@@ -39,7 +40,6 @@ import {
   AddressNonces,
   NftEvent,
 } from '@stacks/stacks-blockchain-api-types';
-import { ChainID } from '@stacks/transactions';
 import { decodeClarityValueToRepr } from 'stacks-encoding-native-js';
 import { validate } from '../validate';
 import { NextFunction, Request, Response } from 'express';

--- a/src/api/routes/bns/addresses.ts
+++ b/src/api/routes/bns/addresses.ts
@@ -2,7 +2,7 @@ import * as express from 'express';
 import { asyncHandler } from '../../async-handler';
 import { PgStore } from '../../../datastore/pg-store';
 import { isUnanchoredRequest } from '../../query-helpers';
-import { ChainID } from '@stacks/transactions';
+import { ChainID } from '../../../helpers';
 import {
   getETagCacheHandler,
   setETagCacheHeaders,

--- a/src/api/routes/bns/names.ts
+++ b/src/api/routes/bns/names.ts
@@ -5,7 +5,7 @@ import { parsePagingQueryInput } from '../../../api/pagination';
 import { isUnanchoredRequest } from '../../query-helpers';
 import { bnsBlockchain, BnsErrors } from '../../../event-stream/bns/bns-constants';
 import { BnsGetNameInfoResponse } from '@stacks/stacks-blockchain-api-types';
-import { ChainID } from '@stacks/transactions';
+import { ChainID } from '../../../helpers';
 import {
   getETagCacheHandler,
   setETagCacheHeaders,

--- a/src/api/routes/bns/pricing.ts
+++ b/src/api/routes/bns/pricing.ts
@@ -8,13 +8,12 @@ import {
   bufferCVFromString,
   callReadOnlyFunction,
   ClarityType,
-  ChainID,
 } from '@stacks/transactions';
 import {
   BnsGetNamePriceResponse,
   BnsGetNamespacePriceResponse,
 } from '@stacks/stacks-blockchain-api-types';
-import { isValidPrincipal } from './../../../helpers';
+import { ChainID, getChainIDNetwork, isValidPrincipal } from './../../../helpers';
 import { PgStore } from '../../../datastore/pg-store';
 import { getBnsContractID, GetStacksNetwork } from '../../../event-stream/bns/bns-helpers';
 import { logger } from '../../../logger';
@@ -34,7 +33,9 @@ export function createBnsPriceRouter(db: PgStore, chainId: ChainID): express.Rou
       const randomPrivKey = makeRandomPrivKey();
       const address = getAddressFromPrivateKey(
         randomPrivKey.data,
-        chainId === ChainID.Mainnet ? TransactionVersion.Mainnet : TransactionVersion.Testnet
+        getChainIDNetwork(chainId) === 'mainnet'
+          ? TransactionVersion.Mainnet
+          : TransactionVersion.Testnet
       );
       const bnsContractIdentifier = getBnsContractID(chainId);
       if (!bnsContractIdentifier || !isValidPrincipal(bnsContractIdentifier)) {
@@ -87,7 +88,9 @@ export function createBnsPriceRouter(db: PgStore, chainId: ChainID): express.Rou
       const randomPrivKey = makeRandomPrivKey();
       const address = getAddressFromPrivateKey(
         randomPrivKey.data,
-        chainId === ChainID.Mainnet ? TransactionVersion.Mainnet : TransactionVersion.Testnet
+        getChainIDNetwork(chainId) === 'mainnet'
+          ? TransactionVersion.Mainnet
+          : TransactionVersion.Testnet
       );
 
       const bnsContractIdentifier = getBnsContractID(chainId);

--- a/src/api/routes/debug.ts
+++ b/src/api/routes/debug.ts
@@ -34,7 +34,7 @@ import {
 import { StacksTestnet } from '@stacks/network';
 import { SampleContracts } from '../../sample-data/broadcast-contract-default';
 import { ClarityAbi, getTypeString, encodeClarityValue } from '../../event-stream/contract-abi';
-import { CHAIN_ID_TESTNET, cssEscape, unwrapOptional } from '../../helpers';
+import { NETWORK_CHAIN_ID, cssEscape, unwrapOptional } from '../../helpers';
 import { StacksCoreRpcClient, getCoreNodeEndpoint } from '../../core-rpc/client';
 import { PgStore } from '../../datastore/pg-store';
 import { DbTx } from '../../datastore/common';
@@ -579,7 +579,7 @@ export function createDebugRouter(db: PgStore): express.Router {
 
   const rosettaNetwork = {
     blockchain: RosettaConstants.blockchain,
-    network: getRosettaNetworkName(CHAIN_ID_TESTNET),
+    network: getRosettaNetworkName(NETWORK_CHAIN_ID.testnet),
   };
 
   async function stackWithRosetta(

--- a/src/api/routes/debug.ts
+++ b/src/api/routes/debug.ts
@@ -29,13 +29,12 @@ import {
   tupleCV,
   bufferCV,
   AnchorMode,
-  ChainID,
   deserializeTransaction,
 } from '@stacks/transactions';
 import { StacksTestnet } from '@stacks/network';
 import { SampleContracts } from '../../sample-data/broadcast-contract-default';
 import { ClarityAbi, getTypeString, encodeClarityValue } from '../../event-stream/contract-abi';
-import { cssEscape, unwrapOptional } from '../../helpers';
+import { CHAIN_ID_TESTNET, cssEscape, unwrapOptional } from '../../helpers';
 import { StacksCoreRpcClient, getCoreNodeEndpoint } from '../../core-rpc/client';
 import { PgStore } from '../../datastore/pg-store';
 import { DbTx } from '../../datastore/common';
@@ -580,7 +579,7 @@ export function createDebugRouter(db: PgStore): express.Router {
 
   const rosettaNetwork = {
     blockchain: RosettaConstants.blockchain,
-    network: getRosettaNetworkName(ChainID.Testnet),
+    network: getRosettaNetworkName(CHAIN_ID_TESTNET),
   };
 
   async function stackWithRosetta(

--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -2,7 +2,7 @@ import * as express from 'express';
 import { asyncHandler } from '../../async-handler';
 import { DbBlock } from '../../../datastore/common';
 import { PgStore } from '../../../datastore/pg-store';
-import { has0xPrefix, FoundOrNot } from '../../../helpers';
+import { has0xPrefix, FoundOrNot, ChainID } from '../../../helpers';
 import {
   RosettaAccount,
   RosettaBlockIdentifier,
@@ -13,7 +13,6 @@ import {
 } from '@stacks/stacks-blockchain-api-types';
 import { RosettaErrors, RosettaConstants, RosettaErrorsTypes } from '../../rosetta-constants';
 import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../rosetta-validate';
-import { ChainID } from '@stacks/transactions';
 import { getValidatedFtMetadata } from '../../../rosetta-helpers';
 import { isFtMetadataEnabled } from '../../../token-metadata/helpers';
 

--- a/src/api/routes/rosetta/block.ts
+++ b/src/api/routes/rosetta/block.ts
@@ -6,10 +6,9 @@ import {
   getRosettaTransactionFromDataStore,
   getRosettaBlockFromDataStore,
 } from '../../controllers/db-controller';
-import { has0xPrefix } from '../../../helpers';
+import { ChainID, has0xPrefix } from '../../../helpers';
 import { RosettaErrors, RosettaErrorsTypes } from '../../rosetta-constants';
 import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../rosetta-validate';
-import { ChainID } from '@stacks/transactions';
 
 export function createRosettaBlockRouter(db: PgStore, chainId: ChainID): express.Router {
   const router = express.Router();

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -27,7 +27,6 @@ import {
   AuthType,
   bufferCV,
   BytesReader,
-  ChainID,
   createMessageSignature,
   deserializeTransaction,
   emptyMessageSignature,
@@ -54,8 +53,10 @@ import { DbBlock } from '../../../datastore/common';
 import { PgStore } from '../../../datastore/pg-store';
 import {
   BigIntMath,
+  ChainID,
   doesThrow,
   FoundOrNot,
+  getChainIDNetwork,
   has0xPrefix,
   hexToBuffer,
   isValidC32Address,
@@ -91,7 +92,9 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
   const stackingOpts = { url: `http://${getCoreNodeEndpoint()}` };
   const stackingRpc = new StackingClient(
     '', // anonymous
-    chainId == ChainID.Mainnet ? new StacksMainnet(stackingOpts) : new StacksTestnet(stackingOpts)
+    getChainIDNetwork(chainId) == 'mainnet'
+      ? new StacksMainnet(stackingOpts)
+      : new StacksTestnet(stackingOpts)
   );
 
   //construction/derive endpoint

--- a/src/api/routes/rosetta/mempool.ts
+++ b/src/api/routes/rosetta/mempool.ts
@@ -1,7 +1,7 @@
 import * as express from 'express';
 import { asyncHandler } from '../../async-handler';
 import { PgStore } from '../../../datastore/pg-store';
-import { has0xPrefix } from '../../../helpers';
+import { ChainID, has0xPrefix } from '../../../helpers';
 import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../rosetta-validate';
 import {
   RosettaMempoolResponse,
@@ -10,7 +10,6 @@ import {
 } from '@stacks/stacks-blockchain-api-types';
 import { getOperations, parseTransactionMemo } from '../../../rosetta-helpers';
 import { RosettaErrors, RosettaErrorsTypes } from '../../rosetta-constants';
-import { ChainID } from '@stacks/transactions';
 
 export function createRosettaMempoolRouter(db: PgStore, chainId: ChainID): express.Router {
   const router = express.Router();

--- a/src/api/routes/rosetta/network.ts
+++ b/src/api/routes/rosetta/network.ts
@@ -20,7 +20,7 @@ import {
   RosettaSyncStatus,
 } from '@stacks/stacks-blockchain-api-types';
 import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../rosetta-validate';
-import { ChainID } from '@stacks/transactions';
+import { ChainID } from '../../../helpers';
 import { PgStore } from '../../../datastore/pg-store';
 
 export function createRosettaNetworkRouter(db: PgStore, chainId: ChainID): express.Router {

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -3,7 +3,7 @@ import {
   AddressUnlockSchedule,
   TransactionType,
 } from '@stacks/stacks-blockchain-api-types';
-import { ChainID, ClarityAbi } from '@stacks/transactions';
+import { ClarityAbi } from '@stacks/transactions';
 import { getTxTypeId, getTxTypeString } from '../api/controllers/db-controller';
 import {
   assertNotNullish,
@@ -13,6 +13,7 @@ import {
   bnsNameCV,
   getBnsSmartContractId,
   bnsNameFromSubdomain,
+  ChainID,
 } from '../helpers';
 import { PgStoreEventEmitter } from './pg-store-event-emitter';
 import {

--- a/src/event-stream/bns/bns-helpers.ts
+++ b/src/event-stream/bns/bns-helpers.ts
@@ -1,5 +1,5 @@
-import { BufferCV, ChainID, ClarityType, hexToCV, StringAsciiCV } from '@stacks/transactions';
-import { bnsNameCV, hexToBuffer, hexToUtf8String } from '../../helpers';
+import { BufferCV, ClarityType, hexToCV, StringAsciiCV } from '@stacks/transactions';
+import { bnsNameCV, ChainID, getChainIDNetwork, hexToBuffer, hexToUtf8String } from '../../helpers';
 import {
   CoreNodeEvent,
   CoreNodeEventType,
@@ -181,7 +181,9 @@ export function parseNamespaceRawValue(
 export function GetStacksNetwork(chainId: ChainID) {
   const url = `http://${getCoreNodeEndpoint()}`;
   const network =
-    chainId === ChainID.Mainnet ? new StacksMainnet({ url }) : new StacksTestnet({ url });
+    getChainIDNetwork(chainId) === 'mainnet'
+      ? new StacksMainnet({ url })
+      : new StacksTestnet({ url });
   return network;
 }
 
@@ -238,7 +240,9 @@ export function parseZoneFileTxt(txtEntries: string | string[]) {
 
 export function getBnsContractID(chainId: ChainID) {
   const contractId =
-    chainId === ChainID.Mainnet ? BnsContractIdentifier.mainnet : BnsContractIdentifier.testnet;
+    getChainIDNetwork(chainId) === 'mainnet'
+      ? BnsContractIdentifier.mainnet
+      : BnsContractIdentifier.testnet;
   return contractId;
 }
 

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -5,7 +5,7 @@ import * as express from 'express';
 import * as bodyParser from 'body-parser';
 import { asyncHandler } from '../api/async-handler';
 import PQueue from 'p-queue';
-import { getIbdBlockHeight, hexToBuffer } from '../helpers';
+import { ChainID, getChainIDNetwork, getIbdBlockHeight, hexToBuffer } from '../helpers';
 import {
   CoreNodeBlockMessage,
   CoreNodeEventType,
@@ -52,7 +52,6 @@ import {
   ClarityValueTuple,
   TxPayloadTypeID,
 } from 'stacks-encoding-native-js';
-import { ChainID } from '@stacks/transactions';
 import { BnsContractIdentifier } from './bns/bns-constants';
 import {
   parseNameFromContractEvent,
@@ -426,7 +425,7 @@ function parseDataStoreTxEventData(
           (event.contract_event.contract_identifier === Pox2ContractIdentifer.mainnet ||
             event.contract_event.contract_identifier === Pox2ContractIdentifer.testnet)
         ) {
-          const network = chainId === ChainID.Mainnet ? 'mainnet' : 'testnet';
+          const network = getChainIDNetwork(chainId) === 'mainnet' ? 'mainnet' : 'testnet';
           const poxEventData = decodePox2PrintEvent(event.contract_event.raw_value, network);
           if (poxEventData !== null) {
             logger.debug(`Pox2 event data:`, poxEventData);

--- a/src/event-stream/reader.ts
+++ b/src/event-stream/reader.ts
@@ -46,10 +46,11 @@ import {
   bufferToHexPrefixString,
   hexToBuffer,
   SubnetContractIdentifer,
+  getChainIDNetwork,
+  ChainID,
 } from '../helpers';
 import {
   TransactionVersion,
-  ChainID,
   uintCV,
   tupleCV,
   bufferCV,
@@ -133,7 +134,10 @@ function createSubnetTransactionFromL1RegisterAsset(
 
   const tx: DecodedTxResult = {
     tx_id: txId,
-    version: chainId === ChainID.Mainnet ? TransactionVersion.Mainnet : TransactionVersion.Testnet,
+    version:
+      getChainIDNetwork(chainId) === 'mainnet'
+        ? TransactionVersion.Mainnet
+        : TransactionVersion.Testnet,
     chain_id: chainId,
     auth: {
       type_id: PostConditionAuthFlag.Standard,
@@ -192,7 +196,10 @@ function createSubnetTransactionFromL1NftDeposit(
 
   const tx: DecodedTxResult = {
     tx_id: txId,
-    version: chainId === ChainID.Mainnet ? TransactionVersion.Mainnet : TransactionVersion.Testnet,
+    version:
+      getChainIDNetwork(chainId) === 'mainnet'
+        ? TransactionVersion.Mainnet
+        : TransactionVersion.Testnet,
     chain_id: chainId,
     auth: {
       type_id: PostConditionAuthFlag.Standard,
@@ -251,7 +258,10 @@ function createSubnetTransactionFromL1FtDeposit(
 
   const tx: DecodedTxResult = {
     tx_id: txId,
-    version: chainId === ChainID.Mainnet ? TransactionVersion.Mainnet : TransactionVersion.Testnet,
+    version:
+      getChainIDNetwork(chainId) === 'mainnet'
+        ? TransactionVersion.Mainnet
+        : TransactionVersion.Testnet,
     chain_id: chainId,
     auth: {
       type_id: PostConditionAuthFlag.Standard,
@@ -293,12 +303,17 @@ function createSubnetTransactionFromL1StxDeposit(
 ): DecodedTxResult {
   const recipientAddress = decodeStacksAddress(event.stx_mint_event.recipient);
   const bootAddressString =
-    chainId === ChainID.Mainnet ? 'SP000000000000000000002Q6VF78' : 'ST000000000000000000002AMW42H';
+    getChainIDNetwork(chainId) === 'mainnet'
+      ? 'SP000000000000000000002Q6VF78'
+      : 'ST000000000000000000002AMW42H';
   const bootAddress = decodeStacksAddress(bootAddressString);
 
   const tx: DecodedTxResult = {
     tx_id: txId,
-    version: chainId === ChainID.Mainnet ? TransactionVersion.Mainnet : TransactionVersion.Testnet,
+    version:
+      getChainIDNetwork(chainId) === 'mainnet'
+        ? TransactionVersion.Mainnet
+        : TransactionVersion.Testnet,
     chain_id: chainId,
     auth: {
       type_id: PostConditionAuthFlag.Standard,
@@ -360,11 +375,13 @@ function createTransactionFromCoreBtcStxLockEvent(
   const unlockBurnHeight = Number(resultTuple.data['unlock-burn-height'].value);
 
   // Number of cycles: floor((unlock-burn-height - burn-height) / reward-cycle-length)
-  const rewardCycleLength = chainId === ChainID.Mainnet ? 2100 : 50;
+  const rewardCycleLength = getChainIDNetwork(chainId) === 'mainnet' ? 2100 : 50;
   const lockPeriod = Math.floor((unlockBurnHeight - burnBlockHeight) / rewardCycleLength);
   const senderAddress = decodeStacksAddress(event.stx_lock_event.locked_address);
   const poxAddressString =
-    chainId === ChainID.Mainnet ? 'SP000000000000000000002Q6VF78' : 'ST000000000000000000002AMW42H';
+    getChainIDNetwork(chainId) === 'mainnet'
+      ? 'SP000000000000000000002Q6VF78'
+      : 'ST000000000000000000002AMW42H';
   const poxAddress = decodeStacksAddress(poxAddressString);
 
   const contractName = event.stx_lock_event.contract_identifier?.split('.')?.[1] ?? 'pox';
@@ -390,7 +407,10 @@ function createTransactionFromCoreBtcStxLockEvent(
 
   const tx: DecodedTxResult = {
     tx_id: txId,
-    version: chainId === ChainID.Mainnet ? TransactionVersion.Mainnet : TransactionVersion.Testnet,
+    version:
+      getChainIDNetwork(chainId) === 'mainnet'
+        ? TransactionVersion.Mainnet
+        : TransactionVersion.Testnet,
     chain_id: chainId,
     auth: {
       type_id: PostConditionAuthFlag.Standard,
@@ -453,7 +473,9 @@ function createTransactionFromCoreBtcDelegateStxEvent(
 
   const senderAddress = decodeStacksAddress(decodedEvent.stacker);
   const poxContractAddressString =
-    chainId === ChainID.Mainnet ? 'SP000000000000000000002Q6VF78' : 'ST000000000000000000002AMW42H';
+    getChainIDNetwork(chainId) === 'mainnet'
+      ? 'SP000000000000000000002Q6VF78'
+      : 'ST000000000000000000002AMW42H';
   const poxContractAddress = decodeStacksAddress(poxContractAddressString);
   const contractName = contractEvent.contract_event.contract_identifier?.split('.')?.[1] ?? 'pox';
 
@@ -483,7 +505,10 @@ function createTransactionFromCoreBtcDelegateStxEvent(
 
   const tx: DecodedTxResult = {
     tx_id: txId,
-    version: chainId === ChainID.Mainnet ? TransactionVersion.Mainnet : TransactionVersion.Testnet,
+    version:
+      getChainIDNetwork(chainId) === 'mainnet'
+        ? TransactionVersion.Mainnet
+        : TransactionVersion.Testnet,
     chain_id: chainId,
     auth: {
       type_id: PostConditionAuthFlag.Standard,
@@ -527,7 +552,10 @@ function createTransactionFromCoreBtcTxEvent(
   const senderAddress = decodeStacksAddress(event.stx_transfer_event.sender);
   const tx: DecodedTxResult = {
     tx_id: txId,
-    version: chainId === ChainID.Mainnet ? TransactionVersion.Mainnet : TransactionVersion.Testnet,
+    version:
+      getChainIDNetwork(chainId) === 'mainnet'
+        ? TransactionVersion.Mainnet
+        : TransactionVersion.Testnet,
     chain_id: chainId,
     auth: {
       type_id: PostConditionAuthFlag.Standard,
@@ -647,7 +675,7 @@ export function parseMessageTransaction(
               e.contract_event.contract_identifier === Pox2ContractIdentifer.testnet)
         )
         .map(e => {
-          const network = chainId === ChainID.Mainnet ? 'mainnet' : 'testnet';
+          const network = getChainIDNetwork(chainId);
           const decodedEvent = decodePox2PrintEvent(e.contract_event.raw_value, network);
           if (decodedEvent) {
             return {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -959,8 +959,10 @@ export function parseDataUrl(
  */
 export type ChainID = number;
 
-export const CHAIN_ID_MAINNET = 0x00000001;
-export const CHAIN_ID_TESTNET = 0x80000000;
+export const enum NETWORK_CHAIN_ID {
+  mainnet = 0x00000001,
+  testnet = 0x80000000,
+}
 
 /**
  * Checks if the given chain_id is a mainnet or testnet chain id.
@@ -968,9 +970,9 @@ export const CHAIN_ID_TESTNET = 0x80000000;
  * the `CUSTOM_CHAIN_IDS` env var for any configured custom chain ids (used for subnets).
  */
 export function getChainIDNetwork(chainID: ChainID): 'mainnet' | 'testnet' {
-  if (chainID === CHAIN_ID_MAINNET) {
+  if (chainID === NETWORK_CHAIN_ID.mainnet) {
     return 'mainnet';
-  } else if (chainID === CHAIN_ID_TESTNET) {
+  } else if (chainID === NETWORK_CHAIN_ID.testnet) {
     return 'testnet';
   }
   const chainIDHex = numberToHex(chainID);
@@ -1009,8 +1011,8 @@ export function chainIdConfigurationCheck() {
   } catch (error) {
     logger.error(error);
     const chainIdHex = numberToHex(chainID);
-    const mainnetHex = numberToHex(CHAIN_ID_MAINNET);
-    const testnetHex = numberToHex(CHAIN_ID_TESTNET);
+    const mainnetHex = numberToHex(NETWORK_CHAIN_ID.mainnet);
+    const testnetHex = numberToHex(NETWORK_CHAIN_ID.testnet);
     logger.error(
       `Oops! The configuration for STACKS_CHAIN_ID=${chainIdHex} does not match mainnet=${mainnetHex}, testnet=${testnetHex}, or custom chain IDs: CUSTOM_CHAIN_IDS=${process.env.CUSTOM_CHAIN_IDS}`
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   parseArgBoolean,
   getApiConfiguredChainID,
   getStacksNodeChainID,
+  chainIdConfigurationCheck,
 } from './helpers';
 import * as sourceMapSupport from 'source-map-support';
 import { startApiServer } from './api/init';
@@ -109,6 +110,7 @@ async function init(): Promise<void> {
         '`/extended/v1/status` endpoint. Please execute `npm run build` to regenerate it.'
     );
   }
+  chainIdConfigurationCheck();
   const apiMode = getApiMode();
   let dbStore: PgStore;
   let dbWriteStore: PgWriteStore;

--- a/src/token-metadata/tokens-contract-handler.ts
+++ b/src/token-metadata/tokens-contract-handler.ts
@@ -1,7 +1,6 @@
 import * as child_process from 'child_process';
 import { DbFungibleTokenMetadata, DbNonFungibleTokenMetadata } from '../datastore/common';
 import {
-  ChainID,
   ClarityAbi,
   ClarityType,
   ClarityValue,
@@ -12,7 +11,7 @@ import {
   uintCV,
   UIntCV,
 } from '@stacks/transactions';
-import { parseDataUrl, REPO_DIR, stopwatch } from '../helpers';
+import { ChainID, getChainIDNetwork, parseDataUrl, REPO_DIR, stopwatch } from '../helpers';
 import * as querystring from 'querystring';
 import {
   getTokenMetadataFetchTimeoutMs,
@@ -115,7 +114,9 @@ export class TokensContractHandler {
 
     this.address = getAddressFromPrivateKey(
       this.randomPrivKey.data,
-      this.chainId === ChainID.Mainnet ? TransactionVersion.Mainnet : TransactionVersion.Testnet
+      getChainIDNetwork(this.chainId) === 'mainnet'
+        ? TransactionVersion.Mainnet
+        : TransactionVersion.Testnet
     );
     if (isCompliantFt(args.smartContractAbi)) {
       this.tokenKind = 'ft';

--- a/src/token-metadata/tokens-processor-queue.ts
+++ b/src/token-metadata/tokens-processor-queue.ts
@@ -1,8 +1,8 @@
-import { FoundOrNot } from '../helpers';
+import { ChainID, FoundOrNot } from '../helpers';
 import { Evt } from 'evt';
 import PQueue from 'p-queue';
 import { DbTokenMetadataQueueEntry, TokenMetadataUpdateInfo } from '../datastore/common';
-import { ChainID, ClarityAbi } from '@stacks/transactions';
+import { ClarityAbi } from '@stacks/transactions';
 import { TokensContractHandler } from './tokens-contract-handler';
 import { PgWriteStore } from '../datastore/pg-write-store';
 import { logger } from '../logger';


### PR DESCRIPTION
Adds a new environment variable that can be used to specify the network (mainnet or testnet) for a given chain_id.

For example, the current subnet testnet chain_id is `0x55005500`. This can be configured with the env var:
```env
CUSTOM_CHAIN_IDS=testnet=0x55005500
```

Multiple values can be configured using comma-separated key-value pairs:
```env
# configure custom testnet and mainnet chainIDs for other networks such as subnets,
# multiple values can be set using comma-separated key-value pairs.
# TODO: currently configured with the default subnet testnet ID, the mainnet values
# are placeholders that should be replaced with the actual subnet mainnet chainID
CUSTOM_CHAIN_IDS=testnet=0x55005500,mainnet=12345678,mainnet=0xdeadbeaf
```


## Implementation

With the introduction of subnets, there is no longer a 1-to-1 mapping between chain_id and network name. For example, it's no longer `chain_id(0x00000001) === mainnet, chain_id(0x80000000) === testnet`. Any given chain_id can now be either testnet or mainnet. So the const enum mapping between chain_id<->network has been removed, and replaced with a function that determines which network a given chain_id corresponds to. 

Because chain_ids for subnets can be configured dynamically / per-deployment, we do not have an known list of mappings. So a new env var has been added which allows deployments to specify chain_id<->network mappings.