### PR TITLE
build: switch to bullseye image, pull duckdb binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,14 @@
-FROM node:18-alpine
+FROM node:18-bullseye
 
 WORKDIR /app
 COPY . .
+COPY --from=qldrsc/duckdb /usr/local/bin/duckdb /bin/duckdb
 
-RUN apk add --no-cache --virtual .build-deps alpine-sdk python3 git openjdk8-jre cmake
+RUN apt-get update && \
+    apt-get install -y git openjdk-11-jre && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 RUN echo "GIT_TAG=$(git tag --points-at HEAD)" >> .env
 RUN npm ci && npm run build && npm run build:docs && npm prune --production
-RUN apk del .build-deps
-
-# As no pre-built binaries of duckdb can be found for Alpine (musl based),
-# a rebuild of duckdb package is need.
-#
-# Library used by the event-replay based on parquet files.
-ARG DUCKDB_VERSION=0.8.1
-WORKDIR /duckdb
-RUN apk add --no-cache --virtual .duckdb-build-deps python3 git g++ make
-RUN git clone https://github.com/duckdb/duckdb.git -b v${DUCKDB_VERSION} --depth 1 \
-  && cd duckdb/tools/nodejs \
-  && ./configure && make all
-WORKDIR /app
-RUN npm uninstall duckdb && npm install /duckdb/duckdb/tools/nodejs
-RUN apk del .duckdb-build-deps
 
 CMD ["node", "./lib/index.js"]


### PR DESCRIPTION
Switches to bullseye based Docker image so we can pull duckdb from another Docker image to make builds much faster.