### PR TITLE
fix: allow more than one Rosetta `stx_unlock` operation per block

### DIFF
--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -4228,7 +4228,6 @@ export class PgStore {
           )
         )
         ORDER BY stacker, block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
-        LIMIT 1
       `;
       poxV2Unlocks = pox2EventQuery.map(row => {
         const pox2Event = parseDbPox2Event(row);
@@ -4306,7 +4305,6 @@ export class PgStore {
           )
         )
         ORDER BY stacker, block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
-        LIMIT 1
       `;
     poxV3Unlocks = pox3EventQuery.map(row => {
       const pox3Event = parseDbPox2Event(row) as DbPox3Event;


### PR DESCRIPTION
Only a single `stx_unlock` Rosetta operation is being returned per block, even when multiple unlocks occur in a block. 

Here are two examples that should include a `stx_unlock` operation for address `SPVEW3RAESA4A4TG5R81A5D06MBMGV3EP0KABEXK`, but do not and only contain a single `stx_unlock` for another address:

```shell
# Get the unlock associated with https://explorer.hiro.so/txid/0x2d8ad4db2d114d89f0e105908bb6af77016cc9c2582921651e70f40dc327de60?chain=mainnet
curl -X POST https://api.mainnet.hiro.so/rosetta/v1/block -H 'Content-Type: application/json' -d '{"network_identifier":{"blockchain":"stacks","network":"mainnet"},"block_identifier":{"index": 110979}}'
```

```shell
# Get the unlock associated with https://explorer.hiro.so/txid/0x41621da710b4c7554983dc06b38e28b61f333676c5c1fb385d291f63f0051619?chain=mainnet
curl -X POST https://api.mainnet.hiro.so/rosetta/v1/block -H 'Content-Type: application/json' -d '{"network_identifier":{"blockchain":"stacks","network":"mainnet"},"block_identifier":{"index": 120101}}'
```