### PR TITLE
fix: do not load duckdb binary unless required

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,6 @@ import { PgStore } from './datastore/pg-store';
 import { PgWriteStore } from './datastore/pg-write-store';
 import { registerMempoolPromStats } from './datastore/helpers';
 import { logger } from './logger';
-import { ReplayController } from './event-replay/parquet-based/replay-controller';
 import {
   isProdEnv,
   numberToHex,
@@ -284,6 +283,7 @@ async function handleProgramArgs() {
       args.options.force
     );
   } else if (args.operand === 'from-parquet-events') {
+    const { ReplayController } = await import('./event-replay/parquet-based/replay-controller');
     const replay = await ReplayController.init();
     await replay.prepare();
     await replay.do();


### PR DESCRIPTION
Fixes an error when starting the API (without event-replay) where duckdb has not been installed. The dependency is now lazy loaded on demand.

```
Error: /stacks-api/node_modules/duckdb/lib/binding/duckdb.node: cannot open shared object file: No such file or directory
```