### PR TITLE
Docs/trigger docs refresh

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -59,6 +59,10 @@ jobs:
         id: deploy
         run: vercel ${{ github.ref_name == 'master' && '--prod' || 'deploy' }} --prebuilt --token=${{ secrets.VERCEL_TOKEN }} | awk '{print "deployment_url="$1}' >> $GITHUB_OUTPUT
 
+      - name: Trigger docs.hiro.so deployment
+        if: github.ref_name == 'master'
+        run: curl -X POST ${{ secrets.VERCEL_DOCS_DEPLOY_HOOK_URL }}
+
       - name: Add comment with Vercel deployment URL
         if: ${{ github.event_name == 'pull_request' }}
         uses: thollander/actions-comment-pull-request@v2


### PR DESCRIPTION
Closes https://github.com/hirosystems/ordinals-api/issues/103

Related: https://github.com/hirosystems/ordinals-api/pull/285
A deploy hook in Vercel will be contacted whenever there's an update to the `master` branch in this repo, which should automate changes to the docs site as docs changes are made here.