### PR TITLE
Fix: FAQs NOT FAQ’s

### DIFF
--- a/content/faqs.md
+++ b/content/faqs.md
@@ -1,8 +1,8 @@
 ---
-Title: FAQ's
+Title: FAQs
 ---
 
-# FAQ's
+# FAQs
 
 #### **I am attempting to receive the status from a local Stacks Blockchain node API and present to a user how close it is to being synced. I can retrieve the current height of the local node (`/v2/info`). Is there any way for me to retrieve the real current height from an API node that is not completely synced? I want to avoid going directly to the centrally-hosted node.**
 


### PR DESCRIPTION

1. Motivation for change doc-a-thon, cleaning docs
2. What was changed Grammar 

