### PR TITLE
ci: add repository dispatch yaml

### DIFF
--- a/.env.apitest
+++ b/.env.apitest
@@ -1,0 +1,1 @@
+DOMAIN_API=https://stacks-node-api.testnet.stacks.co

--- a/repository_dispatch.yaml
+++ b/repository_dispatch.yaml
@@ -1,0 +1,42 @@
+name: Send Repository Dispatch Event to ApiTest Repo
+
+on:
+  push:
+    branches:
+      - master
+env:
+  DOMAIN_API: https://stacks-node-api.testnet.stacks.co #this will be updated with the test api URL
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository A
+        uses: actions/checkout@v2
+
+      - run: touch .env.apitest
+      - run: |
+          echo "" >> .env.apitest
+          echo "DOMAIN_API=$DOMAIN_API" >> .env.apitest
+      - run: cat .env.apitest
+      - name: convert .env to JSON
+        id: convert-json
+        uses: ricosandyca/convert-env-json@main
+        with:
+          type: env-to-json
+          input_path: .env.apitest
+          output_path: .env.apitest.json
+      - name: Read JSON file
+        id: read-json
+        run: |
+          echo "payload=$(echo $(cat .env.apitest.json))" >> $GITHUB_OUTPUT
+      - name: Echo JSON file
+        id: echo-json
+        run: printf ${{ steps.read-json.outputs.payload }}
+      - name: Send repository dispatch event
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.PAT_SECRET }} #to be updated with a Personal Access Token and secret
+          repository: hirosystems/apiTest
+          event-type: data-transfer
+          client-payload: ${{ steps.read-json.outputs.payload }}


### PR DESCRIPTION
add repository dispatch yaml and env.apitest


## Description

This PR works with the following PRs in the hirosystems/apiTest repo https://github.com/hirosystems/apiTest/pull/12 https://github.com/hirosystems/apiTest/pull/11 . The `repository_dispatch.yaml `file and the `.env.apitest` file work with repository dispatch type data transfer to write to send the env variable data over to the apiTest repo that contains the api test URL. This is currently setup to run whenever there is a change to the master branch. In line 39 of the yaml file we reference `(token: ${{ secrets.PAT_SECRET }})` we need to create a Personal Access Token and save it as a secret name PAT_SECRET in this repo for this to work.

1. Motivation for change: To allow the apiTest repo test to run on changes to the stacks-blockchain-api repo and also use the test api URL that is created on the fly.
2. The test in the ApiTest repo where updated to un the env variable that is saved in env.apitest and yaml files in bothe repos were updated to run on changes to the Stacks-blockchain-api repo
3. How does this impact application developers: there should be no impact
4. Link to relevant issues and documentation https://github.com/hirosystems/stacks-blockchain-api/issues/1670
5. Provide examples of use cases with code samples and applicable acceptance criteria

The files are using logic from the following repos
https://github.com/hirosystems/ricosandyca/convert-env-json
https://github.com/hirosystems/peter-evans/repository-dispatch



## Type of Change
- [X] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
no breaking changes