### PR TITLE
fix: handle `Problematic` status in `/drop_mempool_tx` event

### DIFF
--- a/docs/entities/mempool-transactions/transaction-status.schema.json
+++ b/docs/entities/mempool-transactions/transaction-status.schema.json
@@ -2,5 +2,5 @@
   "title": "MempoolTransactionStatus",
   "description": "Status of the transaction",
   "type": "string",
-  "enum": ["pending", "dropped_replace_by_fee", "dropped_replace_across_fork", "dropped_too_expensive", "dropped_stale_garbage_collect"]
+  "enum": ["pending", "dropped_replace_by_fee", "dropped_replace_across_fork", "dropped_too_expensive", "dropped_stale_garbage_collect", "dropped_problematic"]
 }

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -569,7 +569,8 @@ export type MempoolTransactionStatus =
   | "dropped_replace_by_fee"
   | "dropped_replace_across_fork"
   | "dropped_too_expensive"
-  | "dropped_stale_garbage_collect";
+  | "dropped_stale_garbage_collect"
+  | "dropped_problematic";
 /**
  * Describes representation of a Type-1 Stacks 2.0 transaction. https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-005-blocks-and-transactions.md#type-1-instantiating-a-smart-contract
  */

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -161,6 +161,8 @@ function getTxStatusString(txStatus: DbTxStatus): TransactionStatus | MempoolTra
       return 'dropped_replace_across_fork';
     case DbTxStatus.DroppedTooExpensive:
       return 'dropped_too_expensive';
+    case DbTxStatus.DroppedProblematic:
+      return 'dropped_problematic';
     case DbTxStatus.DroppedStaleGarbageCollect:
     case DbTxStatus.DroppedApiGarbageCollect:
       return 'dropped_stale_garbage_collect';

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -117,6 +117,8 @@ export enum DbTxStatus {
   DroppedStaleGarbageCollect = -13,
   /** Dropped by the API (even though the Stacks node hadn't dropped it) because it exceeded maximum mempool age */
   DroppedApiGarbageCollect = -14,
+  /** Transaction is problematic (e.g. a DDoS vector) and should be dropped. */
+  DroppedProblematic = -15,
 }
 
 export enum DbTxAnchorMode {

--- a/src/datastore/helpers.ts
+++ b/src/datastore/helpers.ts
@@ -990,6 +990,8 @@ export function getTxDbStatus(
       return DbTxStatus.DroppedTooExpensive;
     case 'StaleGarbageCollect':
       return DbTxStatus.DroppedStaleGarbageCollect;
+    case 'Problematic':
+      return DbTxStatus.DroppedProblematic;
     default:
       throw new Error(`Unexpected tx status: ${txCoreStatus}`);
   }

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -1247,6 +1247,7 @@ export class PgStore extends BasePgStore {
         DbTxStatus.DroppedTooExpensive,
         DbTxStatus.DroppedStaleGarbageCollect,
         DbTxStatus.DroppedApiGarbageCollect,
+        DbTxStatus.DroppedProblematic,
       ];
       const resultQuery = await sql<(MempoolTxQueryResult & { count: number })[]>`
         SELECT ${unsafeCols(sql, [

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -301,7 +301,8 @@ export type CoreNodeDropMempoolTxReasonType =
   | 'ReplaceByFee'
   | 'ReplaceAcrossFork'
   | 'TooExpensive'
-  | 'StaleGarbageCollect';
+  | 'StaleGarbageCollect'
+  | 'Problematic';
 
 export interface CoreNodeDropMempoolTxMessage {
   dropped_txids: string[];


### PR DESCRIPTION
Handle dropped mempool txs with the new `Problematic` status implemented in https://github.com/stacks-network/stacks-core/pull/3212/files#diff-dd79d18b9e96a0ab54185412b55f3153aa45b2c71812ac33e6d1a07c94d4d9b7