### PR TITLE
fix: move nft custody view into a table

### DIFF
--- a/migrations/1696872367486_nft-custody-tables.js
+++ b/migrations/1696872367486_nft-custody-tables.js
@@ -1,0 +1,187 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = pgm => {
+  pgm.dropIndex('nft_custody', ['recipient', 'asset_identifier']);
+  pgm.dropIndex('nft_custody', 'value');
+  pgm.renameMaterializedView('nft_custody', 'nft_custody_old');
+  pgm.createTable('nft_custody', {
+    asset_identifier: {
+      type: 'string',
+      notNull: true,
+    },
+    value: {
+      type: 'bytea',
+      notNull: true,
+    },
+    recipient: {
+      type: 'text',
+    },
+    block_height: {
+      type: 'integer',
+      notNull: true,
+    },
+    index_block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
+    parent_index_block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
+    microblock_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
+    microblock_sequence: {
+      type: 'integer',
+      notNull: true,
+    },
+    tx_id: {
+      type: 'bytea',
+      notNull: true,
+    },
+    tx_index: {
+      type: 'smallint',
+      notNull: true,
+    },
+    event_index: {
+      type: 'integer',
+      notNull: true,
+    },
+  });
+  pgm.createConstraint('nft_custody', 'nft_custody_unique', 'UNIQUE(asset_identifier, value)');
+  pgm.createIndex('nft_custody', ['recipient', 'asset_identifier']);
+  pgm.createIndex('nft_custody', 'value');
+  pgm.createIndex('nft_custody', [
+    { name: 'block_height', sort: 'DESC' },
+    { name: 'microblock_sequence', sort: 'DESC' },
+    { name: 'tx_index', sort: 'DESC' },
+    { name: 'event_index', sort: 'DESC' }
+  ]);
+  pgm.sql(`
+    INSERT INTO nft_custody (asset_identifier, value, recipient, tx_id, block_height) (
+      SELECT asset_identifier, value, recipient, tx_id, block_height
+      FROM nft_custody_old
+    )
+  `);
+  pgm.dropMaterializedView('nft_custody_old');
+
+  pgm.dropIndex('nft_custody_unanchored', ['recipient', 'asset_identifier']);
+  pgm.dropIndex('nft_custody_unanchored', 'value');
+  pgm.renameMaterializedView('nft_custody_unanchored', 'nft_custody_unanchored_old');
+  pgm.createTable('nft_custody_unanchored', {
+    asset_identifier: {
+      type: 'string',
+      notNull: true,
+    },
+    value: {
+      type: 'bytea',
+      notNull: true,
+    },
+    recipient: {
+      type: 'text',
+    },
+    block_height: {
+      type: 'integer',
+      notNull: true,
+    },
+    index_block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
+    parent_index_block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
+    microblock_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
+    microblock_sequence: {
+      type: 'integer',
+      notNull: true,
+    },
+    tx_id: {
+      type: 'bytea',
+      notNull: true,
+    },
+    tx_index: {
+      type: 'smallint',
+      notNull: true,
+    },
+    event_index: {
+      type: 'integer',
+      notNull: true,
+    },
+  });
+  pgm.createConstraint('nft_custody_unanchored', 'nft_custody_unanchored_unique', 'UNIQUE(asset_identifier, value)');
+  pgm.createIndex('nft_custody_unanchored', ['recipient', 'asset_identifier']);
+  pgm.createIndex('nft_custody_unanchored', 'value');
+  pgm.createIndex('nft_custody_unanchored', [
+    { name: 'block_height', sort: 'DESC' },
+    { name: 'microblock_sequence', sort: 'DESC' },
+    { name: 'tx_index', sort: 'DESC' },
+    { name: 'event_index', sort: 'DESC' }
+  ]);
+  pgm.sql(`
+    INSERT INTO nft_custody_unanchored (asset_identifier, value, recipient, tx_id, block_height) (
+      SELECT asset_identifier, value, recipient, tx_id, block_height
+      FROM nft_custody_unanchored_old
+    )
+  `);
+  pgm.dropMaterializedView('nft_custody_unanchored_old');
+};
+
+exports.down = pgm => {
+  pgm.dropTable('nft_custody');
+  pgm.createMaterializedView('nft_custody', { data: true }, `
+    SELECT
+      DISTINCT ON(asset_identifier, value) asset_identifier, value, recipient, tx_id, nft.block_height
+    FROM
+      nft_events AS nft
+    INNER JOIN
+      txs USING (tx_id)
+    WHERE
+      txs.canonical = true
+      AND txs.microblock_canonical = true
+      AND nft.canonical = true
+      AND nft.microblock_canonical = true
+    ORDER BY
+      asset_identifier,
+      value,
+      txs.block_height DESC,
+      txs.microblock_sequence DESC,
+      txs.tx_index DESC,
+      nft.event_index DESC
+  `);
+  pgm.createIndex('nft_custody', ['recipient', 'asset_identifier']);
+  pgm.createIndex('nft_custody', ['asset_identifier', 'value'], { unique: true });
+  pgm.createIndex('nft_custody', 'value');
+
+  pgm.dropTable('nft_custody_unanchored');
+  pgm.createMaterializedView('nft_custody_unanchored', { data: true }, `
+    SELECT
+      DISTINCT ON(asset_identifier, value) asset_identifier, value, recipient, tx_id, nft.block_height
+    FROM
+      nft_events AS nft
+    INNER JOIN
+      txs USING (tx_id)
+    WHERE
+      txs.canonical = true
+      AND txs.microblock_canonical = true
+      AND nft.canonical = true
+      AND nft.microblock_canonical = true
+    ORDER BY
+      asset_identifier,
+      value,
+      txs.block_height DESC,
+      txs.microblock_sequence DESC,
+      txs.tx_index DESC,
+      nft.event_index DESC
+  `);
+  pgm.createIndex('nft_custody_unanchored', ['recipient', 'asset_identifier']);
+  pgm.createIndex('nft_custody_unanchored', ['asset_identifier', 'value'], { unique: true });
+  pgm.createIndex('nft_custody_unanchored', 'value');
+};

--- a/migrations/1696872367486_nft-custody-tables.js
+++ b/migrations/1696872367486_nft-custody-tables.js
@@ -3,9 +3,7 @@
 exports.shorthands = undefined;
 
 exports.up = pgm => {
-  pgm.dropIndex('nft_custody', ['recipient', 'asset_identifier']);
-  pgm.dropIndex('nft_custody', 'value');
-  pgm.renameMaterializedView('nft_custody', 'nft_custody_old');
+  pgm.dropMaterializedView('nft_custody');
   pgm.createTable('nft_custody', {
     asset_identifier: {
       type: 'string',
@@ -83,11 +81,8 @@ exports.up = pgm => {
         nft.event_index DESC
     )
   `);
-  pgm.dropMaterializedView('nft_custody_old');
 
-  pgm.dropIndex('nft_custody_unanchored', ['recipient', 'asset_identifier']);
-  pgm.dropIndex('nft_custody_unanchored', 'value');
-  pgm.renameMaterializedView('nft_custody_unanchored', 'nft_custody_unanchored_old');
+  pgm.dropMaterializedView('nft_custody_unanchored');
   pgm.createTable('nft_custody_unanchored', {
     asset_identifier: {
       type: 'string',
@@ -165,7 +160,6 @@ exports.up = pgm => {
         nft.event_index DESC
     )
   `);
-  pgm.dropMaterializedView('nft_custody_unanchored_old');
 };
 
 exports.down = pgm => {

--- a/migrations/1696872367486_nft-custody-tables.js
+++ b/migrations/1696872367486_nft-custody-tables.js
@@ -61,9 +61,26 @@ exports.up = pgm => {
     { name: 'event_index', sort: 'DESC' }
   ]);
   pgm.sql(`
-    INSERT INTO nft_custody (asset_identifier, value, recipient, tx_id, block_height) (
-      SELECT asset_identifier, value, recipient, tx_id, block_height
-      FROM nft_custody_old
+    INSERT INTO nft_custody (asset_identifier, value, recipient, tx_id, block_height, index_block_hash, parent_index_block_hash, microblock_hash, microblock_sequence, tx_index, event_index) (
+      SELECT
+        DISTINCT ON(asset_identifier, value) asset_identifier, value, recipient, tx_id, nft.block_height, 
+        nft.index_block_hash, nft.parent_index_block_hash, nft.microblock_hash, nft.microblock_sequence, nft.tx_index, nft.event_index
+      FROM
+        nft_events AS nft
+      INNER JOIN
+        txs USING (tx_id)
+      WHERE
+        txs.canonical = true
+        AND txs.microblock_canonical = true
+        AND nft.canonical = true
+        AND nft.microblock_canonical = true
+      ORDER BY
+        asset_identifier,
+        value,
+        txs.block_height DESC,
+        txs.microblock_sequence DESC,
+        txs.tx_index DESC,
+        nft.event_index DESC
     )
   `);
   pgm.dropMaterializedView('nft_custody_old');
@@ -126,9 +143,26 @@ exports.up = pgm => {
     { name: 'event_index', sort: 'DESC' }
   ]);
   pgm.sql(`
-    INSERT INTO nft_custody_unanchored (asset_identifier, value, recipient, tx_id, block_height) (
-      SELECT asset_identifier, value, recipient, tx_id, block_height
-      FROM nft_custody_unanchored_old
+    INSERT INTO nft_custody_unanchored (asset_identifier, value, recipient, tx_id, block_height, index_block_hash, parent_index_block_hash, microblock_hash, microblock_sequence, tx_index, event_index) (
+      SELECT
+        DISTINCT ON(asset_identifier, value) asset_identifier, value, recipient, tx_id, nft.block_height,
+        nft.index_block_hash, nft.parent_index_block_hash, nft.microblock_hash, nft.microblock_sequence, nft.tx_index, nft.event_index
+      FROM
+        nft_events AS nft
+      INNER JOIN
+        txs USING (tx_id)
+      WHERE
+        txs.canonical = true
+        AND txs.microblock_canonical = true
+        AND nft.canonical = true
+        AND nft.microblock_canonical = true
+      ORDER BY
+        asset_identifier,
+        value,
+        txs.block_height DESC,
+        txs.microblock_sequence DESC,
+        txs.tx_index DESC,
+        nft.event_index DESC
     )
   `);
   pgm.dropMaterializedView('nft_custody_unanchored_old');

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -1357,6 +1357,20 @@ export interface NftEventInsertValues {
   value: PgBytea;
 }
 
+export interface NftCustodyInsertValues {
+  event_index: number;
+  tx_id: PgBytea;
+  tx_index: number;
+  block_height: number;
+  index_block_hash: PgBytea;
+  parent_index_block_hash: PgBytea;
+  microblock_hash: PgBytea;
+  microblock_sequence: number;
+  recipient: string | null;
+  asset_identifier: string;
+  value: PgBytea;
+}
+
 export interface FtEventInsertValues {
   event_index: number;
   tx_id: PgBytea;

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -3318,6 +3318,7 @@ export class PgStore {
         FROM ${nftCustody} AS nft
         WHERE nft.recipient = ${args.principal}
         ${assetIdFilter}
+        ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
         LIMIT ${args.limit}
         OFFSET ${args.offset}
       )

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -3520,11 +3520,11 @@ export class PgStore {
         AND block_height <= ${args.blockHeight}
         ORDER BY asset_identifier, value, block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
       )
-      SELECT sender, recipient, asset_identifier, value, event_index, asset_event_type_id, address_transfers.block_height, address_transfers.tx_id, (COUNT(*) OVER())::INTEGER AS count
-      FROM address_transfers
+      SELECT sender, recipient, asset_identifier, value, at.event_index, asset_event_type_id, at.block_height, at.tx_id, (COUNT(*) OVER())::INTEGER AS count
+      FROM address_transfers AS at
       INNER JOIN ${args.includeUnanchored ? this.sql`last_nft_transfers` : this.sql`nft_custody`}
         USING (asset_identifier, value, recipient)
-      ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+      ORDER BY at.block_height DESC, at.microblock_sequence DESC, at.tx_index DESC, event_index DESC
       LIMIT ${args.limit} OFFSET ${args.offset}
     `;
 

--- a/src/tests/search-tests.ts
+++ b/src/tests/search-tests.ts
@@ -820,7 +820,7 @@ describe('search tests', () => {
       recipient: addr7,
       sender: 'none',
     };
-    await db.updateNftEvent(client, stxTx1, nftEvent1);
+    await db.updateNftEvent(client, stxTx1, nftEvent1, false);
 
     // test address as a nft event recipient
     const searchResult7 = await supertest(api.server).get(`/extended/v1/search/${addr7}`);
@@ -848,7 +848,7 @@ describe('search tests', () => {
       recipient: 'none',
       sender: addr8,
     };
-    await db.updateNftEvent(client, stxTx1, nftEvent2);
+    await db.updateNftEvent(client, stxTx1, nftEvent2, false);
 
     // test address as a nft event sender
     const searchResult8 = await supertest(api.server).get(`/extended/v1/search/${addr8}`);

--- a/src/tests/token-tests.ts
+++ b/src/tests/token-tests.ts
@@ -3,7 +3,6 @@ import { ChainID } from '@stacks/transactions';
 import { ApiServer, startApiServer } from '../api/init';
 import { TestBlockBuilder, TestMicroblockStreamBuilder } from '../test-utils/test-builders';
 import { DbAssetEventTypeId } from '../datastore/common';
-import { hexToBuffer } from '../helpers';
 import { PgWriteStore } from '../datastore/pg-write-store';
 import { cycleMigrations, runMigrations } from '../datastore/migrations';
 


### PR DESCRIPTION
This PR transforms the `nft_custody` and `nft_custody_unanchored` materialized views into tables that are written to with each new block/microblock. This migration increases block ingestion performance considerably.