### PR TITLE
fix: log block event counts after processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [7.7.1](https://github.com/hirosystems/stacks-blockchain-api/compare/v7.7.0...v7.7.1) (2024-01-11)
+
+
+### Bug Fixes
+
+* log re-orgs at `INFO` level ([#1819](https://github.com/hirosystems/stacks-blockchain-api/issues/1819)) ([3b502f7](https://github.com/hirosystems/stacks-blockchain-api/commit/3b502f73149c185265fc8948e75ba064892ce6d2))
+
 ## [7.7.0](https://github.com/hirosystems/stacks-blockchain-api/compare/v7.6.0...v7.7.0) (2024-01-10)
 
 

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -981,43 +981,30 @@ export interface FaucetRequestQueryResult {
   occurred_at: string;
 }
 
+interface ReOrgEntities {
+  blocks: number;
+  microblocks: number;
+  minerRewards: number;
+  txs: number;
+  stxLockEvents: number;
+  stxEvents: number;
+  ftEvents: number;
+  nftEvents: number;
+  pox2Events: number;
+  pox3Events: number;
+  pox4Events: number;
+  contractLogs: number;
+  smartContracts: number;
+  names: number;
+  namespaces: number;
+  subdomains: number;
+}
+
 export interface ReOrgUpdatedEntities {
-  markedCanonical: {
-    blocks: number;
-    microblocks: number;
-    minerRewards: number;
-    txs: number;
-    stxLockEvents: number;
-    stxEvents: number;
-    ftEvents: number;
-    nftEvents: number;
-    pox2Events: number;
-    pox3Events: number;
-    pox4Events: number;
-    contractLogs: number;
-    smartContracts: number;
-    names: number;
-    namespaces: number;
-    subdomains: number;
-  };
-  markedNonCanonical: {
-    blocks: number;
-    microblocks: number;
-    minerRewards: number;
-    txs: number;
-    stxLockEvents: number;
-    stxEvents: number;
-    ftEvents: number;
-    nftEvents: number;
-    pox2Events: number;
-    pox3Events: number;
-    pox4Events: number;
-    contractLogs: number;
-    smartContracts: number;
-    names: number;
-    namespaces: number;
-    subdomains: number;
-  };
+  markedCanonical: ReOrgEntities;
+  markedNonCanonical: ReOrgEntities;
+  prunedMempoolTxs: number;
+  restoredMempoolTxs: number;
 }
 
 export interface TransferQueryResult {

--- a/src/datastore/helpers.ts
+++ b/src/datastore/helpers.ts
@@ -1331,67 +1331,7 @@ export function newReOrgUpdatedEntities(): ReOrgUpdatedEntities {
       namespaces: 0,
       subdomains: 0,
     },
+    prunedMempoolTxs: 0,
+    restoredMempoolTxs: 0,
   };
-}
-
-export function logReorgResultInfo(updatedEntities: ReOrgUpdatedEntities) {
-  const updates = [
-    ['blocks', updatedEntities.markedCanonical.blocks, updatedEntities.markedNonCanonical.blocks],
-    [
-      'microblocks',
-      updatedEntities.markedCanonical.microblocks,
-      updatedEntities.markedNonCanonical.microblocks,
-    ],
-    ['txs', updatedEntities.markedCanonical.txs, updatedEntities.markedNonCanonical.txs],
-    [
-      'miner-rewards',
-      updatedEntities.markedCanonical.minerRewards,
-      updatedEntities.markedNonCanonical.minerRewards,
-    ],
-    [
-      'stx-lock events',
-      updatedEntities.markedCanonical.stxLockEvents,
-      updatedEntities.markedNonCanonical.stxLockEvents,
-    ],
-    [
-      'stx-token events',
-      updatedEntities.markedCanonical.stxEvents,
-      updatedEntities.markedNonCanonical.stxEvents,
-    ],
-    [
-      'non-fungible-token events',
-      updatedEntities.markedCanonical.nftEvents,
-      updatedEntities.markedNonCanonical.nftEvents,
-    ],
-    [
-      'fungible-token events',
-      updatedEntities.markedCanonical.ftEvents,
-      updatedEntities.markedNonCanonical.ftEvents,
-    ],
-    [
-      'contract logs',
-      updatedEntities.markedCanonical.contractLogs,
-      updatedEntities.markedNonCanonical.contractLogs,
-    ],
-    [
-      'smart contracts',
-      updatedEntities.markedCanonical.smartContracts,
-      updatedEntities.markedNonCanonical.smartContracts,
-    ],
-    ['names', updatedEntities.markedCanonical.names, updatedEntities.markedNonCanonical.names],
-    [
-      'namespaces',
-      updatedEntities.markedCanonical.namespaces,
-      updatedEntities.markedNonCanonical.namespaces,
-    ],
-    [
-      'subdomains',
-      updatedEntities.markedCanonical.subdomains,
-      updatedEntities.markedNonCanonical.subdomains,
-    ],
-  ];
-  const markedCanonical = updates.map(e => `${e[1]} ${e[0]}`).join(', ');
-  logger.debug(`Entities marked as canonical: ${markedCanonical}`);
-  const markedNonCanonical = updates.map(e => `${e[2]} ${e[0]}`).join(', ');
-  logger.debug(`Entities marked as non-canonical: ${markedNonCanonical}`);
 }

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -244,22 +244,31 @@ async function handleBlockMessage(
       switch (parsedTx.parsed_tx.payload.type_id) {
         case TxPayloadTypeID.Coinbase:
           counts.txs.coinbase += 1;
+          break;
         case TxPayloadTypeID.CoinbaseToAltRecipient:
           counts.txs.coinbase_to_alt_recipient += 1;
+          break;
         case TxPayloadTypeID.ContractCall:
           counts.txs.contract_call += 1;
+          break;
         case TxPayloadTypeID.NakamotoCoinbase:
           counts.txs.nakamoto_coinbase += 1;
+          break;
         case TxPayloadTypeID.PoisonMicroblock:
           counts.txs.poison_microblock += 1;
+          break;
         case TxPayloadTypeID.SmartContract:
           counts.txs.smart_contract += 1;
+          break;
         case TxPayloadTypeID.TenureChange:
           counts.txs.tenure_change += 1;
+          break;
         case TxPayloadTypeID.TokenTransfer:
           counts.txs.token_transfer += 1;
+          break;
         case TxPayloadTypeID.VersionedSmartContract:
           counts.txs.versioned_smart_contract += 1;
+          break;
       }
     }
   });

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -46,6 +46,7 @@ import {
   CoreNodeMsgBlockData,
   parseMicroblocksFromTxs,
   isPoxPrintEvent,
+  newCoreNoreBlockEventCounts,
 } from './reader';
 import {
   decodeTransaction,
@@ -230,6 +231,7 @@ async function handleBlockMessage(
   db: PgWriteStore
 ): Promise<void> {
   const ingestionTimer = stopwatch();
+  const counts = newCoreNoreBlockEventCounts();
   const parsedTxs: CoreNodeParsedTxMessage[] = [];
   const blockData: CoreNodeMsgBlockData = {
     ...msg,
@@ -238,8 +240,33 @@ async function handleBlockMessage(
     const parsedTx = parseMessageTransaction(chainId, item, blockData, msg.events);
     if (parsedTx) {
       parsedTxs.push(parsedTx);
+      counts.tx_total += 1;
+      switch (parsedTx.parsed_tx.payload.type_id) {
+        case TxPayloadTypeID.Coinbase:
+          counts.txs.coinbase += 1;
+        case TxPayloadTypeID.CoinbaseToAltRecipient:
+          counts.txs.coinbase_to_alt_recipient += 1;
+        case TxPayloadTypeID.ContractCall:
+          counts.txs.contract_call += 1;
+        case TxPayloadTypeID.NakamotoCoinbase:
+          counts.txs.nakamoto_coinbase += 1;
+        case TxPayloadTypeID.PoisonMicroblock:
+          counts.txs.poison_microblock += 1;
+        case TxPayloadTypeID.SmartContract:
+          counts.txs.smart_contract += 1;
+        case TxPayloadTypeID.TenureChange:
+          counts.txs.tenure_change += 1;
+        case TxPayloadTypeID.TokenTransfer:
+          counts.txs.token_transfer += 1;
+        case TxPayloadTypeID.VersionedSmartContract:
+          counts.txs.versioned_smart_contract += 1;
+      }
     }
   });
+  for (const event of msg.events) {
+    counts.event_total += 1;
+    counts.events[event.type] += 1;
+  }
 
   const dbBlock: DbBlock = {
     canonical: true,
@@ -281,6 +308,7 @@ async function handleBlockMessage(
       tx_fees_streamed_produced: BigInt(minerReward.tx_fees_streamed_produced),
     };
     dbMinerRewards.push(dbMinerReward);
+    counts.miner_rewards += 1;
   }
 
   logger.debug(`Received ${dbMinerRewards.length} matured miner rewards`);
@@ -304,16 +332,8 @@ async function handleBlockMessage(
       index_block_hash: msg.index_block_hash,
       block_hash: msg.block_hash,
     };
+    counts.microblocks += 1;
     return microblock;
-  });
-
-  parsedTxs.forEach(tx => {
-    logger.debug(`Received anchor block mined tx: ${tx.core_tx.txid}`);
-    logger.info('Transaction confirmed', {
-      txid: tx.core_tx.txid,
-      in_microblock: tx.microblock_hash != '',
-      stacks_height: dbBlock.block_height,
-    });
   });
 
   const dbData: DataStoreBlockUpdateData = {
@@ -328,7 +348,10 @@ async function handleBlockMessage(
 
   await db.update(dbData);
   const ingestionTime = ingestionTimer.getElapsed();
-  logger.info(`Ingested block ${msg.block_height} (${msg.block_hash}) in ${ingestionTime}ms`);
+  logger.info(
+    counts,
+    `Ingested block ${msg.block_height} (${msg.block_hash}) in ${ingestionTime}ms`
+  );
 }
 
 function parseDataStoreTxEventData(

--- a/src/event-stream/reader.ts
+++ b/src/event-stream/reader.ts
@@ -847,3 +847,67 @@ export function isPoxPrintEvent(event: SmartContractEvent): boolean {
   if (event.contract_event.topic !== 'print') return false;
   return PoxContractIdentifiers.includes(event.contract_event.contract_identifier);
 }
+
+export interface CoreNodeBlockEventCounts {
+  microblocks: number;
+  tx_total: number;
+  txs: {
+    token_transfer: number;
+    smart_contract: number;
+    contract_call: number;
+    poison_microblock: number;
+    coinbase: number;
+    coinbase_to_alt_recipient: number;
+    versioned_smart_contract: number;
+    tenure_change: number;
+    nakamoto_coinbase: number;
+  };
+  event_total: number;
+  events: {
+    contract_event: number;
+    stx_transfer_event: number;
+    stx_mint_event: number;
+    stx_burn_event: number;
+    stx_lock_event: number;
+    nft_transfer_event: number;
+    nft_mint_event: number;
+    nft_burn_event: number;
+    ft_transfer_event: number;
+    ft_mint_event: number;
+    ft_burn_event: number;
+  };
+  miner_rewards: number;
+}
+
+export function newCoreNoreBlockEventCounts(): CoreNodeBlockEventCounts {
+  return {
+    microblocks: 0,
+    tx_total: 0,
+    txs: {
+      token_transfer: 0,
+      smart_contract: 0,
+      contract_call: 0,
+      poison_microblock: 0,
+      coinbase: 0,
+      coinbase_to_alt_recipient: 0,
+      versioned_smart_contract: 0,
+      tenure_change: 0,
+      nakamoto_coinbase: 0,
+    },
+    event_total: 0,
+    events: {
+      contract_event: 0,
+      stx_transfer_event: 0,
+      stx_mint_event: 0,
+      stx_burn_event: 0,
+      stx_lock_event: 0,
+      nft_transfer_event: 0,
+      nft_mint_event: 0,
+      nft_burn_event: 0,
+      ft_transfer_event: 0,
+      ft_mint_event: 0,
+      ft_burn_event: 0,
+    },
+    miner_rewards: 0,
+  };
+}

--- a/src/event-stream/reader.ts
+++ b/src/event-stream/reader.ts
@@ -848,7 +848,7 @@ export function isPoxPrintEvent(event: SmartContractEvent): boolean {
   return PoxContractIdentifiers.includes(event.contract_event.contract_identifier);
 }
 
-export interface CoreNodeBlockEventCounts {
+interface CoreNodeBlockEventCounts {
   microblocks: number;
   tx_total: number;
   txs: {

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -3607,6 +3607,8 @@ describe('postgres datastore', () => {
         namespaces: 0,
         subdomains: 0,
       },
+      prunedMempoolTxs: 0,
+      restoredMempoolTxs: 0,
     });
 
     const blockQuery1 = await db.getBlock({ hash: block1.block_hash });


### PR DESCRIPTION
In order to determine which type of blocks take longer to process, we must know the proportion of transactions and different transaction types that were included. This will help us investigate further performance optimizations.