### PR TITLE
fix(docs): URL query arrays should be formatted with `form` rather than comma-separated

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -212,6 +212,8 @@ paths:
           required: false
           schema:
             type: array
+            style: form
+            explode: true
             example: coinbase
             items:
               type: string
@@ -382,6 +384,8 @@ paths:
         required: true
         schema:
           type: array
+          style: form
+          explode: true
           example: "0x0a411719e3bfde95f9e227a2d7f8fac3d6c646b1e6cc186db0e2838a2c6cd9c0"
           items:
             type: string
@@ -3055,6 +3059,8 @@ paths:
           required: false
           schema:
             type: array
+            style: form
+            explode: true
             example: "SPQZF23W7SEYBFG5JQ496NMY0G7379SRYEDREMSV.Candy::candy"
             items:
               type: string
@@ -3481,6 +3487,8 @@ paths:
           required: false
           schema:
             type: array
+            style: form
+            explode: true
             example: stx_lock
             items:
               type: string

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -386,7 +386,11 @@ paths:
           type: array
           style: form
           explode: true
-          example: "0x0a411719e3bfde95f9e227a2d7f8fac3d6c646b1e6cc186db0e2838a2c6cd9c0"
+          example: [
+            "0x0a411719e3bfde95f9e227a2d7f8fac3d6c646b1e6cc186db0e2838a2c6cd9c0",
+            "0xfbe6412b46e9db87df991a0d043ff47eb58019f770208cf48e2380337cc31785",
+            "0x178b77678a758d9f29a147d6399315c83d0f1baf114431fbe4d3587aa5fbba6f"
+          ]
           items:
             type: string
       - name: event_offset

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -210,10 +210,10 @@ paths:
           in: query
           description: Filter by transaction type
           required: false
+          style: form
+          explode: true
           schema:
             type: array
-            style: form
-            explode: true
             example: coinbase
             items:
               type: string
@@ -382,10 +382,10 @@ paths:
         in: query
         description: Array of transaction ids
         required: true
+        style: form
+        explode: true
         schema:
           type: array
-          style: form
-          explode: true
           example: [
             "0x0a411719e3bfde95f9e227a2d7f8fac3d6c646b1e6cc186db0e2838a2c6cd9c0",
             "0xfbe6412b46e9db87df991a0d043ff47eb58019f770208cf48e2380337cc31785",
@@ -3061,10 +3061,10 @@ paths:
           in: query
           description: identifiers of the token asset classes to filter for
           required: false
+          style: form
+          explode: true
           schema:
             type: array
-            style: form
-            explode: true
             example: "SPQZF23W7SEYBFG5JQ496NMY0G7379SRYEDREMSV.Candy::candy"
             items:
               type: string
@@ -3489,10 +3489,10 @@ paths:
           in: query
           description: Filter the events on event type
           required: false
+          style: form
+          explode: true
           schema:
             type: array
-            style: form
-            explode: true
             example: stx_lock
             items:
               type: string


### PR DESCRIPTION
Addresses issue https://github.com/hirosystems/stacks-blockchain-api/issues/1806

Some OpenAPI tooling default to comma-separated strings for arrays in URL query params. In particular, the `docusaurus` generator used in Hiro docs.

This specifies the default behavior used by Express which is multiple parameters with the same name. E.g.

Before:
   `?tx_id=1111,2222`
After:
   `?tx_id=1111&tx_id=2222`