### PR TITLE
feat: remove reconcile mempool & debounce stats

### DIFF
--- a/.env
+++ b/.env
@@ -61,6 +61,10 @@ PG_APPLICATION_NAME=stacks-blockchain-api
 # the same.
 # STACKS_MEMPOOL_TX_GARBAGE_COLLECTION_THRESHOLD=256
 
+# To avoid running unnecessary mempool stats during transaction influx, we use a debounce mechanism for the process.
+# This variable controls the duration it waits until there are no further mempool updates
+# MEMPOOL_STATS_DEBOUNCE_INTERVAL=1000
+
 # If specified, an http server providing profiling capability endpoints will be opened on the given port.
 # This port should not be publicly exposed.
 # STACKS_PROFILER_PORT=9119

--- a/.env
+++ b/.env
@@ -64,6 +64,7 @@ PG_APPLICATION_NAME=stacks-blockchain-api
 # To avoid running unnecessary mempool stats during transaction influx, we use a debounce mechanism for the process.
 # This variable controls the duration it waits until there are no further mempool updates
 # MEMPOOL_STATS_DEBOUNCE_INTERVAL=1000
+# MEMPOOL_STATS_DEBOUNCE_MAX_INTERVAL=10000
 
 # If specified, an http server providing profiling capability endpoints will be opened on the given port.
 # This port should not be publicly exposed.

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -1686,38 +1686,46 @@ export class PgWriteStore extends PgStore {
         tenure_change_signature: tx.tenure_change_signature ?? null,
         tenure_change_signers: tx.tenure_change_signers ?? null,
       }));
-      // The incoming mempool transactions might have already been settled
-      // We need to mark them as pruned to avoid inconsistent tx state
       const result = await sql<{ tx_id: string }[]>`
         WITH inserted AS (
           INSERT INTO mempool_txs ${sql(values)}
           ON CONFLICT ON CONSTRAINT unique_tx_id DO NOTHING
           RETURNING tx_id
         ),
-        settled AS (
-          SELECT tx_id
-          FROM txs
-          WHERE
-            tx_id IN ${sql(values.map(b => b.tx_id))} AND
-            canonical = true AND
-            microblock_canonical = true
-        ),
-        pruned AS (
-          UPDATE mempool_txs
-          SET pruned = true
-          WHERE
-            tx_id IN (SELECT tx_id FROM settled) AND
-            pruned = false
-          RETURNING tx_id
-        ),
         count_update AS (
           UPDATE chain_tip SET
-            mempool_tx_count = mempool_tx_count + (SELECT COUNT(*) FROM inserted) - (SELECT COUNT(*) FROM pruned),
+            mempool_tx_count = mempool_tx_count + (SELECT COUNT(*) FROM inserted),
             mempool_updated_at = NOW()
         )
         SELECT tx_id FROM inserted
       `;
       txIds.push(...result.map(r => r.tx_id));
+      // The incoming mempool transactions might have already been settled
+      // We need to mark them as pruned to avoid inconsistent tx state
+      const pruned_tx = await sql<{ tx_id: string }[]>`
+        SELECT tx_id
+        FROM txs
+        WHERE
+          tx_id IN ${sql(batch.map(b => b.tx_id))} AND
+          canonical = true AND
+          microblock_canonical = true`;
+      if (pruned_tx.length > 0) {
+        await sql<{ tx_id: string }[]>`
+          WITH pruned AS (
+            UPDATE mempool_txs
+            SET pruned = true
+            WHERE
+              tx_id IN ${sql(pruned_tx.map(t => t.tx_id))} AND
+              pruned = false
+            RETURNING tx_id
+          ),
+          count_update AS (
+            UPDATE chain_tip SET
+              mempool_tx_count = mempool_tx_count - (SELECT COUNT(*) FROM pruned),
+              mempool_updated_at = NOW()
+          )
+          SELECT tx_id FROM pruned`;
+      }
     }
     return txIds;
   }

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -97,6 +97,9 @@ import { PgServer, getConnectionArgs, getConnectionConfig } from './connection';
 
 const MIGRATIONS_TABLE = 'pgmigrations';
 const INSERT_BATCH_SIZE = 500;
+const MEMPOOL_STATS_DEBOUNCE_INTERVAL = Number(
+  BigInt(process.env['MEMPOOL_STATS_DEBOUNCE_INTERVAL'] ?? 1000)
+);
 
 class MicroblockGapError extends Error {
   constructor(message: string) {
@@ -1743,7 +1746,7 @@ export class PgWriteStore extends PgStore {
           this.debounceMempoolStat();
         }
       }
-    }, 1000);
+    }, MEMPOOL_STATS_DEBOUNCE_INTERVAL);
   }
 
   async updateMempoolTxs({ mempoolTxs: txs }: { mempoolTxs: DbMempoolTxRaw[] }): Promise<void> {

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -1700,11 +1700,15 @@ export class PgWriteStore extends PgStore {
     running: boolean;
     listeners: (() => unknown)[];
   } = { running: false, listeners: [] };
-  public waitForNextReconcileMempool() {
+  // for testing purposes: wait for the next debounced process to complete.
+  public waitForNextMempoolReconcile() {
     return new Promise<void>(f => {
       this._debounceReconcileMempool.listeners.push(f);
     });
   }
+  /**
+   * Debounce the process in case new transactions pour in.
+   */
   private debounceReconcileMempool() {
     this._debounceReconcileMempool.lastTrigger = Date.now();
     if (this._debounceReconcileMempool.running) return;

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -1750,13 +1750,12 @@ export class PgWriteStore extends PgStore {
         const mempoolStats = await this.getMempoolStatsInternal({ sql: this.sql });
         this.eventEmitter.emit('mempoolStatsUpdate', mempoolStats);
       } catch (e) {
-        logger.error(e, `failed to reconcile mempool`);
+        logger.error(e, `failed to run mempool stats update`);
       } finally {
         this._debounceMempoolStat.running = false;
+        this._debounceMempoolStat.debounce = null;
         if (this._debounceMempoolStat.triggeredAt != null) {
           this.debounceMempoolStat();
-        } else {
-          this._debounceMempoolStat.debounce = null;
         }
       }
     }, delay);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -766,10 +766,10 @@ export enum BootContractAddress {
 }
 
 export function getUintEnvOrDefault(envName: string, defaultValue = 0) {
-  const v = BigInt(process.env['MEMPOOL_STATS_DEBOUNCE_INTERVAL'] ?? defaultValue);
+  const v = BigInt(process.env[envName] ?? defaultValue);
   if (v < 0n) {
     throw new Error(
-      `Expecting ENV ${envName} to be non-negative number but it is configured as ${process.env['MEMPOOL_STATS_DEBOUNCE_INTERVAL']}`
+      `Expecting ENV ${envName} to be non-negative number but it is configured as ${process.env[envName]}`
     );
   }
   return Number(v);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -764,3 +764,13 @@ export enum BootContractAddress {
   mainnet = 'SP000000000000000000002Q6VF78',
   testnet = 'ST000000000000000000002AMW42H',
 }
+
+export function getUintEnvOrDefault(envName: string, defaultValue = 0) {
+  const v = BigInt(process.env['MEMPOOL_STATS_DEBOUNCE_INTERVAL'] ?? defaultValue);
+  if (v < 0n) {
+    throw new Error(
+      `Expecting ENV ${envName} to be non-negative number but it is configured as ${process.env['MEMPOOL_STATS_DEBOUNCE_INTERVAL']}`
+    );
+  }
+  return Number(v);
+}

--- a/src/tests/helpers-tests.ts
+++ b/src/tests/helpers-tests.ts
@@ -3,7 +3,7 @@ import * as c32check from 'c32check';
 import { bitcoinToStacksAddress, stacksToBitcoinAddress } from 'stacks-encoding-native-js';
 import * as c32AddrCache from '../c32-addr-cache';
 import { ADDR_CACHE_ENV_VAR } from '../c32-addr-cache';
-import { isValidBitcoinAddress } from '../helpers';
+import { isValidBitcoinAddress, getUintEnvOrDefault } from '../helpers';
 import { ECPair, getBitcoinAddressFromKey } from '../ec-helpers';
 import { decodeBtcAddress, poxAddressToBtcAddress } from '@stacks/stacking';
 import { has0xPrefix } from '@hirosystems/api-toolkit';
@@ -535,4 +535,14 @@ describe('Bitcoin address encoding formats', () => {
     });
     expect(randP2TRTestnet).toMatch(/^tb1p/);
   });
+});
+
+test('getUintEnvOrDefault tests', () => {
+  const key = 'SOME_UINT_ENV';
+  process.env[key] = '123';
+  expect(getUintEnvOrDefault(key)).toBe(123);
+  process.env[key] = '-123';
+  expect(() => getUintEnvOrDefault(key)).toThrowError();
+  process.env[key] = 'ABC';
+  expect(() => getUintEnvOrDefault(key)).toThrowError();
 });

--- a/src/tests/mempool-tests.ts
+++ b/src/tests/mempool-tests.ts
@@ -1691,7 +1691,22 @@ describe('mempool tests', () => {
       block: dbBlock2,
       microblocks: [],
       minerRewards: [],
-      txs: [],
+      txs: [
+        {
+          tx: dbTx1,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          smartContracts: [],
+          names: [],
+          namespaces: [],
+          pox2Events: [],
+          pox3Events: [],
+          pox4Events: [],
+        },
+      ],
     });
 
     // Verify tx pruned from mempool

--- a/src/tests/mempool-tests.ts
+++ b/src/tests/mempool-tests.ts
@@ -1693,6 +1693,7 @@ describe('mempool tests', () => {
       minerRewards: [],
       txs: [],
     });
+    await db.waitForNextReconcileMempool();
 
     // Verify tx pruned from mempool
     const mempoolResult3 = await supertest(api.server).get(

--- a/src/tests/mempool-tests.ts
+++ b/src/tests/mempool-tests.ts
@@ -1693,7 +1693,7 @@ describe('mempool tests', () => {
       minerRewards: [],
       txs: [],
     });
-    await db.waitForNextReconcileMempool();
+    await db.waitForNextMempoolReconcile();
 
     // Verify tx pruned from mempool
     const mempoolResult3 = await supertest(api.server).get(

--- a/src/tests/mempool-tests.ts
+++ b/src/tests/mempool-tests.ts
@@ -1693,7 +1693,6 @@ describe('mempool tests', () => {
       minerRewards: [],
       txs: [],
     });
-    await db.waitForNextMempoolReconcile();
 
     // Verify tx pruned from mempool
     const mempoolResult3 = await supertest(api.server).get(

--- a/src/tests/websocket-tests.ts
+++ b/src/tests/websocket-tests.ts
@@ -111,7 +111,6 @@ describe('websocket notifications', () => {
         .addTx({ tx_id: txId })
         .build();
       await db.updateMicroblocks(microblock);
-      await db.waitForNextMempoolReconcile();
 
       // check for tx update notification
       const txStatus1 = await txUpdates[0];

--- a/src/tests/websocket-tests.ts
+++ b/src/tests/websocket-tests.ts
@@ -111,7 +111,7 @@ describe('websocket notifications', () => {
         .addTx({ tx_id: txId })
         .build();
       await db.updateMicroblocks(microblock);
-      await db.waitForNextReconcileMempool();
+      await db.waitForNextMempoolReconcile();
 
       // check for tx update notification
       const txStatus1 = await txUpdates[0];

--- a/src/tests/websocket-tests.ts
+++ b/src/tests/websocket-tests.ts
@@ -111,6 +111,7 @@ describe('websocket notifications', () => {
         .addTx({ tx_id: txId })
         .build();
       await db.updateMicroblocks(microblock);
+      await db.waitForNextReconcileMempool();
 
       // check for tx update notification
       const txStatus1 = await txUpdates[0];


### PR DESCRIPTION
## Description

Currently when the event server handles a new_mempool_tx event, it reconcile mempool status and recalculate mempool stats. This is really unnecessary, especially when an influx of new transactions occurs. As the stacks node awaits the event server processing, it slows down the new block processing.

This PR suggests a method to reconcile and update mempool statistics through a debounce scheme. It significantly decreases the processing time for new_mempool_tx events from over 1s to less than 10ms. 

## Type of Change

Performance optimization.

## Does this introduce a breaking change?

No.

## Are documentation updates required?

No.

## Testing information

Since the reconcile process is deferred, a method to wait for next reconcile is added for testing purposes. And the tests are updated accordingly.

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @rafaelcr or @zone117x for review
