### PR TITLE
Disable stx faucet POST body

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -105,21 +105,6 @@ paths:
       tags:
         - Faucets
       operationId: run_faucet_stx
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                address:
-                  description: STX testnet address
-                  type: string
-                stacking:
-                  description: Use required number of tokens for stacking
-                  type: boolean
-              example:
-                address: ST3M7N9Q9HDRM7RVP1Q26P0EE69358PZZAZD7KMXQ
-                stacking: false
       responses:
         200:
           description: Success

--- a/src/tests-2.4/faucet-stx.ts
+++ b/src/tests-2.4/faucet-stx.ts
@@ -30,6 +30,17 @@ describe('STX Faucet', () => {
     expect(reqTx.success).toBe(true);
   });
 
+  test('STX faucet http request post body', async () => {
+    const response = await supertest(testEnv.api.server)
+      .post(`/extended/v1/faucets/stx`)
+      .send({ address: reqAccount.stxAddr });
+    expect(response.status).toBe(200);
+    reqTx = response.body;
+    expect(typeof reqTx.txId).toBe('string');
+    expect(typeof reqTx.txRaw).toBe('string');
+    expect(reqTx.success).toBe(true);
+  });
+
   test('STX faucet tx mined successfully', async () => {
     const tx = await standByForTxSuccess(reqTx.txId!);
     expect(tx.token_transfer_recipient_address).toBe(reqAccount.stxAddr);

--- a/src/tests-2.4/faucet-stx.ts
+++ b/src/tests-2.4/faucet-stx.ts
@@ -33,12 +33,13 @@ describe('STX Faucet', () => {
   test('STX faucet http request post body', async () => {
     const response = await supertest(testEnv.api.server)
       .post(`/extended/v1/faucets/stx`)
-      .send({ address: reqAccount.stxAddr });
-    expect(response.status).toBe(200);
-    reqTx = response.body;
-    expect(typeof reqTx.txId).toBe('string');
-    expect(typeof reqTx.txRaw).toBe('string');
-    expect(reqTx.success).toBe(true);
+      .send({ address: reqAccount.stxAddr, stacking: true });
+    expect(response.status).toBe(400);
+    const reqTx: any = response.body;
+    expect(reqTx.success).toBe(false);
+    expect(reqTx.error).toContain('POST body is no longer supported');
+    // check for helpful error message
+    expect(reqTx.error).toContain(`address=${reqAccount.stxAddr}`);
   });
 
   test('STX faucet tx mined successfully', async () => {


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/1756

Disable the option to specify faucet parameters via POST body. It now returns an http 400 with a helpful error message. Example:
```shell
$ curl -X POST "http://127.0.0.1:3999/extended/v1/faucets/stx" \                                                              
     -H "Content-Type: application/json" \
     -d '{"address": "ST12KYHMD4GJZJHAPM4VC0VZTB4FEWTQSY74YHEYN", "stacking": true}'

{
  "error": "POST body is no longer supported, parameters must be passed as query parameters, e.g. http://127.0.0.1:3999/extended/v1/faucets/stx?address=ST12KYHMD4GJZJHAPM4VC0VZTB4FEWTQSY74YHEYN&stacking=true",
  "help": "Example curl request: curl -X POST 'http://127.0.0.1:3999/extended/v1/faucets/stx?address=ST12KYHMD4GJZJHAPM4VC0VZTB4FEWTQSY74YHEYN&stacking=true'",
  "success": false
}
```

Using url query parameters continues to work as expected:
```shell
$ curl -X POST 'http://127.0.0.1:3999/extended/v1/faucets/stx?address=ST12KYHMD4GJZJHAPM4VC0VZTB4FEWTQSY74YHEYN&stacking=true'
{
  "success": true,
  "txId": "0x7ebf6932f0f7e9f9f29c2076798e7c4ac7a163f82215fe2bd6a08d8b01058350",
  "txRaw": "80800000000400164247d6f2b425ac5771423ae6c80c754f7172b0000000000000000000000000000000b40001ef33d2b1622a50b796f5848a402cf9a7d3c60ff723c22a2c0a17b641d9fa61b676fa53aefb47254f5dc93c60ae2e8a2bc1363f520dbae04bb5a086cf68e910c603020000000000051a453f468d2425f94556a136c06ffa591eee6af9f10007fe8f3d59100046617563657400000000000000000000000000000000000000000000000000000000"
}
```