### PR TITLE
fix: log re-orgs at `INFO` level

### DIFF
--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -981,43 +981,30 @@ export interface FaucetRequestQueryResult {
   occurred_at: string;
 }
 
+interface ReOrgEntities {
+  blocks: number;
+  microblocks: number;
+  minerRewards: number;
+  txs: number;
+  stxLockEvents: number;
+  stxEvents: number;
+  ftEvents: number;
+  nftEvents: number;
+  pox2Events: number;
+  pox3Events: number;
+  pox4Events: number;
+  contractLogs: number;
+  smartContracts: number;
+  names: number;
+  namespaces: number;
+  subdomains: number;
+}
+
 export interface ReOrgUpdatedEntities {
-  markedCanonical: {
-    blocks: number;
-    microblocks: number;
-    minerRewards: number;
-    txs: number;
-    stxLockEvents: number;
-    stxEvents: number;
-    ftEvents: number;
-    nftEvents: number;
-    pox2Events: number;
-    pox3Events: number;
-    pox4Events: number;
-    contractLogs: number;
-    smartContracts: number;
-    names: number;
-    namespaces: number;
-    subdomains: number;
-  };
-  markedNonCanonical: {
-    blocks: number;
-    microblocks: number;
-    minerRewards: number;
-    txs: number;
-    stxLockEvents: number;
-    stxEvents: number;
-    ftEvents: number;
-    nftEvents: number;
-    pox2Events: number;
-    pox3Events: number;
-    pox4Events: number;
-    contractLogs: number;
-    smartContracts: number;
-    names: number;
-    namespaces: number;
-    subdomains: number;
-  };
+  markedCanonical: ReOrgEntities;
+  markedNonCanonical: ReOrgEntities;
+  prunedMempoolTxs: number;
+  restoredMempoolTxs: number;
 }
 
 export interface TransferQueryResult {

--- a/src/datastore/helpers.ts
+++ b/src/datastore/helpers.ts
@@ -1331,67 +1331,7 @@ export function newReOrgUpdatedEntities(): ReOrgUpdatedEntities {
       namespaces: 0,
       subdomains: 0,
     },
+    prunedMempoolTxs: 0,
+    restoredMempoolTxs: 0,
   };
-}
-
-export function logReorgResultInfo(updatedEntities: ReOrgUpdatedEntities) {
-  const updates = [
-    ['blocks', updatedEntities.markedCanonical.blocks, updatedEntities.markedNonCanonical.blocks],
-    [
-      'microblocks',
-      updatedEntities.markedCanonical.microblocks,
-      updatedEntities.markedNonCanonical.microblocks,
-    ],
-    ['txs', updatedEntities.markedCanonical.txs, updatedEntities.markedNonCanonical.txs],
-    [
-      'miner-rewards',
-      updatedEntities.markedCanonical.minerRewards,
-      updatedEntities.markedNonCanonical.minerRewards,
-    ],
-    [
-      'stx-lock events',
-      updatedEntities.markedCanonical.stxLockEvents,
-      updatedEntities.markedNonCanonical.stxLockEvents,
-    ],
-    [
-      'stx-token events',
-      updatedEntities.markedCanonical.stxEvents,
-      updatedEntities.markedNonCanonical.stxEvents,
-    ],
-    [
-      'non-fungible-token events',
-      updatedEntities.markedCanonical.nftEvents,
-      updatedEntities.markedNonCanonical.nftEvents,
-    ],
-    [
-      'fungible-token events',
-      updatedEntities.markedCanonical.ftEvents,
-      updatedEntities.markedNonCanonical.ftEvents,
-    ],
-    [
-      'contract logs',
-      updatedEntities.markedCanonical.contractLogs,
-      updatedEntities.markedNonCanonical.contractLogs,
-    ],
-    [
-      'smart contracts',
-      updatedEntities.markedCanonical.smartContracts,
-      updatedEntities.markedNonCanonical.smartContracts,
-    ],
-    ['names', updatedEntities.markedCanonical.names, updatedEntities.markedNonCanonical.names],
-    [
-      'namespaces',
-      updatedEntities.markedCanonical.namespaces,
-      updatedEntities.markedNonCanonical.namespaces,
-    ],
-    [
-      'subdomains',
-      updatedEntities.markedCanonical.subdomains,
-      updatedEntities.markedNonCanonical.subdomains,
-    ],
-  ];
-  const markedCanonical = updates.map(e => `${e[1]} ${e[0]}`).join(', ');
-  logger.debug(`Entities marked as canonical: ${markedCanonical}`);
-  const markedNonCanonical = updates.map(e => `${e[2]} ${e[0]}`).join(', ');
-  logger.debug(`Entities marked as non-canonical: ${markedNonCanonical}`);
 }

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -3607,6 +3607,8 @@ describe('postgres datastore', () => {
         namespaces: 0,
         subdomains: 0,
       },
+      prunedMempoolTxs: 0,
+      restoredMempoolTxs: 0,
     });
 
     const blockQuery1 = await db.getBlock({ hash: block1.block_hash });


### PR DESCRIPTION
Log re-org data using the complete re-org entities serialized object, including restored and pruned mempool transaction totals.