### PR TITLE
fix: support comma-separated strings in array query params

### DIFF
--- a/src/api/query-helpers.ts
+++ b/src/api/query-helpers.ts
@@ -319,7 +319,11 @@ export function parseEventTypeFilter(
     }
   } else if (typeof typeQuery === 'string') {
     try {
-      eventTypeFilter = parseEventTypeStrings([typeQuery]);
+      if (typeQuery.includes(',')) {
+        eventTypeFilter = parseEventTypeStrings(typeQuery.split(','));
+      } else {
+        eventTypeFilter = parseEventTypeStrings([typeQuery]);
+      }
     } catch (error) {
       handleBadRequest(res, next, `invalid 'event type'`);
     }

--- a/src/api/routes/tokens.ts
+++ b/src/api/routes/tokens.ts
@@ -32,8 +32,17 @@ export function createTokenRouter(db: PgStore): express.Router {
         return;
       }
       let assetIdentifiers: string[] | undefined;
-      if (req.query.asset_identifiers !== undefined) {
-        for (const assetIdentifier of [req.query.asset_identifiers].flat()) {
+      if (req.query.asset_identifiers) {
+        if (typeof req.query.asset_identifiers === 'string') {
+          if (req.query.asset_identifiers.includes(',')) {
+            assetIdentifiers = req.query.asset_identifiers.split(',');
+          } else {
+            assetIdentifiers = [req.query.asset_identifiers];
+          }
+        } else {
+          assetIdentifiers = req.query.asset_identifiers as string[];
+        }
+        for (const assetIdentifier of assetIdentifiers) {
           if (
             typeof assetIdentifier !== 'string' ||
             !isValidPrincipal(assetIdentifier.split('::')[0])

--- a/src/api/routes/tokens.ts
+++ b/src/api/routes/tokens.ts
@@ -32,7 +32,7 @@ export function createTokenRouter(db: PgStore): express.Router {
         return;
       }
       let assetIdentifiers: string[] | undefined;
-      if (req.query.asset_identifiers) {
+      if (req.query.asset_identifiers !== undefined) {
         if (typeof req.query.asset_identifiers === 'string') {
           if (req.query.asset_identifiers.includes(',')) {
             assetIdentifiers = req.query.asset_identifiers.split(',');
@@ -49,11 +49,6 @@ export function createTokenRouter(db: PgStore): express.Router {
           ) {
             res.status(400).json({ error: `Invalid asset identifier ${assetIdentifier}` });
             return;
-          } else {
-            if (!assetIdentifiers) {
-              assetIdentifiers = [];
-            }
-            assetIdentifiers?.push(assetIdentifier);
           }
         }
       }

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -52,7 +52,11 @@ export function createTxRouter(db: PgStore): express.Router {
       if (Array.isArray(typeQuery)) {
         txTypeFilter = parseTxTypeStrings(typeQuery as string[]);
       } else if (typeof typeQuery === 'string') {
-        txTypeFilter = parseTxTypeStrings([typeQuery]);
+        if (typeQuery.includes(',')) {
+          txTypeFilter = parseTxTypeStrings(typeQuery.split(','));
+        } else {
+          txTypeFilter = parseTxTypeStrings([typeQuery]);
+        }
       } else if (typeQuery) {
         throw new Error(`Unexpected tx type query value: ${JSON.stringify(typeQuery)}`);
       } else {
@@ -82,8 +86,13 @@ export function createTxRouter(db: PgStore): express.Router {
     '/multiple',
     asyncHandler(async (req, res, next) => {
       if (typeof req.query.tx_id === 'string') {
-        // in case req.query.tx_id is a single tx_id string and not an array
-        req.query.tx_id = [req.query.tx_id];
+        // check if tx_id is a comma-seperated list of tx_ids
+        if (req.query.tx_id.includes(',')) {
+          req.query.tx_id = req.query.tx_id.split(',');
+        } else {
+          // in case req.query.tx_id is a single tx_id string and not an array
+          req.query.tx_id = [req.query.tx_id];
+        }
       }
       const txList: string[] = req.query.tx_id as string[];
 

--- a/src/tests/tx-tests.ts
+++ b/src/tests/tx-tests.ts
@@ -299,6 +299,13 @@ describe('tx tests', () => {
     expect(jsonRes[dbTx3.tx_id].result.tx_id).toEqual(dbTx3.tx_id);
     expect(jsonRes[dbTx3.tx_id].result.tx_type).toEqual('smart_contract');
     expect(jsonRes[dbTx3.tx_id].result.smart_contract.clarity_version).toEqual(2);
+
+    // test comma-separated tx_id list
+    const txIds = [mempoolTx.tx_id, tx1.tx_id, notFoundTxId, dbTx2.tx_id, dbTx3.tx_id].join(',');
+    const txsListDetail2 = await supertest(api.server).get(
+      `/extended/v1/tx/multiple?tx_id=${txIds}`
+    );
+    expect(txsListDetail2.body).toEqual(txsListDetail.body);
   });
 
   test('getTxList returns object', async () => {


### PR DESCRIPTION
Related to https://github.com/hirosystems/stacks-blockchain-api/pull/1807

This adds support for parsing comma-separated array strings from url query params. Now both common formats for specifying arrays should work:
* `?tx_id=ID1,ID2,ID3`
* `?tx_id=ID1&tx_id=ID2&tx_id=ID3`