### PR TITLE
fix: pox 4 revoke events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -855,7 +855,6 @@ jobs:
       - lint
       - lint-docs
       - test
-      - test-2_5
       - test-bns
       - test-rosetta
       - test-rosetta-cli-construction

--- a/client/src/generated/models/RosettaOptions.ts
+++ b/client/src/generated/models/RosettaOptions.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Stacks Blockchain API
- * Welcome to the API reference overview for the <a href=\"https://docs.hiro.so/get-started/stacks-blockchain-api\">Stacks Blockchain API</a>.  <a href=\"https://hirosystems.github.io/stacks-blockchain-api/collection.json\" download=\"stacks-api-collection.json\">Download Postman collection</a> 
+ * Welcome to the API reference overview for the [Stacks Blockchain API](https://docs.hiro.so/get-started/stacks-blockchain-api).  [Download Postman collection](https://hirosystems.github.io/stacks-blockchain-api/collection.json) 
  *
  * The version of the OpenAPI document: STACKS_API_VERSION
  * 
@@ -139,6 +139,12 @@ export interface RosettaOptions {
      * @memberof RosettaOptions
      */
     pox_addr?: string;
+    /**
+     * The hex-encoded signer key (buff 33) for PoX.
+     * @type {string}
+     * @memberof RosettaOptions
+     */
+    signer_key?: string;
 }
 
 export function RosettaOptionsFromJSON(json: any): RosettaOptions {
@@ -171,6 +177,7 @@ export function RosettaOptionsFromJSONTyped(json: any, ignoreDiscriminator: bool
         'burn_block_height': !exists(json, 'burn_block_height') ? undefined : json['burn_block_height'],
         'delegate_to': !exists(json, 'delegate_to') ? undefined : json['delegate_to'],
         'pox_addr': !exists(json, 'pox_addr') ? undefined : json['pox_addr'],
+        'signer_key': !exists(json, 'signer_key') ? undefined : json['signer_key'],
     };
 }
 
@@ -203,6 +210,7 @@ export function RosettaOptionsToJSON(value?: RosettaOptions | null): any {
         'burn_block_height': value.burn_block_height,
         'delegate_to': value.delegate_to,
         'pox_addr': value.pox_addr,
+        'signer_key': value.signer_key,
     };
 }
 

--- a/docker/docker-compose.dev.stacks-blockchain.yml
+++ b/docker/docker-compose.dev.stacks-blockchain.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   stacks-blockchain:
-    image: 'hirosystems/stacks-api-e2e:stacks3.0-e6330cf'
+    image: 'hirosystems/stacks-api-e2e:stacks3.0-204ab4c'
     restart: on-failure
     environment:
       STACKS_EVENT_OBSERVER: host.docker.internal:3700

--- a/docker/docker-compose.dev.stacks-blockchain.yml
+++ b/docker/docker-compose.dev.stacks-blockchain.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   stacks-blockchain:
-    image: 'hirosystems/stacks-api-e2e:stacks3.0-204ab4c'
+    image: 'hirosystems/stacks-api-e2e:stacks3.0-1d675fd'
     restart: on-failure
     environment:
       STACKS_EVENT_OBSERVER: host.docker.internal:3700

--- a/docker/docker-compose.dev.stacks-blockchain.yml
+++ b/docker/docker-compose.dev.stacks-blockchain.yml
@@ -1,17 +1,17 @@
 version: '3.7'
 services:
   stacks-blockchain:
-    image: "hirosystems/stacks-api-e2e:stacks3.0-800259e"
+    image: 'hirosystems/stacks-api-e2e:stacks3.0-e6330cf'
     restart: on-failure
     environment:
       STACKS_EVENT_OBSERVER: host.docker.internal:3700
       BLOCKSTACK_USE_TEST_GENESIS_CHAINSTATE: 1
       NOP_BLOCKSTACK_DEBUG: 1
     ports:
-      - "20443:20443"
-      - "20444:20444"
+      - '20443:20443'
+      - '20444:20444'
     volumes:
       - ../stacks-blockchain/:/app/config
       - ../stacks-blockchain/.chaindata:/tmp/stacks-blockchain-data
     extra_hosts:
-      - "host.docker.internal:host-gateway" # fixes `host.docker.internal` on linux hosts
+      - 'host.docker.internal:host-gateway' # fixes `host.docker.internal` on linux hosts

--- a/docker/docker-compose.dev.stacks-krypton.yml
+++ b/docker/docker-compose.dev.stacks-krypton.yml
@@ -1,16 +1,16 @@
 version: '3.7'
 services:
   stacks-blockchain:
-    image: "hirosystems/stacks-api-e2e:stacks3.0-800259e"
+    image: 'hirosystems/stacks-api-e2e:stacks3.0-e6330cf'
     ports:
-      - "18443:18443" # bitcoin regtest JSON-RPC interface
-      - "18444:18444" # bitcoin regtest p2p
-      - "20443:20443" # stacks-node RPC interface
-      - "20444:20444" # stacks-node p2p
+      - '18443:18443' # bitcoin regtest JSON-RPC interface
+      - '18444:18444' # bitcoin regtest p2p
+      - '20443:20443' # stacks-node RPC interface
+      - '20444:20444' # stacks-node p2p
     environment:
       MINE_INTERVAL: 0.1s
       STACKS_EVENT_OBSERVER: host.docker.internal:3700
       # STACKS_LOG_TRACE: 1
       # STACKS_LOG_DEBUG: 1
     extra_hosts:
-      - "host.docker.internal:host-gateway" # fixes `host.docker.internal` on linux hosts
+      - 'host.docker.internal:host-gateway' # fixes `host.docker.internal` on linux hosts

--- a/docker/docker-compose.dev.stacks-krypton.yml
+++ b/docker/docker-compose.dev.stacks-krypton.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   stacks-blockchain:
-    image: 'hirosystems/stacks-api-e2e:stacks3.0-e6330cf'
+    image: 'hirosystems/stacks-api-e2e:stacks3.0-204ab4c'
     ports:
       - '18443:18443' # bitcoin regtest JSON-RPC interface
       - '18444:18444' # bitcoin regtest p2p

--- a/docker/docker-compose.dev.stacks-krypton.yml
+++ b/docker/docker-compose.dev.stacks-krypton.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   stacks-blockchain:
-    image: 'hirosystems/stacks-api-e2e:stacks3.0-204ab4c'
+    image: 'hirosystems/stacks-api-e2e:stacks3.0-1d675fd'
     ports:
       - '18443:18443' # bitcoin regtest JSON-RPC interface
       - '18444:18444' # bitcoin regtest p2p

--- a/docs/entities/rosetta/rosetta-construction-options.schema.json
+++ b/docs/entities/rosetta/rosetta-construction-options.schema.json
@@ -83,6 +83,10 @@
     "pox_addr": {
       "type": "string",
       "description": "The reward address for stacking transaction. It should be a valid Bitcoin address"
+    },
+    "signer_key": {
+      "type": "string",
+      "description": "The hex-encoded signer key (buff 33) for PoX."
     }
   }
 }

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -2538,6 +2538,10 @@ export interface RosettaOptions {
    * The reward address for stacking transaction. It should be a valid Bitcoin address
    */
   pox_addr?: string;
+  /**
+   * The hex-encoded signer key (buff 33) for PoX.
+   */
+  signer_key?: string;
 }
 /**
  * The ConstructionMetadataResponse returns network-specific metadata used for transaction construction. Optionally, the implementer can return the suggested fee associated with the transaction being constructed. The caller may use this info to adjust the intent of the transaction or to create a transaction with a different account that can pay the suggested fee. Suggested fee is an array in case fee payment must occur in multiple currencies.

--- a/migrations/1706196613000_update-pox4-event-constraint.js
+++ b/migrations/1706196613000_update-pox4-event-constraint.js
@@ -1,0 +1,115 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = pgm => {
+  pgm.dropConstraint('pox4_events', 'valid_event_specific_columns', { ifExists: true });
+  pgm.addConstraint(
+    'pox4_events',
+    'valid_event_specific_columns',
+    `CHECK (
+    CASE name
+      WHEN 'handle-unlock' THEN
+        first_cycle_locked IS NOT NULL AND
+        first_unlocked_cycle IS NOT NULL
+      WHEN 'stack-stx' THEN
+        lock_period IS NOT NULL AND
+        lock_amount IS NOT NULL AND
+        start_burn_height IS NOT NULL AND
+        unlock_burn_height IS NOT NULL
+      WHEN 'stack-increase' THEN
+        increase_by IS NOT NULL AND
+        total_locked IS NOT NULL
+      WHEN 'stack-extend' THEN
+        extend_count IS NOT NULL AND
+        unlock_burn_height IS NOT NULL
+      WHEN 'delegate-stx' THEN
+        amount_ustx IS NOT NULL AND
+        delegate_to IS NOT NULL
+      WHEN 'delegate-stack-stx' THEN
+        lock_period IS NOT NULL AND
+        lock_amount IS NOT NULL AND
+        start_burn_height IS NOT NULL AND
+        unlock_burn_height IS NOT NULL AND
+        delegator IS NOT NULL
+      WHEN 'delegate-stack-increase' THEN
+        increase_by IS NOT NULL AND
+        total_locked IS NOT NULL AND
+        delegator IS NOT NULL
+      WHEN 'delegate-stack-extend' THEN
+        extend_count IS NOT NULL AND
+        unlock_burn_height IS NOT NULL AND
+        delegator IS NOT NULL
+      WHEN 'stack-aggregation-commit' THEN
+        reward_cycle IS NOT NULL AND
+        amount_ustx IS NOT NULL
+      WHEN 'stack-aggregation-commit-indexed' THEN
+        reward_cycle IS NOT NULL AND
+        amount_ustx IS NOT NULL
+      WHEN 'stack-aggregation-increase' THEN
+        reward_cycle IS NOT NULL AND
+        amount_ustx IS NOT NULL
+      WHEN 'revoke-delegate-stx' THEN
+        delegate_to IS NOT NULL
+      ELSE false
+    END
+  )`
+  );
+};
+
+exports.down = pgm => {
+  pgm.dropConstraint('pox4_events', 'valid_event_specific_columns', { ifExists: true });
+
+  // constraint from migrations/1702134678728_pox_4_events.js
+  // first, remove rows that would violate the constraint
+  pgm.sql("DELETE FROM pox4_events WHERE name = 'revoke-delegate-stx';");
+  pgm.addConstraint(
+    'pox4_events',
+    'valid_event_specific_columns',
+    `CHECK (
+    CASE name
+      WHEN 'handle-unlock' THEN
+        first_cycle_locked IS NOT NULL AND
+        first_unlocked_cycle IS NOT NULL
+      WHEN 'stack-stx' THEN
+        lock_period IS NOT NULL AND
+        lock_amount IS NOT NULL AND
+        start_burn_height IS NOT NULL AND
+        unlock_burn_height IS NOT NULL
+      WHEN 'stack-increase' THEN
+        increase_by IS NOT NULL AND
+        total_locked IS NOT NULL
+      WHEN 'stack-extend' THEN
+        extend_count IS NOT NULL AND
+        unlock_burn_height IS NOT NULL
+      WHEN 'delegate-stx' THEN
+        amount_ustx IS NOT NULL AND
+        delegate_to IS NOT NULL
+      WHEN 'delegate-stack-stx' THEN
+        lock_period IS NOT NULL AND
+        lock_amount IS NOT NULL AND
+        start_burn_height IS NOT NULL AND
+        unlock_burn_height IS NOT NULL AND
+        delegator IS NOT NULL
+      WHEN 'delegate-stack-increase' THEN
+        increase_by IS NOT NULL AND
+        total_locked IS NOT NULL AND
+        delegator IS NOT NULL
+      WHEN 'delegate-stack-extend' THEN
+        extend_count IS NOT NULL AND
+        unlock_burn_height IS NOT NULL AND
+        delegator IS NOT NULL
+      WHEN 'stack-aggregation-commit' THEN
+        reward_cycle IS NOT NULL AND
+        amount_ustx IS NOT NULL
+      WHEN 'stack-aggregation-commit-indexed' THEN
+        reward_cycle IS NOT NULL AND
+        amount_ustx IS NOT NULL
+      WHEN 'stack-aggregation-increase' THEN
+        reward_cycle IS NOT NULL AND
+        amount_ustx IS NOT NULL
+      ELSE false
+    END
+  )`
+  );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@sinclair/typebox": "0.31.28",
         "@stacks/common": "6.8.1",
         "@stacks/network": "6.8.1",
-        "@stacks/stacking": "6.11.2-pr.64326b1.0",
+        "@stacks/stacking": "6.9.0",
         "@stacks/transactions": "6.9.0",
         "@types/express-list-endpoints": "4.0.1",
         "@types/lru-cache": "5.1.1",
@@ -2931,35 +2931,17 @@
       }
     },
     "node_modules/@stacks/stacking": {
-      "version": "6.11.2-pr.64326b1.0",
-      "resolved": "https://registry.npmjs.org/@stacks/stacking/-/stacking-6.11.2-pr.64326b1.0.tgz",
-      "integrity": "sha512-eee32gt5Oy0d37Iu24lXUWB7u0DuPBPzgXAxabVqFDYHLCeBB3VhWG6o8wvQq5oayAuxb3bpwqnZKibrnBfNlA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@stacks/stacking/-/stacking-6.9.0.tgz",
+      "integrity": "sha512-nxTGwaVBE/M06P8bTlXPXlzeV/bOLaxbMd3ftAnQUu8ubX2UB/iEHywnAkrg/Bj2Qy9ZjKyi6QKw+aG38rVZaw==",
       "dependencies": {
         "@scure/base": "1.1.1",
-        "@stacks/common": "^6.11.2-pr.64326b1.0",
-        "@stacks/encryption": "^6.11.2-pr.64326b1.0",
-        "@stacks/network": "^6.11.2-pr.64326b1.0",
+        "@stacks/common": "^6.8.1",
+        "@stacks/encryption": "^6.9.0",
+        "@stacks/network": "^6.8.1",
         "@stacks/stacks-blockchain-api-types": "^0.61.0",
-        "@stacks/transactions": "^6.11.2-pr.64326b1.0",
+        "@stacks/transactions": "^6.9.0",
         "bs58": "^5.0.0"
-      }
-    },
-    "node_modules/@stacks/stacking/node_modules/@stacks/common": {
-      "version": "6.11.2-pr.f09ba06.0",
-      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-6.11.2-pr.f09ba06.0.tgz",
-      "integrity": "sha512-cOSMnD9ECeCPgn+RJ1Dn80bLy/hQr87l/qoMmdFjDF2z27JwlLKbdsADlU5YB5yyYatVe7RZG4HYmB9IKjAOmA==",
-      "dependencies": {
-        "@types/bn.js": "^5.1.0",
-        "@types/node": "^18.0.4"
-      }
-    },
-    "node_modules/@stacks/stacking/node_modules/@stacks/network": {
-      "version": "6.11.2-pr.f09ba06.0",
-      "resolved": "https://registry.npmjs.org/@stacks/network/-/network-6.11.2-pr.f09ba06.0.tgz",
-      "integrity": "sha512-4t0HcuOgc0GvjJyG5yoUu6LqqDNwX3H7l7DmHSrk4VvkZXDTng66H/YryaYrou3mlADXCg3DsZsVrzP/52kzPA==",
-      "dependencies": {
-        "@stacks/common": "^6.11.2-pr.f09ba06.0",
-        "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@stacks/stacking/node_modules/@stacks/transactions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@sinclair/typebox": "0.31.28",
         "@stacks/common": "6.8.1",
         "@stacks/network": "6.8.1",
-        "@stacks/stacking": "6.9.0",
+        "@stacks/stacking": "6.11.2-pr.64326b1.0",
         "@stacks/transactions": "6.9.0",
         "@types/express-list-endpoints": "4.0.1",
         "@types/lru-cache": "5.1.1",
@@ -2551,22 +2551,22 @@
       }
     },
     "node_modules/@stacks/common/node_modules/@types/node": {
-      "version": "18.19.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.7.tgz",
-      "integrity": "sha512-IGRJfoNX10N/PfrReRZ1br/7SQ+2vF/tK3KXNwzXz82D32z5dMQEoOlFew18nLSN+vMNcLY4GrKfzwi/yWI8/w==",
+      "version": "18.19.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.8.tgz",
+      "integrity": "sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
     },
     "node_modules/@stacks/encryption": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@stacks/encryption/-/encryption-6.9.0.tgz",
-      "integrity": "sha512-hbpZ47eYgw9ZH5ly+GSgvw2Ffsu9L6d++2XIhvYSzL7yxYl4m1+FV5QYdJthJ2AS3vi8cI5otE254HTfCrhKzg==",
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/@stacks/encryption/-/encryption-6.11.2.tgz",
+      "integrity": "sha512-lkTlAmsmc8feLk57SVeTn08Z1brMX7kyxJ1KT02lAYvlhq34Hf/GoNLnHaowBRR6cExI2rAQYtOX162+mgJ5aQ==",
       "dependencies": {
         "@noble/hashes": "1.1.5",
         "@noble/secp256k1": "1.7.1",
         "@scure/bip39": "1.1.0",
-        "@stacks/common": "^6.8.1",
+        "@stacks/common": "^6.10.0",
         "@types/node": "^18.0.4",
         "base64-js": "^1.5.1",
         "bs58": "^5.0.0",
@@ -2574,10 +2574,19 @@
         "varuint-bitcoin": "^1.1.2"
       }
     },
+    "node_modules/@stacks/encryption/node_modules/@stacks/common": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-6.10.0.tgz",
+      "integrity": "sha512-6x5Z7AKd9/kj3+DYE9xIDIkFLHihBH614i2wqrZIjN02WxVo063hWSjIlUxlx8P4gl6olVzlOy5LzhLJD9OP0A==",
+      "dependencies": {
+        "@types/bn.js": "^5.1.0",
+        "@types/node": "^18.0.4"
+      }
+    },
     "node_modules/@stacks/encryption/node_modules/@types/node": {
-      "version": "18.19.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.7.tgz",
-      "integrity": "sha512-IGRJfoNX10N/PfrReRZ1br/7SQ+2vF/tK3KXNwzXz82D32z5dMQEoOlFew18nLSN+vMNcLY4GrKfzwi/yWI8/w==",
+      "version": "18.19.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.8.tgz",
+      "integrity": "sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2922,17 +2931,86 @@
       }
     },
     "node_modules/@stacks/stacking": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@stacks/stacking/-/stacking-6.9.0.tgz",
-      "integrity": "sha512-nxTGwaVBE/M06P8bTlXPXlzeV/bOLaxbMd3ftAnQUu8ubX2UB/iEHywnAkrg/Bj2Qy9ZjKyi6QKw+aG38rVZaw==",
+      "version": "6.11.2-pr.64326b1.0",
+      "resolved": "https://registry.npmjs.org/@stacks/stacking/-/stacking-6.11.2-pr.64326b1.0.tgz",
+      "integrity": "sha512-eee32gt5Oy0d37Iu24lXUWB7u0DuPBPzgXAxabVqFDYHLCeBB3VhWG6o8wvQq5oayAuxb3bpwqnZKibrnBfNlA==",
       "dependencies": {
         "@scure/base": "1.1.1",
-        "@stacks/common": "^6.8.1",
-        "@stacks/encryption": "^6.9.0",
-        "@stacks/network": "^6.8.1",
+        "@stacks/common": "^6.11.2-pr.64326b1.0",
+        "@stacks/encryption": "^6.11.2-pr.64326b1.0",
+        "@stacks/network": "^6.11.2-pr.64326b1.0",
         "@stacks/stacks-blockchain-api-types": "^0.61.0",
-        "@stacks/transactions": "^6.9.0",
+        "@stacks/transactions": "^6.11.2-pr.64326b1.0",
         "bs58": "^5.0.0"
+      }
+    },
+    "node_modules/@stacks/stacking/node_modules/@stacks/common": {
+      "version": "6.11.2-pr.f09ba06.0",
+      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-6.11.2-pr.f09ba06.0.tgz",
+      "integrity": "sha512-cOSMnD9ECeCPgn+RJ1Dn80bLy/hQr87l/qoMmdFjDF2z27JwlLKbdsADlU5YB5yyYatVe7RZG4HYmB9IKjAOmA==",
+      "dependencies": {
+        "@types/bn.js": "^5.1.0",
+        "@types/node": "^18.0.4"
+      }
+    },
+    "node_modules/@stacks/stacking/node_modules/@stacks/network": {
+      "version": "6.11.2-pr.f09ba06.0",
+      "resolved": "https://registry.npmjs.org/@stacks/network/-/network-6.11.2-pr.f09ba06.0.tgz",
+      "integrity": "sha512-4t0HcuOgc0GvjJyG5yoUu6LqqDNwX3H7l7DmHSrk4VvkZXDTng66H/YryaYrou3mlADXCg3DsZsVrzP/52kzPA==",
+      "dependencies": {
+        "@stacks/common": "^6.11.2-pr.f09ba06.0",
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "node_modules/@stacks/stacking/node_modules/@stacks/transactions": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-6.11.2.tgz",
+      "integrity": "sha512-Ojz+8gEl0NcLNnlKqu2itLqqcdzH8zrkmyRUU2zcOJseKy6q7JID16wxMdEI8dSUcL7gxLYJzNMhx8BoI9CMPQ==",
+      "dependencies": {
+        "@noble/hashes": "1.1.5",
+        "@noble/secp256k1": "1.7.1",
+        "@stacks/common": "^6.10.0",
+        "@stacks/network": "^6.10.0",
+        "c32check": "^2.0.0",
+        "lodash.clonedeep": "^4.5.0"
+      }
+    },
+    "node_modules/@stacks/stacking/node_modules/@stacks/transactions/node_modules/@stacks/common": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-6.10.0.tgz",
+      "integrity": "sha512-6x5Z7AKd9/kj3+DYE9xIDIkFLHihBH614i2wqrZIjN02WxVo063hWSjIlUxlx8P4gl6olVzlOy5LzhLJD9OP0A==",
+      "dependencies": {
+        "@types/bn.js": "^5.1.0",
+        "@types/node": "^18.0.4"
+      }
+    },
+    "node_modules/@stacks/stacking/node_modules/@stacks/transactions/node_modules/@stacks/network": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@stacks/network/-/network-6.10.0.tgz",
+      "integrity": "sha512-mbiZ8nlsyy77ndmBdaqhHXii22IFdK4ThRcOQs9j/O00DkAr04jCM4GV5Q+VLUnZ9OBoJq7yOV7Pf6jglh+0hw==",
+      "dependencies": {
+        "@stacks/common": "^6.10.0",
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "node_modules/@stacks/stacking/node_modules/@types/node": {
+      "version": "18.19.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.8.tgz",
+      "integrity": "sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@stacks/stacking/node_modules/c32check": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
+      "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
+      "dependencies": {
+        "@noble/hashes": "^1.1.2",
+        "base-x": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@stacks/stacks-blockchain-api-types": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@sinclair/typebox": "0.31.28",
     "@stacks/common": "6.8.1",
     "@stacks/network": "6.8.1",
-    "@stacks/stacking": "6.11.2-pr.64326b1.0",
+    "@stacks/stacking": "6.9.0",
     "@stacks/transactions": "6.9.0",
     "@types/express-list-endpoints": "4.0.1",
     "@types/lru-cache": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@sinclair/typebox": "0.31.28",
     "@stacks/common": "6.8.1",
     "@stacks/network": "6.8.1",
-    "@stacks/stacking": "6.9.0",
+    "@stacks/stacking": "6.11.2-pr.64326b1.0",
     "@stacks/transactions": "6.9.0",
     "@types/express-list-endpoints": "4.0.1",
     "@types/lru-cache": "5.1.1",

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -326,7 +326,6 @@ export function parsePoxSyntheticEvent(poxEvent: DbPoxSyntheticEvent) {
       return {
         ...baseInfo,
         data: {
-          amount_ustx: poxEvent.data.amount_ustx.toString(),
           delegate_to: poxEvent.data.delegate_to,
         },
       };

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -454,8 +454,6 @@ export interface DbPoxSyntheticStackAggregationIncreaseEvent extends DbPoxSynthe
 export interface DbPoxSyntheticRevokeDelegateStxEvent extends DbPoxSyntheticBaseEventData {
   name: SyntheticPoxEventName.RevokeDelegateStx;
   data: {
-    // TODO: determine what data is available for this event type
-    amount_ustx: bigint;
     delegate_to: string;
   };
 }

--- a/src/datastore/helpers.ts
+++ b/src/datastore/helpers.ts
@@ -808,8 +808,6 @@ export function parseDbPoxSyntheticEvent(row: PoxSyntheticEventQueryResult): DbP
         ...basePoxEvent,
         name: rowName,
         data: {
-          // TODO: figure out what data is available for this event
-          amount_ustx: BigInt(unwrapOptionalProp(row, 'amount_ustx')),
           delegate_to: unwrapOptionalProp(row, 'delegate_to'),
         },
       };

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -880,7 +880,6 @@ export class PgWriteStore extends PgStore {
             break;
           }
           case SyntheticPoxEventName.RevokeDelegateStx: {
-            value.amount_ustx = event.data.amount_ustx.toString();
             value.delegate_to = event.data.delegate_to;
             break;
           }

--- a/src/event-stream/pox-event-parsing.ts
+++ b/src/event-stream/pox-event-parsing.ts
@@ -149,7 +149,6 @@ interface PoxSyntheticPrintEventTypes {
     'amount-ustx': ClarityValueUInt;
   };
   [SyntheticPoxEventName.RevokeDelegateStx]: {
-    'pox-addr': PoxSyntheticEventAddr | ClarityValueOptionalNone;
     'delegate-to': ClarityValuePrincipalStandard | ClarityValuePrincipalContract;
   };
 }

--- a/src/event-stream/pox-event-parsing.ts
+++ b/src/event-stream/pox-event-parsing.ts
@@ -149,9 +149,8 @@ interface PoxSyntheticPrintEventTypes {
     'amount-ustx': ClarityValueUInt;
   };
   [SyntheticPoxEventName.RevokeDelegateStx]: {
-    'amount-ustx': ClarityValueUInt;
-    'delegate-to': ClarityValuePrincipalStandard | ClarityValuePrincipalContract;
     'pox-addr': PoxSyntheticEventAddr | ClarityValueOptionalNone;
+    'delegate-to': ClarityValuePrincipalStandard | ClarityValuePrincipalContract;
   };
 }
 
@@ -410,7 +409,6 @@ export function decodePoxSyntheticPrintEvent(
         ...baseEventData,
         name: eventName,
         data: {
-          amount_ustx: BigInt(d['amount-ustx'].value),
           delegate_to: clarityPrincipalToFullAddress(d['delegate-to']),
         },
       };

--- a/src/rosetta/rosetta-helpers.ts
+++ b/src/rosetta/rosetta-helpers.ts
@@ -774,10 +774,13 @@ export function getOptionsFromOperations(operations: RosettaOperation[]): Rosett
         if (!operation.metadata || typeof operation.metadata.number_of_cycles !== 'number') {
           return null;
         }
-
+        if (!operation.metadata || typeof operation.metadata.signer_key !== 'string') {
+          return null;
+        }
         options.sender_address = operation.account?.address;
         options.type = operation.type;
         options.number_of_cycles = operation.metadata.number_of_cycles;
+        options.signer_key = operation.metadata.signer_key;
         options.amount = operation.amount?.value.replace('-', '');
         options.symbol = operation.amount?.currency.symbol;
         options.decimals = operation.amount?.currency.decimals;
@@ -790,6 +793,9 @@ export function getOptionsFromOperations(operations: RosettaOperation[]): Rosett
         if (!operation.metadata || typeof operation.metadata.delegate_to !== 'string') {
           return null;
         }
+        if (!operation.metadata || typeof operation.metadata.signer_key !== 'string') {
+          return null;
+        }
         options.sender_address = operation.account?.address;
         options.type = operation.type;
         options.delegate_to = operation.metadata?.delegate_to;
@@ -797,6 +803,7 @@ export function getOptionsFromOperations(operations: RosettaOperation[]): Rosett
         options.symbol = operation.amount?.currency.symbol;
         options.decimals = operation.amount?.currency.decimals;
         options.pox_addr = operation.metadata?.pox_addr as string;
+        options.signer_key = operation.metadata.signer_key;
         break;
       default:
         return null;

--- a/src/rosetta/rosetta-helpers.ts
+++ b/src/rosetta/rosetta-helpers.ts
@@ -793,9 +793,6 @@ export function getOptionsFromOperations(operations: RosettaOperation[]): Rosett
         if (!operation.metadata || typeof operation.metadata.delegate_to !== 'string') {
           return null;
         }
-        if (!operation.metadata || typeof operation.metadata.signer_key !== 'string') {
-          return null;
-        }
         options.sender_address = operation.account?.address;
         options.type = operation.type;
         options.delegate_to = operation.metadata?.delegate_to;
@@ -803,7 +800,7 @@ export function getOptionsFromOperations(operations: RosettaOperation[]): Rosett
         options.symbol = operation.amount?.currency.symbol;
         options.decimals = operation.amount?.currency.decimals;
         options.pox_addr = operation.metadata?.pox_addr as string;
-        options.signer_key = operation.metadata.signer_key;
+
         break;
       default:
         return null;

--- a/src/test-utils/test-helpers.ts
+++ b/src/test-utils/test-helpers.ts
@@ -54,9 +54,6 @@ import { coerceToBuffer, hexToBuffer, runMigrations, timeout } from '@hirosystem
 import { MIGRATIONS_DIR } from '../datastore/pg-store';
 import { getConnectionArgs } from '../datastore/connection';
 
-/** A (buff 33) signer key of all zeroes, to be used for testing */
-export const ZERO_SIGNER_KEY_BYTES = hexToBytes('00'.repeat(33));
-
 export async function migrate(direction: 'up' | 'down') {
   await runMigrations(MIGRATIONS_DIR, direction, getConnectionArgs());
 }
@@ -137,6 +134,7 @@ export function accountFromKey(
   return { secretKey, pubKey, stxAddr, poxAddr, poxAddrClar, btcAddr, btcTestnetAddr, wif };
 }
 
+/** Stand by until prepare phase of next pox cycle (still in current cycle) */
 export async function standByForNextPoxCycle(): Promise<CoreRpcPoxInfo> {
   const firstPoxInfo = await testEnv.client.getPox();
   await standByUntilBurnBlock(firstPoxInfo.next_cycle.prepare_phase_start_block_height);
@@ -151,6 +149,7 @@ export async function standByForNextPoxCycle(): Promise<CoreRpcPoxInfo> {
   return lastPoxInfo;
 }
 
+/** Stand by until `current_cycle.id` increases */
 export async function standByForPoxCycle(
   apiArg?: ApiServer,
   clientArg?: StacksCoreRpcClient

--- a/src/test-utils/test-helpers.ts
+++ b/src/test-utils/test-helpers.ts
@@ -515,6 +515,7 @@ export async function stackStxWithRosetta(opts: {
   privateKey: string;
   cycleCount: number;
   ustxAmount: bigint;
+  signerKey: string;
 }) {
   const rosettaNetwork: NetworkIdentifier = {
     blockchain: RosettaConstants.blockchain,
@@ -535,6 +536,7 @@ export async function stackStxWithRosetta(opts: {
       metadata: {
         number_of_cycles: opts.cycleCount,
         pox_addr: opts.btcAddr,
+        signer_key: opts.signerKey,
       },
     },
     {

--- a/src/test-utils/test-helpers.ts
+++ b/src/test-utils/test-helpers.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { bytesToHex } from '@stacks/common';
+import { bytesToHex, hexToBytes } from '@stacks/common';
 import { StacksNetwork } from '@stacks/network';
 import { decodeBtcAddress, poxAddressToBtcAddress } from '@stacks/stacking';
 import {
@@ -53,6 +53,9 @@ import { b58ToC32 } from 'c32check';
 import { coerceToBuffer, hexToBuffer, runMigrations, timeout } from '@hirosystems/api-toolkit';
 import { MIGRATIONS_DIR } from '../datastore/pg-store';
 import { getConnectionArgs } from '../datastore/connection';
+
+/** A (buff 33) signer key of all zeroes, to be used for testing */
+export const ZERO_SIGNER_KEY_BYTES = hexToBytes('00'.repeat(33));
 
 export async function migrate(direction: 'up' | 'down') {
   await runMigrations(MIGRATIONS_DIR, direction, getConnectionArgs());

--- a/src/test-utils/test-helpers.ts
+++ b/src/test-utils/test-helpers.ts
@@ -149,7 +149,7 @@ export async function standByForNextPoxCycle(): Promise<CoreRpcPoxInfo> {
   return lastPoxInfo;
 }
 
-/** Stand by until `current_cycle.id` increases */
+/** Stand by until block height reaches the start of the next cycle */
 export async function standByForPoxCycle(
   apiArg?: ApiServer,
   clientArg?: StacksCoreRpcClient
@@ -162,8 +162,10 @@ export async function standByForPoxCycle(
   do {
     await standByUntilBurnBlock(lastPoxInfo.current_burnchain_block_height! + 1, api, client);
     lastPoxInfo = await client.getPox();
-  } while (lastPoxInfo.current_cycle.id <= firstPoxInfo.current_cycle.id);
-  expect(lastPoxInfo.current_cycle.id).toBe(firstPoxInfo.next_cycle.id);
+  } while (
+    (lastPoxInfo.current_burnchain_block_height as number) <=
+    firstPoxInfo.next_cycle.reward_phase_start_block_height
+  );
   const info = await client.getInfo();
   console.log({
     'firstPoxInfo.next_cycle.prepare_phase_start_block_height':

--- a/src/tests-2.5/env-setup.ts
+++ b/src/tests-2.5/env-setup.ts
@@ -34,7 +34,7 @@ beforeAll(async () => {
     user: BTC_RPC_USER,
     pass: BTC_RPC_PW,
     timeout: 120000,
-    wallet: '',
+    wallet: 'main',
   });
 
   testEnv = {

--- a/src/tests-2.5/pox-4-btc-address-formats.ts
+++ b/src/tests-2.5/pox-4-btc-address-formats.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { hexToBuffer } from '@hirosystems/api-toolkit';
-import { hexToBytes } from '@stacks/common';
 import { decodeBtcAddress } from '@stacks/stacking';
 import {
   AddressStxBalanceResponse,
@@ -8,77 +7,71 @@ import {
   BurnchainRewardSlotHolderListResponse,
   BurnchainRewardsTotal,
 } from '@stacks/stacks-blockchain-api-types';
-import { AnchorMode, bufferCV, makeContractCall, tupleCV, uintCV } from '@stacks/transactions';
+import {
+  AnchorMode,
+  bufferCV,
+  makeContractCall,
+  randomBytes,
+  tupleCV,
+  uintCV,
+} from '@stacks/transactions';
 import bignumber from 'bignumber.js';
 import { testnetKeys } from '../api/routes/debug';
 import { CoreRpcPoxInfo } from '../core-rpc/client';
 import { DbEventTypeId, DbStxLockEvent } from '../datastore/common';
-import { VerboseKeyOutput, getBitcoinAddressFromKey, privateToPublicKey } from '../ec-helpers';
+import { getBitcoinAddressFromKey, privateToPublicKey } from '../ec-helpers';
 import {
   fetchGet,
-  standByForNextPoxCycle,
+  standByForPoxCycle,
   standByForTxSuccess,
   standByUntilBurnBlock,
   testEnv,
 } from '../test-utils/test-helpers';
 
-describe('PoX-4 - Stack using supported bitcoin address formats', () => {
-  let poxInfo: CoreRpcPoxInfo;
-  let burnBlockHeight: number;
-  let cycleBlockLength: number;
-  let contractAddress: string;
-  let contractName: string;
-  let ustxAmount: bigint;
-  const cycleCount = 1;
-  const btcPrivateKey = '0000000000000000000000000000000000000000000000000000000000000002';
+const BTC_PRIVATE_KEY = '0000000000000000000000000000000000000000000000000000000000000002';
 
-  describe('PoX-4 - Stacking operations P2SH-P2WPKH', () => {
+describe.each([P2SH_P2WPKH, P2WPKH, P2WSH, P2TR])(
+  'PoX-4 - Stack using bitcoin address %p',
+  addressSetup => {
     const account = testnetKeys[1];
-    let btcAddr: string;
-    let btcAddrDecoded: { version: number; data: Uint8Array };
-    let btcAddrRegtest: VerboseKeyOutput;
-    let btcPubKey: string;
 
-    test('P2SH-P2WPKH setup', async () => {
-      btcAddr = getBitcoinAddressFromKey({
-        privateKey: btcPrivateKey,
-        network: 'testnet',
-        addressFormat: 'p2sh-p2wpkh',
-      });
-      expect(btcAddr).toBe('2N74VLxyT79VGHiBK2zEg3a9HJG7rEc5F3o');
-      btcPubKey = privateToPublicKey(btcPrivateKey).toString('hex');
-      expect(btcPubKey).toBe('02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5');
+    let poxInfo: CoreRpcPoxInfo;
+    let burnBlockHeight: number;
+    let cycleBlockLength: number;
+    let contractAddress: string;
+    let contractName: string;
+    let ustxAmount: bigint;
+    const cycleCount = 1;
 
-      btcAddrDecoded = decodeBtcAddress(btcAddr);
-      expect({
-        data: Buffer.from(btcAddrDecoded.data).toString('hex'),
-        version: btcAddrDecoded.version,
-      }).toEqual({ data: '978a0121f9a24de65a13bab0c43c3a48be074eae', version: 1 });
+    const { btcAddr, btcAddrDecoded, btcAddrRegtest, btcDescriptor } = addressSetup();
 
-      // Create a regtest address to use with bitcoind json-rpc since the krypton-stacks-node uses testnet addresses
-      btcAddrRegtest = getBitcoinAddressFromKey({
-        privateKey: btcPrivateKey,
-        network: 'regtest',
-        addressFormat: 'p2sh-p2wpkh',
-        verbose: true,
-      });
-      expect(btcAddrRegtest.address).toBe('2N74VLxyT79VGHiBK2zEg3a9HJG7rEc5F3o');
+    test('prepare', async () => {
+      await standByForPoxCycle();
 
-      await testEnv.bitcoinRpcClient.importaddress({
-        address: btcAddrRegtest.address,
-        label: btcAddrRegtest.address,
-      });
-      // await testEnv.bitcoinRpcClient.importprivkey({
-      //   privkey: btcAddrRegtest.wif,
-      //   label: btcAddrRegtest.address,
-      //   rescan: false,
-      // });
-      const btcWalletAddrs = await testEnv.bitcoinRpcClient.getaddressesbylabel({
-        label: btcAddrRegtest.address,
-      });
-      expect(Object.keys(btcWalletAddrs)).toContain(btcAddrRegtest.address);
-
-      await standByForNextPoxCycle();
+      try {
+        // legacy wallets
+        await testEnv.bitcoinRpcClient.importaddress({
+          address: btcAddrRegtest,
+          label: btcAddrRegtest,
+        });
+        const btcWalletAddrs = await testEnv.bitcoinRpcClient.getaddressesbylabel({
+          label: btcAddrRegtest,
+        });
+        expect(Object.keys(btcWalletAddrs)).toContain(btcAddrRegtest);
+      } catch (e) {
+        // descriptor wallets, if legacy wallet import fails
+        await withDescriptorWallet(async walletName => {
+          const info = await testEnv.bitcoinRpcClient.getdescriptorinfo({
+            descriptor: btcDescriptor!,
+          });
+          const request = { label: btcAddrRegtest, desc: info.descriptor, timestamp: 'now' };
+          await testEnv.bitcoinRpcClient.rpc(
+            'importdescriptors',
+            { requests: [request] },
+            walletName
+          );
+        });
+      }
 
       poxInfo = await testEnv.client.getPox();
 
@@ -105,7 +98,7 @@ describe('PoX-4 - Stack using supported bitcoin address formats', () => {
           }), // pox-addr
           uintCV(burnBlockHeight), // start-burn-ht
           uintCV(cycleCount), // lock-period
-          bufferCV(hexToBytes('1'.padStart(66, '0'))), // signer-key
+          bufferCV(randomBytes(33)), // signer-key
         ],
         network: testEnv.stacksNetwork,
         anchorMode: AnchorMode.OnChainOnly,
@@ -204,248 +197,9 @@ describe('PoX-4 - Stack using supported bitcoin address formats', () => {
       });
       const vout = blockResult.tx
         .flatMap(t => t.vout)
-        .find(v => v?.value && v.scriptPubKey.address == btcAddrRegtest.address);
+        .find(v => v?.value && v.scriptPubKey.address == btcAddrRegtest);
       if (!vout?.value) {
         throw new Error(
-          `Could not find bitcoin vout for ${btcAddrRegtest.address} in block ${firstReward.burn_block_hash}`
-        );
-      }
-      const sats = new bignumber(vout.value).shiftedBy(8).toString();
-      expect(sats).toBe(firstReward.reward_amount);
-    });
-
-    test('stacking rewards - BTC JSON-RPC - listtransactions', async () => {
-      const rewards = await fetchGet<BurnchainRewardListResponse>(
-        `/extended/v1/burnchain/rewards/${btcAddr}`
-      );
-      const firstReward = rewards.results.sort(
-        (a, b) => a.burn_block_height - b.burn_block_height
-      )[0];
-
-      let received: {
-        address: string;
-        category: string;
-        amount: number;
-        blockhash: string;
-        blockheight: number;
-      }[] = await testEnv.bitcoinRpcClient.listtransactions({
-        label: btcAddrRegtest.address,
-        include_watchonly: true,
-      });
-      received = received.filter(r => r.address === btcAddrRegtest.address);
-      expect(received.length).toBe(1);
-      expect(received[0].category).toBe('receive');
-      expect(received[0].blockhash).toBe(hexToBuffer(firstReward.burn_block_hash).toString('hex'));
-      const sats = new bignumber(received[0].amount).shiftedBy(8).toString();
-      expect(sats).toBe(firstReward.reward_amount);
-    });
-
-    test('stx unlocked - RPC balance endpoint', async () => {
-      // Wait until account has unlocked (finished Stacking cycles)
-      const rpcAccountInfo1 = await testEnv.client.getAccount(account.stacksAddress);
-      const burnBlockUnlockHeight = rpcAccountInfo1.unlock_height + 1;
-      await standByUntilBurnBlock(burnBlockUnlockHeight);
-
-      // Check that STX are no longer reported as locked by the RPC endpoints:
-      const rpcAccountInfo = await testEnv.client.getAccount(account.stacksAddress);
-      expect(BigInt(rpcAccountInfo.locked)).toBe(0n);
-      expect(rpcAccountInfo.unlock_height).toBe(0);
-    });
-
-    test('stx unlocked - API balance endpoint', async () => {
-      // Check that STX are no longer reported as locked by the API endpoints:
-      const addrBalance = await fetchGet<AddressStxBalanceResponse>(
-        `/extended/v1/address/${account.stacksAddress}/stx`
-      );
-      expect(BigInt(addrBalance.locked)).toBe(0n);
-      expect(addrBalance.burnchain_unlock_height).toBe(0);
-      expect(addrBalance.lock_height).toBe(0);
-      expect(addrBalance.lock_tx_id).toBe('');
-    });
-
-    test('BTC stacking reward received', async () => {
-      const received: number = await testEnv.bitcoinRpcClient.getreceivedbyaddress({
-        address: btcAddrRegtest.address,
-        minconf: 0,
-      });
-      expect(received).toBeGreaterThan(0);
-    });
-  });
-
-  describe('PoX-4 - Stacking operations P2WPKH', () => {
-    const account = testnetKeys[1];
-    let btcAddr: string;
-    let btcAddrDecoded: { version: number; data: Uint8Array };
-    let btcPubKey: string;
-    let btcAddrRegtest: string;
-
-    test('P2WPKH setup', async () => {
-      btcAddr = getBitcoinAddressFromKey({
-        privateKey: btcPrivateKey,
-        network: 'testnet',
-        addressFormat: 'p2wpkh',
-      });
-      expect(btcAddr).toBe('tb1qq6hag67dl53wl99vzg42z8eyzfz2xlkvvlryfj');
-      btcPubKey = privateToPublicKey(btcPrivateKey).toString('hex');
-      expect(btcPubKey).toBe('02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5');
-
-      btcAddrDecoded = decodeBtcAddress(btcAddr);
-      expect({
-        data: Buffer.from(btcAddrDecoded.data).toString('hex'),
-        version: btcAddrDecoded.version,
-      }).toEqual({ data: '06afd46bcdfd22ef94ac122aa11f241244a37ecc', version: 4 });
-
-      // Create a regtest address to use with bitcoind json-rpc since the krypton-stacks-node uses testnet addresses
-      btcAddrRegtest = getBitcoinAddressFromKey({
-        privateKey: btcPrivateKey,
-        network: 'regtest',
-        addressFormat: 'p2wpkh',
-      });
-      expect(btcAddrRegtest).toBe('bcrt1qq6hag67dl53wl99vzg42z8eyzfz2xlkvwk6f7m');
-
-      await testEnv.bitcoinRpcClient.importaddress({
-        address: btcAddrRegtest,
-        label: btcAddrRegtest,
-      });
-      const btcWalletAddrs = await testEnv.bitcoinRpcClient.getaddressesbylabel({
-        label: btcAddrRegtest,
-      });
-      expect(Object.keys(btcWalletAddrs)).toContain(btcAddrRegtest);
-
-      // If we're close to or in the prepare phase, wait until until the start of the next cycle
-      // if ((await testEnv.client.getPox()).next_cycle.blocks_until_prepare_phase <= 20) {
-      if (true) {
-        await standByForNextPoxCycle();
-      }
-
-      poxInfo = await testEnv.client.getPox();
-
-      burnBlockHeight = poxInfo.current_burnchain_block_height as number;
-      ustxAmount = BigInt(Math.round(Number(poxInfo.min_amount_ustx) * 1.1).toString());
-      cycleBlockLength = cycleCount * poxInfo.reward_cycle_length;
-      [contractAddress, contractName] = poxInfo.contract_id.split('.');
-
-      expect(contractName).toBe('pox-4');
-    });
-
-    test('stack-stx tx', async () => {
-      // Create and broadcast a `stack-stx` tx
-      const tx1 = await makeContractCall({
-        senderKey: account.secretKey,
-        contractAddress,
-        contractName,
-        functionName: 'stack-stx',
-        functionArgs: [
-          uintCV(ustxAmount.toString()), // amount-ustx
-          tupleCV({
-            hashbytes: bufferCV(btcAddrDecoded.data),
-            version: bufferCV(Buffer.from([btcAddrDecoded.version])),
-          }), // pox-addr
-          uintCV(burnBlockHeight), // start-burn-ht
-          uintCV(cycleCount), // lock-period
-          bufferCV(hexToBytes('2'.padStart(66, '0'))), // signer-key
-        ],
-        network: testEnv.stacksNetwork,
-        anchorMode: AnchorMode.OnChainOnly,
-        fee: 10000,
-        validateWithAbi: false,
-      });
-      const expectedTxId1 = '0x' + tx1.txid();
-      const sendResult1 = await testEnv.client.sendTransaction(Buffer.from(tx1.serialize()));
-      expect(sendResult1.txId).toBe(expectedTxId1);
-
-      // Wait for API to receive and ingest tx
-      const dbTx1 = await standByForTxSuccess(expectedTxId1);
-
-      const tx1Events = await testEnv.api.datastore.getTxEvents({
-        txId: expectedTxId1,
-        indexBlockHash: dbTx1.index_block_hash,
-        limit: 99999,
-        offset: 0,
-      });
-      expect(tx1Events.results).toBeTruthy();
-      const lockEvent1 = tx1Events.results.find(
-        r => r.event_type === DbEventTypeId.StxLock
-      ) as DbStxLockEvent;
-      expect(lockEvent1).toBeDefined();
-      expect(lockEvent1.locked_address).toBe(account.stacksAddress);
-      expect(lockEvent1.locked_amount).toBe(ustxAmount);
-
-      // Test that the unlock height event data in the API db matches the expected height from the
-      // calculated values from the /v2/pox data and the cycle count specified in the `stack-stx` tx.
-      const expectedUnlockHeight1 =
-        cycleBlockLength + poxInfo.next_cycle.reward_phase_start_block_height;
-      expect(lockEvent1.unlock_height).toBe(expectedUnlockHeight1);
-
-      // Test the API address balance data after a `stack-stx` operation
-      const addrBalance1 = await fetchGet<AddressStxBalanceResponse>(
-        `/extended/v1/address/${account.stacksAddress}/stx`
-      );
-      expect(addrBalance1.locked).toBe(ustxAmount.toString());
-      expect(addrBalance1.burnchain_unlock_height).toBe(expectedUnlockHeight1);
-      expect(addrBalance1.lock_height).toBe(dbTx1.block_height);
-      expect(addrBalance1.lock_tx_id).toBe(dbTx1.tx_id);
-    });
-
-    test('stacking rewards - API /burnchain/reward_slot_holders', async () => {
-      const prepareStart = poxInfo.next_cycle.prepare_phase_start_block_height;
-      const prepareEnd = prepareStart + poxInfo.prepare_phase_block_length;
-
-      await standByUntilBurnBlock(prepareEnd + 1);
-
-      const rewardSlotHolders = await fetchGet<BurnchainRewardSlotHolderListResponse>(
-        `/extended/v1/burnchain/reward_slot_holders/${btcAddr}`
-      );
-      expect(rewardSlotHolders.total).toBe(1);
-      expect(rewardSlotHolders.results[0].address).toBe(btcAddr);
-      expect(rewardSlotHolders.results[0].burn_block_height).toBeGreaterThanOrEqual(prepareStart);
-      expect(rewardSlotHolders.results[0].burn_block_height).toBeLessThanOrEqual(prepareEnd);
-    });
-
-    test('stacking rewards - API /burnchain/rewards', async () => {
-      await standByUntilBurnBlock(poxInfo.next_cycle.reward_phase_start_block_height + 2);
-
-      const rewards = await fetchGet<BurnchainRewardListResponse>(
-        `/extended/v1/burnchain/rewards/${btcAddr}`
-      );
-      const firstReward = rewards.results.sort(
-        (a, b) => a.burn_block_height - b.burn_block_height
-      )[0];
-      expect(rewards.results.length).toBe(1);
-      expect(firstReward.reward_recipient).toBe(btcAddr);
-      expect(Number(firstReward.burn_amount)).toBeGreaterThan(0);
-      expect(firstReward.burn_block_height).toBeGreaterThanOrEqual(
-        poxInfo.next_cycle.reward_phase_start_block_height
-      );
-      expect(firstReward.burn_block_height).toBeLessThanOrEqual(
-        poxInfo.next_cycle.reward_phase_start_block_height + 2
-      );
-
-      const rewardsTotal = await fetchGet<BurnchainRewardsTotal>(
-        `/extended/v1/burnchain/rewards/${btcAddr}/total`
-      );
-      expect(rewardsTotal.reward_recipient).toBe(btcAddr);
-      expect(Number(rewardsTotal.reward_amount)).toBeGreaterThan(0);
-    });
-
-    test('stacking rewards - BTC JSON-RPC', async () => {
-      const rewards = await fetchGet<BurnchainRewardListResponse>(
-        `/extended/v1/burnchain/rewards/${btcAddr}`
-      );
-      const firstReward = rewards.results.sort(
-        (a, b) => a.burn_block_height - b.burn_block_height
-      )[0];
-      const blockResult: {
-        tx: { vout?: { scriptPubKey: { address?: string }; value?: number }[] }[];
-      } = await testEnv.bitcoinRpcClient.getblock({
-        blockhash: hexToBuffer(firstReward.burn_block_hash).toString('hex'),
-        verbosity: 2,
-      });
-      const vout = blockResult.tx
-        .flatMap(t => t.vout)
-        .find(v => v?.value && v.scriptPubKey.address == btcAddrRegtest);
-      if (!vout || !vout.value) {
-        throw new Error(
           `Could not find bitcoin vout for ${btcAddrRegtest} in block ${firstReward.burn_block_hash}`
         );
       }
@@ -461,23 +215,27 @@ describe('PoX-4 - Stack using supported bitcoin address formats', () => {
         (a, b) => a.burn_block_height - b.burn_block_height
       )[0];
 
-      let received: {
-        address: string;
-        category: string;
-        amount: number;
-        blockhash: string;
-        blockheight: number;
-        txid: string;
-        confirmations: number;
-      }[] = await testEnv.bitcoinRpcClient.listtransactions({
-        label: btcAddrRegtest,
-        include_watchonly: true,
-      });
-      received = received.filter(r => r.address === btcAddrRegtest);
-      expect(received.length).toBe(1);
-      expect(received[0].category).toBe('receive');
-      expect(received[0].blockhash).toBe(hexToBuffer(firstReward.burn_block_hash).toString('hex'));
-      const sats = new bignumber(received[0].amount).shiftedBy(8).toString();
+      let txs = await withDescriptorWallet(
+        async walletName =>
+          (await testEnv.bitcoinRpcClient.listtransactions(
+            {
+              label: btcAddrRegtest,
+              include_watchonly: true,
+            },
+            btcDescriptor ? walletName : undefined
+          )) as {
+            address: string;
+            category: string;
+            amount: number;
+            blockhash: string;
+            blockheight: number;
+          }[]
+      );
+      txs = txs.filter(r => r.address === btcAddrRegtest);
+      expect(txs.length).toBe(1);
+      expect(txs[0].category).toBe('receive');
+      expect(txs[0].blockhash).toBe(hexToBuffer(firstReward.burn_block_hash).toString('hex'));
+      const sats = new bignumber(txs[0].amount).shiftedBy(8).toString();
       expect(sats).toBe(firstReward.reward_amount);
     });
 
@@ -505,501 +263,177 @@ describe('PoX-4 - Stack using supported bitcoin address formats', () => {
     });
 
     test('BTC stacking reward received', async () => {
-      const received: number = await testEnv.bitcoinRpcClient.getreceivedbyaddress({
-        address: btcAddrRegtest,
-        minconf: 0,
-      });
+      const received = await withDescriptorWallet(
+        async walletName =>
+          (await testEnv.bitcoinRpcClient.getreceivedbyaddress(
+            {
+              address: btcAddrRegtest,
+              minconf: 0,
+            },
+            btcDescriptor ? walletName : undefined
+          )) as number
+      );
       expect(received).toBeGreaterThan(0);
     });
+  }
+);
+
+function P2SH_P2WPKH() {
+  const btcAddr = getBitcoinAddressFromKey({
+    privateKey: BTC_PRIVATE_KEY,
+    network: 'testnet',
+    addressFormat: 'p2sh-p2wpkh',
+  });
+  expect(btcAddr).toBe('2N74VLxyT79VGHiBK2zEg3a9HJG7rEc5F3o');
+  const btcPubKey = privateToPublicKey(BTC_PRIVATE_KEY).toString('hex');
+  expect(btcPubKey).toBe('02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5');
+
+  const btcAddrDecoded = decodeBtcAddress(btcAddr);
+  expect({
+    data: Buffer.from(btcAddrDecoded.data).toString('hex'),
+    version: btcAddrDecoded.version,
+  }).toEqual({ data: '978a0121f9a24de65a13bab0c43c3a48be074eae', version: 1 });
+
+  // Create a regtest address to use with bitcoind json-rpc since the krypton-stacks-node uses testnet addresses
+  const btcAddrRegtest = getBitcoinAddressFromKey({
+    privateKey: BTC_PRIVATE_KEY,
+    network: 'regtest',
+    addressFormat: 'p2sh-p2wpkh',
+  });
+  expect(btcAddrRegtest).toBe('2N74VLxyT79VGHiBK2zEg3a9HJG7rEc5F3o');
+
+  return {
+    btcAddr,
+    btcAddrDecoded,
+    btcAddrRegtest,
+    btcPubKey,
+    btcDescriptor: undefined,
+  };
+}
+
+function P2WSH() {
+  const btcAddr = getBitcoinAddressFromKey({
+    privateKey: BTC_PRIVATE_KEY,
+    network: 'testnet',
+    addressFormat: 'p2wsh',
+  });
+  expect(btcAddr).toBe('tb1q4qp0380kg75cqv25k4zruwa87wefwz0uefv78jekagm2j8568rwqvz7llf');
+  const btcPubKey = privateToPublicKey(BTC_PRIVATE_KEY).toString('hex');
+  expect(btcPubKey).toBe('02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5');
+
+  const btcAddrDecoded = decodeBtcAddress(btcAddr);
+  expect({
+    data: Buffer.from(btcAddrDecoded.data).toString('hex'),
+    version: btcAddrDecoded.version,
+  }).toEqual({
+    data: 'a802f89df647a9803154b5443e3ba7f3b29709fcca59e3cb36ea36a91e9a38dc',
+    version: 5,
   });
 
-  describe('PoX-4 - Stacking operations P2WSH', () => {
-    const account = testnetKeys[1];
-    let btcAddr: string;
-    let btcAddrDecoded: { version: number; data: Uint8Array };
-    let btcPubKey: string;
-    let btcAddrRegtest: string;
+  // Create a regtest address to use with bitcoind json-rpc since the krypton-stacks-node uses testnet addresses
+  const btcAddrRegtest = getBitcoinAddressFromKey({
+    privateKey: BTC_PRIVATE_KEY,
+    network: 'regtest',
+    addressFormat: 'p2wsh',
+  });
+  expect(btcAddrRegtest).toBe('bcrt1q4qp0380kg75cqv25k4zruwa87wefwz0uefv78jekagm2j8568rwqpm5e2n');
 
-    test('P2WSH setup', async () => {
-      btcAddr = getBitcoinAddressFromKey({
-        privateKey: btcPrivateKey,
-        network: 'testnet',
-        addressFormat: 'p2wsh',
-      });
-      expect(btcAddr).toBe('tb1q4qp0380kg75cqv25k4zruwa87wefwz0uefv78jekagm2j8568rwqvz7llf');
-      btcPubKey = privateToPublicKey(btcPrivateKey).toString('hex');
-      expect(btcPubKey).toBe('02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5');
+  return {
+    btcAddr,
+    btcAddrDecoded,
+    btcAddrRegtest,
+    btcPubKey,
+    btcDescriptor: undefined,
+  };
+}
 
-      btcAddrDecoded = decodeBtcAddress(btcAddr);
-      expect({
-        data: Buffer.from(btcAddrDecoded.data).toString('hex'),
-        version: btcAddrDecoded.version,
-      }).toEqual({
-        data: 'a802f89df647a9803154b5443e3ba7f3b29709fcca59e3cb36ea36a91e9a38dc',
-        version: 5,
-      });
+function P2WPKH() {
+  const btcAddr = getBitcoinAddressFromKey({
+    privateKey: BTC_PRIVATE_KEY,
+    network: 'testnet',
+    addressFormat: 'p2wpkh',
+  });
+  expect(btcAddr).toBe('tb1qq6hag67dl53wl99vzg42z8eyzfz2xlkvvlryfj');
+  const btcPubKey = privateToPublicKey(BTC_PRIVATE_KEY).toString('hex');
+  expect(btcPubKey).toBe('02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5');
 
-      // Create a regtest address to use with bitcoind json-rpc since the krypton-stacks-node uses testnet addresses
-      btcAddrRegtest = getBitcoinAddressFromKey({
-        privateKey: btcPrivateKey,
-        network: 'regtest',
-        addressFormat: 'p2wsh',
-      });
-      expect(btcAddrRegtest).toBe(
-        'bcrt1q4qp0380kg75cqv25k4zruwa87wefwz0uefv78jekagm2j8568rwqpm5e2n'
-      );
+  const btcAddrDecoded = decodeBtcAddress(btcAddr);
+  expect({
+    data: Buffer.from(btcAddrDecoded.data).toString('hex'),
+    version: btcAddrDecoded.version,
+  }).toEqual({ data: '06afd46bcdfd22ef94ac122aa11f241244a37ecc', version: 4 });
 
-      await testEnv.bitcoinRpcClient.importaddress({
-        address: btcAddrRegtest,
-        label: btcAddrRegtest,
-      });
-      const btcWalletAddrs = await testEnv.bitcoinRpcClient.getaddressesbylabel({
-        label: btcAddrRegtest,
-      });
-      expect(Object.keys(btcWalletAddrs)).toContain(btcAddrRegtest);
+  // Create a regtest address to use with bitcoind json-rpc since the krypton-stacks-node uses testnet addresses
+  const btcAddrRegtest = getBitcoinAddressFromKey({
+    privateKey: BTC_PRIVATE_KEY,
+    network: 'regtest',
+    addressFormat: 'p2wpkh',
+  });
+  expect(btcAddrRegtest).toBe('bcrt1qq6hag67dl53wl99vzg42z8eyzfz2xlkvwk6f7m');
 
-      // If we're close to or in the prepare phase, wait until until the start of the next cycle
-      // if ((await testEnv.client.getPox()).next_cycle.blocks_until_prepare_phase <= 20) {
-      if (true) {
-        await standByForNextPoxCycle();
-      }
+  return {
+    btcAddr,
+    btcAddrDecoded,
+    btcAddrRegtest,
+    btcPubKey,
+    btcDescriptor: undefined,
+  };
+}
 
-      poxInfo = await testEnv.client.getPox();
+function P2TR() {
+  const btcAddr = getBitcoinAddressFromKey({
+    privateKey: BTC_PRIVATE_KEY,
+    network: 'testnet',
+    addressFormat: 'p2tr',
+  });
+  expect(btcAddr).toBe('tb1pet7ep3czdu9k4wvdlz2fp5p8x2yp7t6ttyqg2c6cmh0lgeuu9lasvfnc28');
+  const btcPubKey = privateToPublicKey(BTC_PRIVATE_KEY).toString('hex');
+  expect(btcPubKey).toBe('02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5');
 
-      burnBlockHeight = poxInfo.current_burnchain_block_height as number;
-      ustxAmount = BigInt(Math.round(Number(poxInfo.min_amount_ustx) * 1.1).toString());
-      cycleBlockLength = cycleCount * poxInfo.reward_cycle_length;
-      [contractAddress, contractName] = poxInfo.contract_id.split('.');
-
-      expect(contractName).toBe('pox-4');
-    });
-
-    test('stack-stx tx', async () => {
-      // Create and broadcast a `stack-stx` tx
-      const tx1 = await makeContractCall({
-        senderKey: account.secretKey,
-        contractAddress,
-        contractName,
-        functionName: 'stack-stx',
-        functionArgs: [
-          uintCV(ustxAmount.toString()), // amount-ustx
-          tupleCV({
-            hashbytes: bufferCV(btcAddrDecoded.data),
-            version: bufferCV(Buffer.from([btcAddrDecoded.version])),
-          }), // pox-addr
-          uintCV(burnBlockHeight), // start-burn-ht
-          uintCV(cycleCount), // lock-period
-          bufferCV(hexToBytes('3'.padStart(66, '0'))), // signer-key
-        ],
-        network: testEnv.stacksNetwork,
-        anchorMode: AnchorMode.OnChainOnly,
-        fee: 10000,
-        validateWithAbi: false,
-      });
-      const expectedTxId1 = '0x' + tx1.txid();
-      const sendResult1 = await testEnv.client.sendTransaction(Buffer.from(tx1.serialize()));
-      expect(sendResult1.txId).toBe(expectedTxId1);
-
-      // Wait for API to receive and ingest tx
-      const dbTx1 = await standByForTxSuccess(expectedTxId1);
-
-      const tx1Events = await testEnv.api.datastore.getTxEvents({
-        txId: expectedTxId1,
-        indexBlockHash: dbTx1.index_block_hash,
-        limit: 99999,
-        offset: 0,
-      });
-      expect(tx1Events.results).toBeTruthy();
-      const lockEvent1 = tx1Events.results.find(
-        r => r.event_type === DbEventTypeId.StxLock
-      ) as DbStxLockEvent;
-      expect(lockEvent1).toBeDefined();
-      expect(lockEvent1.locked_address).toBe(account.stacksAddress);
-      expect(lockEvent1.locked_amount).toBe(ustxAmount);
-
-      // Test that the unlock height event data in the API db matches the expected height from the
-      // calculated values from the /v2/pox data and the cycle count specified in the `stack-stx` tx.
-      const expectedUnlockHeight1 =
-        cycleBlockLength + poxInfo.next_cycle.reward_phase_start_block_height;
-      expect(lockEvent1.unlock_height).toBe(expectedUnlockHeight1);
-
-      // Test the API address balance data after a `stack-stx` operation
-      const addrBalance1 = await fetchGet<AddressStxBalanceResponse>(
-        `/extended/v1/address/${account.stacksAddress}/stx`
-      );
-      expect(addrBalance1.locked).toBe(ustxAmount.toString());
-      expect(addrBalance1.burnchain_unlock_height).toBe(expectedUnlockHeight1);
-      expect(addrBalance1.lock_height).toBe(dbTx1.block_height);
-      expect(addrBalance1.lock_tx_id).toBe(dbTx1.tx_id);
-    });
-
-    test('stacking rewards - API /burnchain/reward_slot_holders', async () => {
-      const prepareStart = poxInfo.next_cycle.prepare_phase_start_block_height;
-      const prepareEnd = prepareStart + poxInfo.prepare_phase_block_length;
-
-      await standByUntilBurnBlock(prepareEnd + 1);
-
-      const rewardSlotHolders = await fetchGet<BurnchainRewardSlotHolderListResponse>(
-        `/extended/v1/burnchain/reward_slot_holders/${btcAddr}`
-      );
-      expect(rewardSlotHolders.total).toBe(1);
-      expect(rewardSlotHolders.results[0].address).toBe(btcAddr);
-      expect(rewardSlotHolders.results[0].burn_block_height).toBeGreaterThanOrEqual(prepareStart);
-      expect(rewardSlotHolders.results[0].burn_block_height).toBeLessThanOrEqual(prepareEnd);
-    });
-
-    test('stacking rewards - API /burnchain/rewards', async () => {
-      await standByUntilBurnBlock(poxInfo.next_cycle.reward_phase_start_block_height + 2);
-
-      const rewards = await fetchGet<BurnchainRewardListResponse>(
-        `/extended/v1/burnchain/rewards/${btcAddr}`
-      );
-      const firstReward = rewards.results.sort(
-        (a, b) => a.burn_block_height - b.burn_block_height
-      )[0];
-      expect(firstReward.reward_recipient).toBe(btcAddr);
-      expect(Number(firstReward.burn_amount)).toBeGreaterThan(0);
-      expect(firstReward.burn_block_height).toBeGreaterThanOrEqual(
-        poxInfo.next_cycle.reward_phase_start_block_height
-      );
-      expect(firstReward.burn_block_height).toBeLessThanOrEqual(
-        poxInfo.next_cycle.reward_phase_start_block_height + 2
-      );
-
-      const rewardsTotal = await fetchGet<BurnchainRewardsTotal>(
-        `/extended/v1/burnchain/rewards/${btcAddr}/total`
-      );
-      expect(rewardsTotal.reward_recipient).toBe(btcAddr);
-      expect(Number(rewardsTotal.reward_amount)).toBeGreaterThan(0);
-    });
-
-    test('stacking rewards - BTC JSON-RPC', async () => {
-      const rewards = await fetchGet<BurnchainRewardListResponse>(
-        `/extended/v1/burnchain/rewards/${btcAddr}`
-      );
-      const firstReward = rewards.results.sort(
-        (a, b) => a.burn_block_height - b.burn_block_height
-      )[0];
-      const blockResult: {
-        tx: { vout?: { scriptPubKey: { address?: string }; value?: number }[] }[];
-      } = await testEnv.bitcoinRpcClient.getblock({
-        blockhash: hexToBuffer(firstReward.burn_block_hash).toString('hex'),
-        verbosity: 2,
-      });
-      const vout = blockResult.tx
-        .flatMap(t => t.vout)
-        .find(v => v?.value && v.scriptPubKey.address == btcAddrRegtest);
-      if (!vout || !vout.value) {
-        throw new Error(
-          `Could not find bitcoin vout for ${btcAddrRegtest} in block ${firstReward.burn_block_hash}`
-        );
-      }
-      const sats = new bignumber(vout.value).shiftedBy(8).toString();
-      expect(sats).toBe(firstReward.reward_amount);
-    });
-
-    test('stacking rewards - BTC JSON-RPC - listtransactions', async () => {
-      const rewards = await fetchGet<BurnchainRewardListResponse>(
-        `/extended/v1/burnchain/rewards/${btcAddr}`
-      );
-      const firstReward = rewards.results.sort(
-        (a, b) => a.burn_block_height - b.burn_block_height
-      )[0];
-
-      let received: {
-        address: string;
-        category: string;
-        amount: number;
-        blockhash: string;
-        blockheight: number;
-        txid: string;
-        confirmations: number;
-      }[] = await testEnv.bitcoinRpcClient.listtransactions({
-        label: btcAddrRegtest,
-        include_watchonly: true,
-      });
-      received = received.filter(r => r.address === btcAddrRegtest);
-      expect(received.length).toBe(1);
-      expect(received[0].category).toBe('receive');
-      expect(received[0].blockhash).toBe(hexToBuffer(firstReward.burn_block_hash).toString('hex'));
-      const sats = new bignumber(received[0].amount).shiftedBy(8).toString();
-      expect(sats).toBe(firstReward.reward_amount);
-    });
-
-    test('stx unlocked - RPC balance endpoint', async () => {
-      // Wait until account has unlocked (finished Stacking cycles)
-      const rpcAccountInfo1 = await testEnv.client.getAccount(account.stacksAddress);
-      const burnBlockUnlockHeight = rpcAccountInfo1.unlock_height + 1;
-      await standByUntilBurnBlock(burnBlockUnlockHeight);
-
-      // Check that STX are no longer reported as locked by the RPC endpoints:
-      const rpcAccountInfo = await testEnv.client.getAccount(account.stacksAddress);
-      expect(BigInt(rpcAccountInfo.locked)).toBe(0n);
-      expect(rpcAccountInfo.unlock_height).toBe(0);
-    });
-
-    test('stx unlocked - API balance endpoint', async () => {
-      // Check that STX are no longer reported as locked by the API endpoints:
-      const addrBalance = await fetchGet<AddressStxBalanceResponse>(
-        `/extended/v1/address/${account.stacksAddress}/stx`
-      );
-      expect(BigInt(addrBalance.locked)).toBe(0n);
-      expect(addrBalance.burnchain_unlock_height).toBe(0);
-      expect(addrBalance.lock_height).toBe(0);
-      expect(addrBalance.lock_tx_id).toBe('');
-    });
-
-    test('BTC stacking reward received', async () => {
-      const received: number = await testEnv.bitcoinRpcClient.getreceivedbyaddress({
-        address: btcAddrRegtest,
-        minconf: 0,
-      });
-      expect(received).toBeGreaterThan(0);
-    });
+  const btcAddrDecoded = decodeBtcAddress(btcAddr);
+  expect({
+    data: Buffer.from(btcAddrDecoded.data).toString('hex'),
+    version: btcAddrDecoded.version,
+  }).toEqual({
+    data: 'cafd90c7026f0b6ab98df89490d02732881f2f4b5900856358dddff4679c2ffb',
+    version: 6,
   });
 
-  describe('PoX-4 - Stacking operations P2TR', () => {
-    const account = testnetKeys[1];
-    let btcAddr: string;
-    let btcAddrDecoded: { version: number; data: Uint8Array };
-    let btcPubKey: string;
-    let btcAddrRegtest: string;
-
-    test('P2TR setup', async () => {
-      btcAddr = getBitcoinAddressFromKey({
-        privateKey: btcPrivateKey,
-        network: 'testnet',
-        addressFormat: 'p2tr',
-      });
-      expect(btcAddr).toBe('tb1pet7ep3czdu9k4wvdlz2fp5p8x2yp7t6ttyqg2c6cmh0lgeuu9lasvfnc28');
-      btcPubKey = privateToPublicKey(btcPrivateKey).toString('hex');
-      expect(btcPubKey).toBe('02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5');
-
-      btcAddrDecoded = decodeBtcAddress(btcAddr);
-      expect({
-        data: Buffer.from(btcAddrDecoded.data).toString('hex'),
-        version: btcAddrDecoded.version,
-      }).toEqual({
-        data: 'cafd90c7026f0b6ab98df89490d02732881f2f4b5900856358dddff4679c2ffb',
-        version: 6,
-      });
-
-      // Create a regtest address to use with bitcoind json-rpc since the krypton-stacks-node uses testnet addresses
-      btcAddrRegtest = getBitcoinAddressFromKey({
-        privateKey: btcPrivateKey,
-        network: 'regtest',
-        addressFormat: 'p2tr',
-      });
-      expect(btcAddrRegtest).toBe(
-        'bcrt1pet7ep3czdu9k4wvdlz2fp5p8x2yp7t6ttyqg2c6cmh0lgeuu9laspse7la'
-      );
-
-      await testEnv.bitcoinRpcClient.importaddress({
-        address: btcAddrRegtest,
-        label: btcAddrRegtest,
-      });
-      const btcWalletAddrs = await testEnv.bitcoinRpcClient.getaddressesbylabel({
-        label: btcAddrRegtest,
-      });
-      expect(Object.keys(btcWalletAddrs)).toContain(btcAddrRegtest);
-
-      // If we're close to or in the prepare phase, wait until until the start of the next cycle
-      // if ((await testEnv.client.getPox()).next_cycle.blocks_until_prepare_phase <= 20) {
-      if (true) {
-        await standByForNextPoxCycle();
-      }
-
-      poxInfo = await testEnv.client.getPox();
-
-      burnBlockHeight = poxInfo.current_burnchain_block_height as number;
-      ustxAmount = BigInt(Math.round(Number(poxInfo.min_amount_ustx) * 1.1).toString());
-      cycleBlockLength = cycleCount * poxInfo.reward_cycle_length;
-      [contractAddress, contractName] = poxInfo.contract_id.split('.');
-
-      expect(contractName).toBe('pox-4');
-    });
-
-    test('stack-stx tx', async () => {
-      // Create and broadcast a `stack-stx` tx
-      const tx1 = await makeContractCall({
-        senderKey: account.secretKey,
-        contractAddress,
-        contractName,
-        functionName: 'stack-stx',
-        functionArgs: [
-          uintCV(ustxAmount.toString()), // amount-ustx
-          tupleCV({
-            hashbytes: bufferCV(btcAddrDecoded.data),
-            version: bufferCV(Buffer.from([btcAddrDecoded.version])),
-          }), // pox-addr
-          uintCV(burnBlockHeight), // start-burn-ht
-          uintCV(cycleCount), // lock-period
-          bufferCV(hexToBytes('4'.padStart(66, '0'))), // signer-key
-        ],
-        network: testEnv.stacksNetwork,
-        anchorMode: AnchorMode.OnChainOnly,
-        fee: 10000,
-        validateWithAbi: false,
-      });
-      const expectedTxId1 = '0x' + tx1.txid();
-      const sendResult1 = await testEnv.client.sendTransaction(Buffer.from(tx1.serialize()));
-      expect(sendResult1.txId).toBe(expectedTxId1);
-
-      // Wait for API to receive and ingest tx
-      const dbTx1 = await standByForTxSuccess(expectedTxId1);
-
-      const tx1Events = await testEnv.api.datastore.getTxEvents({
-        txId: expectedTxId1,
-        indexBlockHash: dbTx1.index_block_hash,
-        limit: 99999,
-        offset: 0,
-      });
-      expect(tx1Events.results).toBeTruthy();
-      const lockEvent1 = tx1Events.results.find(
-        r => r.event_type === DbEventTypeId.StxLock
-      ) as DbStxLockEvent;
-      expect(lockEvent1).toBeDefined();
-      expect(lockEvent1.locked_address).toBe(account.stacksAddress);
-      expect(lockEvent1.locked_amount).toBe(ustxAmount);
-
-      // Test that the unlock height event data in the API db matches the expected height from the
-      // calculated values from the /v2/pox data and the cycle count specified in the `stack-stx` tx.
-      const expectedUnlockHeight1 =
-        cycleBlockLength + poxInfo.next_cycle.reward_phase_start_block_height;
-      expect(lockEvent1.unlock_height).toBe(expectedUnlockHeight1);
-
-      // Test the API address balance data after a `stack-stx` operation
-      const addrBalance1 = await fetchGet<AddressStxBalanceResponse>(
-        `/extended/v1/address/${account.stacksAddress}/stx`
-      );
-      expect(addrBalance1.locked).toBe(ustxAmount.toString());
-      expect(addrBalance1.burnchain_unlock_height).toBe(expectedUnlockHeight1);
-      expect(addrBalance1.lock_height).toBe(dbTx1.block_height);
-      expect(addrBalance1.lock_tx_id).toBe(dbTx1.tx_id);
-    });
-
-    test('stacking rewards - API /burnchain/reward_slot_holders', async () => {
-      const prepareStart = poxInfo.next_cycle.prepare_phase_start_block_height;
-      const prepareEnd = prepareStart + poxInfo.prepare_phase_block_length;
-
-      await standByUntilBurnBlock(prepareEnd + 1);
-
-      const rewardSlotHolders = await fetchGet<BurnchainRewardSlotHolderListResponse>(
-        `/extended/v1/burnchain/reward_slot_holders/${btcAddr}`
-      );
-      expect(rewardSlotHolders.total).toBe(1);
-      expect(rewardSlotHolders.results[0].address).toBe(btcAddr);
-      expect(rewardSlotHolders.results[0].burn_block_height).toBeGreaterThanOrEqual(prepareStart);
-      expect(rewardSlotHolders.results[0].burn_block_height).toBeLessThanOrEqual(prepareEnd);
-    });
-
-    test('stacking rewards - API /burnchain/rewards', async () => {
-      await standByUntilBurnBlock(poxInfo.next_cycle.reward_phase_start_block_height + 2);
-
-      const rewards = await fetchGet<BurnchainRewardListResponse>(
-        `/extended/v1/burnchain/rewards/${btcAddr}`
-      );
-      const firstReward = rewards.results.sort(
-        (a, b) => a.burn_block_height - b.burn_block_height
-      )[0];
-      expect(firstReward.reward_recipient).toBe(btcAddr);
-      expect(Number(firstReward.burn_amount)).toBeGreaterThan(0);
-      expect(firstReward.burn_block_height).toBeGreaterThanOrEqual(
-        poxInfo.next_cycle.reward_phase_start_block_height
-      );
-      expect(firstReward.burn_block_height).toBeLessThanOrEqual(
-        poxInfo.next_cycle.reward_phase_start_block_height + 2
-      );
-
-      const rewardsTotal = await fetchGet<BurnchainRewardsTotal>(
-        `/extended/v1/burnchain/rewards/${btcAddr}/total`
-      );
-      expect(rewardsTotal.reward_recipient).toBe(btcAddr);
-      expect(Number(rewardsTotal.reward_amount)).toBeGreaterThan(0);
-    });
-
-    test('stacking rewards - BTC JSON-RPC', async () => {
-      const rewards = await fetchGet<BurnchainRewardListResponse>(
-        `/extended/v1/burnchain/rewards/${btcAddr}`
-      );
-      const firstReward = rewards.results.sort(
-        (a, b) => a.burn_block_height - b.burn_block_height
-      )[0];
-      const blockResult: {
-        tx: { vout?: { scriptPubKey: { address?: string }; value?: number }[] }[];
-      } = await testEnv.bitcoinRpcClient.getblock({
-        blockhash: hexToBuffer(firstReward.burn_block_hash).toString('hex'),
-        verbosity: 2,
-      });
-      const vout = blockResult.tx
-        .flatMap(t => t.vout)
-        .find(v => v?.value && v.scriptPubKey.address == btcAddrRegtest);
-      if (!vout || !vout.value) {
-        throw new Error(
-          `Could not find bitcoin vout for ${btcAddrRegtest} in block ${firstReward.burn_block_hash}`
-        );
-      }
-      const sats = new bignumber(vout.value).shiftedBy(8).toString();
-      expect(sats).toBe(firstReward.reward_amount);
-    });
-
-    test('stacking rewards - BTC JSON-RPC - listtransactions', async () => {
-      const rewards = await fetchGet<BurnchainRewardListResponse>(
-        `/extended/v1/burnchain/rewards/${btcAddr}`
-      );
-      const firstReward = rewards.results.sort(
-        (a, b) => a.burn_block_height - b.burn_block_height
-      )[0];
-
-      let received: {
-        address: string;
-        category: string;
-        amount: number;
-        blockhash: string;
-        blockheight: number;
-        txid: string;
-        confirmations: number;
-      }[] = await testEnv.bitcoinRpcClient.listtransactions({
-        label: btcAddrRegtest,
-        include_watchonly: true,
-      });
-      received = received.filter(r => r.address === btcAddrRegtest);
-      expect(received.length).toBe(1);
-      expect(received[0].category).toBe('receive');
-      expect(received[0].blockhash).toBe(hexToBuffer(firstReward.burn_block_hash).toString('hex'));
-      const sats = new bignumber(received[0].amount).shiftedBy(8).toString();
-      expect(sats).toBe(firstReward.reward_amount);
-    });
-
-    test('stx unlocked - RPC balance endpoint', async () => {
-      // Wait until account has unlocked (finished Stacking cycles)
-      const rpcAccountInfo1 = await testEnv.client.getAccount(account.stacksAddress);
-      const burnBlockUnlockHeight = rpcAccountInfo1.unlock_height + 1;
-      await standByUntilBurnBlock(burnBlockUnlockHeight);
-
-      // Check that STX are no longer reported as locked by the RPC endpoints:
-      const rpcAccountInfo = await testEnv.client.getAccount(account.stacksAddress);
-      expect(BigInt(rpcAccountInfo.locked)).toBe(0n);
-      expect(rpcAccountInfo.unlock_height).toBe(0);
-    });
-
-    test('stx unlocked - API balance endpoint', async () => {
-      // Check that STX are no longer reported as locked by the API endpoints:
-      const addrBalance = await fetchGet<AddressStxBalanceResponse>(
-        `/extended/v1/address/${account.stacksAddress}/stx`
-      );
-      expect(BigInt(addrBalance.locked)).toBe(0n);
-      expect(addrBalance.burnchain_unlock_height).toBe(0);
-      expect(addrBalance.lock_height).toBe(0);
-      expect(addrBalance.lock_tx_id).toBe('');
-    });
-
-    test('BTC stacking reward received', async () => {
-      const received: number = await testEnv.bitcoinRpcClient.getreceivedbyaddress({
-        address: btcAddrRegtest,
-        minconf: 0,
-      });
-      expect(received).toBeGreaterThan(0);
-    });
+  // Create a regtest address to use with bitcoind json-rpc since the krypton-stacks-node uses testnet addresses
+  const btcAddrRegtest = getBitcoinAddressFromKey({
+    privateKey: BTC_PRIVATE_KEY,
+    network: 'regtest',
+    addressFormat: 'p2tr',
   });
-});
+  expect(btcAddrRegtest).toBe('bcrt1pet7ep3czdu9k4wvdlz2fp5p8x2yp7t6ttyqg2c6cmh0lgeuu9laspse7la');
+
+  return {
+    btcAddr,
+    btcAddrDecoded,
+    btcAddrRegtest,
+    btcPubKey,
+    btcDescriptor: `tr(${btcPubKey})`,
+  };
+}
+
+// helper
+async function withDescriptorWallet<R>(fn: (walletName: string) => Promise<R> | R): Promise<R> {
+  // before: load or create descriptor wallet
+  try {
+    await testEnv.bitcoinRpcClient.loadwallet({ filename: 'descriptor-wallet' });
+  } catch (e) {
+    await testEnv.bitcoinRpcClient.createwallet({
+      wallet_name: 'descriptor-wallet',
+      disable_private_keys: true,
+      descriptors: true,
+      load_on_startup: false,
+    } as any);
+  }
+
+  const res = await fn('descriptor-wallet');
+
+  // after: unload descriptor walletl
+  await testEnv.bitcoinRpcClient.unloadwallet({ wallet_name: 'descriptor-wallet' });
+
+  return res;
+}

--- a/src/tests-2.5/pox-4-btc-address-formats.ts
+++ b/src/tests-2.5/pox-4-btc-address-formats.ts
@@ -1,4 +1,4 @@
-import { hexToBuffer } from '@hirosystems/api-toolkit';
+import { hexToBuffer, timeout } from '@hirosystems/api-toolkit';
 import { decodeBtcAddress } from '@stacks/stacking';
 import {
   AddressStxBalanceResponse,
@@ -144,11 +144,11 @@ describe.each([P2SH_P2WPKH, P2WPKH, P2WSH, P2TR])(
 
     test('stx unlocked - RPC balance', async () => {
       // Wait until account has unlocked (finished Stacking cycles)
-      const rpcAccountBefore = await testEnv.client.getAccount(account.stacksAddress);
-      const unlockHeight = rpcAccountBefore.unlock_height + 1;
-      await standByUntilBurnBlock(unlockHeight);
+      const rpcAccount = await testEnv.client.getAccount(account.stacksAddress);
+      await standByUntilBurnBlock(rpcAccount.unlock_height + 1);
 
       // Check that STX are no longer reported as locked by the RPC endpoints:
+      await timeout(200); // make sure unlock was processed
       const rpcAccountAfter = await testEnv.client.getAccount(account.stacksAddress);
       expect(BigInt(rpcAccountAfter.locked)).toBe(0n);
       expect(rpcAccountAfter.unlock_height).toBe(0);

--- a/src/tests-2.5/pox-4-btc-address-formats.ts
+++ b/src/tests-2.5/pox-4-btc-address-formats.ts
@@ -13,6 +13,7 @@ import { CoreRpcPoxInfo } from '../core-rpc/client';
 import { DbEventTypeId, DbStxLockEvent } from '../datastore/common';
 import { getBitcoinAddressFromKey, privateToPublicKey, VerboseKeyOutput } from '../ec-helpers';
 import {
+  ZERO_SIGNER_KEY_BYTES,
   fetchGet,
   standByForPoxCycle,
   standByForTxSuccess,
@@ -95,13 +96,14 @@ describe('PoX-4 - Stack using supported bitcoin address formats', () => {
         contractName,
         functionName: 'stack-stx',
         functionArgs: [
-          uintCV(ustxAmount.toString()),
+          uintCV(ustxAmount.toString()), // amount-ustx
           tupleCV({
             hashbytes: bufferCV(decodedBtcAddr.data),
             version: bufferCV(Buffer.from([decodedBtcAddr.version])),
-          }),
-          uintCV(burnBlockHeight),
-          uintCV(cycleCount),
+          }), // pox-addr
+          uintCV(burnBlockHeight), // start-burn-ht
+          uintCV(cycleCount), // lock-period
+          bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
         ],
         network: testEnv.stacksNetwork,
         anchorMode: AnchorMode.OnChainOnly,
@@ -342,13 +344,14 @@ describe('PoX-4 - Stack using supported bitcoin address formats', () => {
         contractName,
         functionName: 'stack-stx',
         functionArgs: [
-          uintCV(ustxAmount.toString()),
+          uintCV(ustxAmount.toString()), // amount-ustx
           tupleCV({
             hashbytes: bufferCV(decodedBtcAddr.data),
             version: bufferCV(Buffer.from([decodedBtcAddr.version])),
-          }),
-          uintCV(burnBlockHeight),
-          uintCV(cycleCount),
+          }), // pox-addr
+          uintCV(burnBlockHeight), // start-burn-ht
+          uintCV(cycleCount), // lock-period
+          bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
         ],
         network: testEnv.stacksNetwork,
         anchorMode: AnchorMode.OnChainOnly,
@@ -595,13 +598,14 @@ describe('PoX-4 - Stack using supported bitcoin address formats', () => {
         contractName,
         functionName: 'stack-stx',
         functionArgs: [
-          uintCV(ustxAmount.toString()),
+          uintCV(ustxAmount.toString()), // amount-ustx
           tupleCV({
             hashbytes: bufferCV(decodedBtcAddr.data),
             version: bufferCV(Buffer.from([decodedBtcAddr.version])),
-          }),
-          uintCV(burnBlockHeight),
-          uintCV(cycleCount),
+          }), // pox-addr
+          uintCV(burnBlockHeight), // start-burn-ht
+          uintCV(cycleCount), // lock-period
+          bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
         ],
         network: testEnv.stacksNetwork,
         anchorMode: AnchorMode.OnChainOnly,

--- a/src/tests-2.5/pox-4-burnchain-delegate-stx.ts
+++ b/src/tests-2.5/pox-4-burnchain-delegate-stx.ts
@@ -10,6 +10,7 @@ import {
   bufferCV,
   makeContractCall,
   makeSTXTokenTransfer,
+  randomBytes,
   standardPrincipalCV,
   uintCV,
 } from '@stacks/transactions';
@@ -28,7 +29,6 @@ import {
   standByUntilBurnBlock,
   testEnv,
   TestEnvContext,
-  ZERO_SIGNER_KEY_BYTES,
 } from '../test-utils/test-helpers';
 import * as btc from 'bitcoinjs-lib';
 import { b58ToC32, c32ToB58 } from 'c32check';
@@ -403,7 +403,7 @@ describe('PoX-4 - Stack using Bitcoin-chain ops', () => {
         poxAddrPayoutAccount.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(1), // lock-period
-        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
+        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,

--- a/src/tests-2.5/pox-4-burnchain-delegate-stx.ts
+++ b/src/tests-2.5/pox-4-burnchain-delegate-stx.ts
@@ -7,6 +7,7 @@ import {
 } from '@stacks/stacks-blockchain-api-types';
 import {
   AnchorMode,
+  bufferCV,
   makeContractCall,
   makeSTXTokenTransfer,
   standardPrincipalCV,
@@ -27,6 +28,7 @@ import {
   standByUntilBurnBlock,
   testEnv,
   TestEnvContext,
+  ZERO_SIGNER_KEY_BYTES,
 } from '../test-utils/test-helpers';
 import * as btc from 'bitcoinjs-lib';
 import { b58ToC32, c32ToB58 } from 'c32check';
@@ -401,6 +403,7 @@ describe('PoX-4 - Stack using Bitcoin-chain ops', () => {
         poxAddrPayoutAccount.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(1), // lock-period
+        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,

--- a/src/tests-2.5/pox-4-burnchain-delegate-stx.ts
+++ b/src/tests-2.5/pox-4-burnchain-delegate-stx.ts
@@ -174,7 +174,7 @@ async function createPox2DelegateStx(args: {
   };
 }
 
-describe('PoX-4 - Stack using Bitcoin-chain ops', () => {
+describe('PoX-4 - Stack using Bitcoin-chain delegate ops', () => {
   const seedAccount = testnetKeys[0];
 
   let db: PgWriteStore;

--- a/src/tests-2.5/pox-4-burnchain-stack-stx.ts
+++ b/src/tests-2.5/pox-4-burnchain-stack-stx.ts
@@ -281,7 +281,8 @@ describe('PoX-4 - Stack using Bitcoin-chain stack ops', () => {
     await standByUntilBlock(curInfo.stacks_tip_height + 1);
   });
 
-  test('Test synthetic STX tx', async () => {
+  // TODO: this is blocked by a blockchain bug: https://github.com/stacks-network/stacks-core/issues/4282
+  test.skip('Test synthetic STX tx', async () => {
     const coreNodeBalance = await client.getAccount(account.stxAddr);
     const addressEventsResp = await supertest(api.server)
       .get(`/extended/v1/tx/events?address=${account.stxAddr}`)

--- a/src/tests-2.5/pox-4-burnchain-stack-stx.ts
+++ b/src/tests-2.5/pox-4-burnchain-stack-stx.ts
@@ -134,7 +134,7 @@ async function createPox2StackStx(args: {
   };
 }
 
-describe('PoX-4 - Stack using Bitcoin-chain ops', () => {
+describe('PoX-4 - Stack using Bitcoin-chain stack ops', () => {
   const seedAccount = testnetKeys[0];
 
   let db: PgWriteStore;
@@ -186,7 +186,7 @@ describe('PoX-4 - Stack using Bitcoin-chain ops', () => {
 
     // transfer pox "min_amount_ustx" from seed to test account
     const poxInfo = await client.getPox();
-    testAccountBalance = BigInt(Math.round(Number(poxInfo.min_amount_ustx) * 2.1).toString());
+    testAccountBalance = BigInt(poxInfo.min_amount_ustx) * 2n;
     const stxXfer1 = await makeSTXTokenTransfer({
       senderKey: seedAccount.secretKey,
       recipient: account.stxAddr,

--- a/src/tests-2.5/pox-4-delegate-aggregation.ts
+++ b/src/tests-2.5/pox-4-delegate-aggregation.ts
@@ -58,15 +58,12 @@ describe('PoX-4 - Delegate aggregation increase operations', () => {
   });
 
   test('Import testing accounts to bitcoind', async () => {
-    // register delegate accounts to bitcoind wallet
-    // TODO: only one of these (delegatee ?) should be required..
-    for (const account of [delegatorAccount, delegateeAccount]) {
-      await testEnv.bitcoinRpcClient.importprivkey({
-        privkey: account.wif,
-        label: account.btcAddr,
-        rescan: false,
-      });
-    }
+    // register delegatee account to bitcoind wallet
+    await testEnv.bitcoinRpcClient.importaddress({
+      address: delegateeAccount.btcAddr,
+      label: delegateeAccount.btcAddr,
+      rescan: false,
+    });
   });
 
   test('Seed delegate accounts', async () => {
@@ -445,5 +442,13 @@ describe('PoX-4 - Delegate aggregation increase operations', () => {
     );
     expect(BigInt(apiBalance.locked)).toBe(BigInt(BigInt(coreBalanceInfo.locked)));
     expect(apiBalance.burnchain_unlock_height).toBe(coreBalanceInfo.unlock_height);
+  });
+
+  test('BTC stacking reward received', async () => {
+    const received: number = await testEnv.bitcoinRpcClient.getreceivedbyaddress({
+      address: delegateeAccount.btcAddr,
+      minconf: 0,
+    });
+    expect(received).toBeGreaterThan(0);
   });
 });

--- a/src/tests-2.5/pox-4-delegate-aggregation.ts
+++ b/src/tests-2.5/pox-4-delegate-aggregation.ts
@@ -11,10 +11,12 @@ import {
   standByForTxSuccess,
   standByForAccountUnlock,
   testEnv,
+  ZERO_SIGNER_KEY_BYTES,
 } from '../test-utils/test-helpers';
 import { stxToMicroStx } from '../helpers';
 import {
   AnchorMode,
+  bufferCV,
   makeContractCall,
   makeSTXTokenTransfer,
   noneCV,
@@ -202,7 +204,8 @@ describe('PoX-4 - Delegate aggregation increase operations', () => {
         uintCV(amountStackedInitial), // amount-ustx
         delegateeAccount.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
-        uintCV(1), // lock-period
+        uintCV(1), // lock-period,
+        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,

--- a/src/tests-2.5/pox-4-delegate-aggregation.ts
+++ b/src/tests-2.5/pox-4-delegate-aggregation.ts
@@ -11,7 +11,6 @@ import {
   standByForTxSuccess,
   standByForAccountUnlock,
   testEnv,
-  ZERO_SIGNER_KEY_BYTES,
 } from '../test-utils/test-helpers';
 import { stxToMicroStx } from '../helpers';
 import {
@@ -20,6 +19,7 @@ import {
   makeContractCall,
   makeSTXTokenTransfer,
   noneCV,
+  randomBytes,
   someCV,
   standardPrincipalCV,
   uintCV,
@@ -205,7 +205,7 @@ describe('PoX-4 - Delegate aggregation increase operations', () => {
         delegateeAccount.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(1), // lock-period,
-        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
+        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,

--- a/src/tests-2.5/pox-4-delegate-revoked-stacking.ts
+++ b/src/tests-2.5/pox-4-delegate-revoked-stacking.ts
@@ -53,16 +53,6 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
     STACKER = accountFromKey(delegateeKey);
   });
 
-  test('Import testing accounts to bitcoind', async () => {
-    for (const account of [POOL, STACKER]) {
-      await testEnv.bitcoinRpcClient.importprivkey({
-        privkey: account.wif,
-        label: account.btcAddr,
-        rescan: false,
-      });
-    }
-  });
-
   test('Seed delegate accounts', async () => {
     poxInfo = await testEnv.client.getPox();
 

--- a/src/tests-2.5/pox-4-delegate-revoked-stacking.ts
+++ b/src/tests-2.5/pox-4-delegate-revoked-stacking.ts
@@ -19,6 +19,7 @@ import { DbTxStatus } from '../datastore/common';
 import { stxToMicroStx } from '../helpers';
 import {
   Account,
+  ZERO_SIGNER_KEY_BYTES,
   accountFromKey,
   fetchGet,
   readOnlyFnCall,
@@ -136,7 +137,7 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
         STACKER.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(1), // lock-period
-        bufferCV(hexToBytes('00'.repeat(33))), // signer-key
+        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -223,7 +224,7 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
         STACKER.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(3), // lock-period
-        bufferCV(hexToBytes('00'.repeat(33))), // signer-key
+        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -328,7 +329,7 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
         STACKER.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(1), // lock-period
-        bufferCV(hexToBytes('00'.repeat(33))), // signer-key
+        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -378,7 +379,7 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
       functionArgs: [
         standardPrincipalCV(STACKER.stxAddr), // stacker
         STACKER.poxAddrClar, // pox-addr
-        bufferCV(hexToBytes('00'.repeat(33))), // signer-key
+        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
         uintCV(2), // extend-count
       ],
       network: testEnv.stacksNetwork,
@@ -409,7 +410,7 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
         STACKER.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(1), // lock-period
-        bufferCV(hexToBytes('00'.repeat(33))), // signer-key
+        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,

--- a/src/tests-2.5/pox-4-delegate-revoked-stacking.ts
+++ b/src/tests-2.5/pox-4-delegate-revoked-stacking.ts
@@ -379,8 +379,8 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
       functionArgs: [
         standardPrincipalCV(STACKER.stxAddr), // stacker
         STACKER.poxAddrClar, // pox-addr
-        bufferCV(randomBytes(33)), // signer-key
         uintCV(2), // extend-count
+        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,

--- a/src/tests-2.5/pox-4-delegate-revoked-stacking.ts
+++ b/src/tests-2.5/pox-4-delegate-revoked-stacking.ts
@@ -238,7 +238,7 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
     expect(BigInt(coreBalanceInfo.locked)).toBe(DELEGATE_HALF_AMOUNT);
     expect(coreBalanceInfo.unlock_height).toBeGreaterThan(0);
 
-    // validate delegate-stack-stx pox2 event for this tx
+    // validate delegate-stack-stx pox event for this tx
     const res: any = await fetchGet(`/extended/v1/pox4_events/tx/${delegateStackStxTxId}`);
     expect(res).toBeDefined();
     expect(res.results).toHaveLength(1);
@@ -284,6 +284,28 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
     const revokeStackResult = decodeClarityValue(revokeStackDbTx.raw_result);
     expect(revokeStackResult.repr).toEqual('(ok true)');
     expect(revokeStackDbTx.status).toBe(DbTxStatus.Success);
+
+    // validate revoke-delegate-stx pox event for this tx
+    const res: any = await fetchGet(`/extended/v1/pox4_events/tx/${revokeTxResult.txId}`);
+    expect(res).toBeDefined();
+    expect(res.results).toHaveLength(1);
+    console.log('res.results[0]', res.results[0]);
+    expect(res.results[0]).toEqual(
+      expect.objectContaining({
+        name: 'revoke-delegate-stx',
+        pox_addr: STACKER.btcTestnetAddr,
+        stacker: STACKER.stxAddr,
+        // balance: BigInt(coreBalanceInfo.balance).toString(),
+        locked: DELEGATE_HALF_AMOUNT.toString(),
+        // burnchain_unlock_height: coreBalanceInfo.unlock_height.toString(),
+      })
+    );
+    console.log('res.results[0].data', res.results[0].data);
+    expect(res.results[0].data).toEqual(
+      expect.objectContaining({
+        delegate_to: POOL.stxAddr,
+      })
+    );
 
     // revocation doesn't change anything for the previous delegate-stack-stx state
     const coreBalanceInfo = await testEnv.client.getAccount(STACKER.stxAddr);
@@ -421,7 +443,7 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
     );
     await standByForTxSuccess(stackAggrCommitTxId);
 
-    // validate stack-aggregation-commit pox2 event for this tx
+    // validate stack-aggregation-commit pox event for this tx
     const res: any = await fetchGet(`/extended/v1/pox4_events/tx/${stackAggrCommitTxId}`);
     expect(res).toBeDefined();
     expect(res.results).toHaveLength(1);

--- a/src/tests-2.5/pox-4-delegate-revoked-stacking.ts
+++ b/src/tests-2.5/pox-4-delegate-revoked-stacking.ts
@@ -8,6 +8,7 @@ import {
   makeContractCall,
   makeSTXTokenTransfer,
   noneCV,
+  randomBytes,
   someCV,
   standardPrincipalCV,
   uintCV,
@@ -19,7 +20,6 @@ import { DbTxStatus } from '../datastore/common';
 import { stxToMicroStx } from '../helpers';
 import {
   Account,
-  ZERO_SIGNER_KEY_BYTES,
   accountFromKey,
   fetchGet,
   readOnlyFnCall,
@@ -137,7 +137,7 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
         STACKER.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(1), // lock-period
-        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
+        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -224,7 +224,7 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
         STACKER.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(3), // lock-period
-        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
+        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -329,7 +329,7 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
         STACKER.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(1), // lock-period
-        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
+        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -379,7 +379,7 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
       functionArgs: [
         standardPrincipalCV(STACKER.stxAddr), // stacker
         STACKER.poxAddrClar, // pox-addr
-        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
+        bufferCV(randomBytes(33)), // signer-key
         uintCV(2), // extend-count
       ],
       network: testEnv.stacksNetwork,
@@ -410,7 +410,7 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
         STACKER.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(1), // lock-period
-        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
+        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,

--- a/src/tests-2.5/pox-4-delegate-stacking.ts
+++ b/src/tests-2.5/pox-4-delegate-stacking.ts
@@ -2,7 +2,6 @@ import { CoreRpcPoxInfo } from '../core-rpc/client';
 import { testnetKeys } from '../api/routes/debug';
 import {
   Account,
-  ZERO_SIGNER_KEY_BYTES,
   accountFromKey,
   fetchGet,
   readOnlyFnCall,
@@ -19,6 +18,7 @@ import {
   makeContractCall,
   makeSTXTokenTransfer,
   noneCV,
+  randomBytes,
   someCV,
   standardPrincipalCV,
   uintCV,
@@ -221,7 +221,7 @@ describe('PoX-4 - Delegate Stacking operations', () => {
         delegateeAccount.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(1), // lock-period,
-        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
+        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -346,7 +346,7 @@ describe('PoX-4 - Delegate Stacking operations', () => {
       functionArgs: [
         standardPrincipalCV(delegateeAccount.stxAddr), // stacker
         delegateeAccount.poxAddrClar, // pox-addr
-        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
+        bufferCV(randomBytes(33)), // signer-key
         uintCV(extendCount), // extend-count
       ],
       network: testEnv.stacksNetwork,

--- a/src/tests-2.5/pox-4-delegate-stacking.ts
+++ b/src/tests-2.5/pox-4-delegate-stacking.ts
@@ -2,6 +2,7 @@ import { CoreRpcPoxInfo } from '../core-rpc/client';
 import { testnetKeys } from '../api/routes/debug';
 import {
   Account,
+  ZERO_SIGNER_KEY_BYTES,
   accountFromKey,
   fetchGet,
   readOnlyFnCall,
@@ -14,6 +15,7 @@ import {
 import { stxToMicroStx } from '../helpers';
 import {
   AnchorMode,
+  bufferCV,
   makeContractCall,
   makeSTXTokenTransfer,
   noneCV,
@@ -218,7 +220,8 @@ describe('PoX-4 - Delegate Stacking operations', () => {
         uintCV(amountToDelegateInitial), // amount-ustx
         delegateeAccount.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
-        uintCV(1), // lock-period
+        uintCV(1), // lock-period,
+        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -343,6 +346,7 @@ describe('PoX-4 - Delegate Stacking operations', () => {
       functionArgs: [
         standardPrincipalCV(delegateeAccount.stxAddr), // stacker
         delegateeAccount.poxAddrClar, // pox-addr
+        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
         uintCV(extendCount), // extend-count
       ],
       network: testEnv.stacksNetwork,

--- a/src/tests-2.5/pox-4-delegate-stacking.ts
+++ b/src/tests-2.5/pox-4-delegate-stacking.ts
@@ -346,8 +346,8 @@ describe('PoX-4 - Delegate Stacking operations', () => {
       functionArgs: [
         standardPrincipalCV(delegateeAccount.stxAddr), // stacker
         delegateeAccount.poxAddrClar, // pox-addr
-        bufferCV(randomBytes(33)), // signer-key
         uintCV(extendCount), // extend-count
+        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,

--- a/src/tests-2.5/pox-4-delegate-stacking.ts
+++ b/src/tests-2.5/pox-4-delegate-stacking.ts
@@ -48,15 +48,12 @@ describe('PoX-4 - Delegate Stacking operations', () => {
   });
 
   test('Import testing accounts to bitcoind', async () => {
-    // register delegate accounts to bitcoind wallet
-    // TODO: only one of these (delegatee ?) should be required..
-    for (const account of [delegatorAccount, delegateeAccount]) {
-      await testEnv.bitcoinRpcClient.importprivkey({
-        privkey: account.wif,
-        label: account.btcAddr,
-        rescan: false,
-      });
-    }
+    // register delegatee account to bitcoind wallet
+    await testEnv.bitcoinRpcClient.importaddress({
+      address: delegateeAccount.btcAddr,
+      label: delegateeAccount.btcAddr,
+      rescan: false,
+    });
   });
 
   test('Seed delegate accounts', async () => {
@@ -448,5 +445,13 @@ describe('PoX-4 - Delegate Stacking operations', () => {
     );
     expect(BigInt(apiBalance.locked)).toBe(BigInt(BigInt(coreBalanceInfo.locked)));
     expect(apiBalance.burnchain_unlock_height).toBe(coreBalanceInfo.unlock_height);
+  });
+
+  test('BTC stacking reward received', async () => {
+    const received: number = await testEnv.bitcoinRpcClient.getreceivedbyaddress({
+      address: delegateeAccount.btcAddr,
+      minconf: 0,
+    });
+    expect(received).toBeGreaterThan(0);
   });
 });

--- a/src/tests-2.5/pox-4-rosetta-btc-addr-types.ts
+++ b/src/tests-2.5/pox-4-rosetta-btc-addr-types.ts
@@ -9,6 +9,8 @@ import {
 import { CoreRpcPoxInfo } from '../core-rpc/client';
 import { DbTxStatus } from '../datastore/common';
 import { BurnchainRewardSlotHolderListResponse } from '@stacks/stacks-blockchain-api-types';
+import { bytesToHex } from '@stacks/common';
+import { randomBytes } from '@stacks/transactions';
 
 const BTC_ADDRESS_CASES = [
   { addressFormat: 'p2pkh' },
@@ -55,6 +57,7 @@ describe.each(BTC_ADDRESS_CASES)(
         privateKey: account.secretKey,
         cycleCount,
         ustxAmount,
+        signerKey: bytesToHex(randomBytes(33)),
       });
       expect(rosettaStackStx.tx.status).toBe(DbTxStatus.Success);
       expect(rosettaStackStx.constructionMetadata.metadata.contract_name).toBe('pox-4');

--- a/src/tests-2.5/pox-4-rosetta-btc-addr-types.ts
+++ b/src/tests-2.5/pox-4-rosetta-btc-addr-types.ts
@@ -47,7 +47,7 @@ describe.each(BTC_ADDRESS_CASES)(
     test('Perform stack-stx using Rosetta', async () => {
       poxInfo = await testEnv.client.getPox();
       expect(poxInfo.next_cycle.blocks_until_reward_phase).toBeGreaterThanOrEqual(
-        poxInfo.reward_cycle_length - 1 // close to cycle start (+1 block margin)
+        poxInfo.reward_cycle_length - 1 // close to cycle start (1 block margin)
       );
 
       const ustxAmount = BigInt(Math.round(Number(poxInfo.min_amount_ustx) * 1.1).toString());
@@ -70,7 +70,7 @@ describe.each(BTC_ADDRESS_CASES)(
       const nextCycleStart = poxInfo.next_cycle.reward_phase_start_block_height;
 
       await standByUntilBurnBlock(nextCycleStart); // time to check reward sets after a few blocks
-      await timeout(2000); // wait for indexer to catch up
+      await timeout(3000); // make sure rewards have been processed
 
       poxInfo = await testEnv.client.getPox();
       const rewardSlotHolders = await fetchGet<BurnchainRewardSlotHolderListResponse>(

--- a/src/tests-2.5/pox-4-rosetta-cycle-phases.ts
+++ b/src/tests-2.5/pox-4-rosetta-cycle-phases.ts
@@ -1,3 +1,5 @@
+import { bytesToHex } from '@stacks/common';
+import { randomBytes } from '@stacks/transactions';
 import { testnetKeys } from '../api/routes/debug';
 import { stackStxWithRosetta, standByUntilBurnBlock, testEnv } from '../test-utils/test-helpers';
 
@@ -41,6 +43,7 @@ describe.each(BLOCK_SHIFT_COUNT)(
         cycleCount: 1,
         ustxAmount,
         btcAddr,
+        signerKey: bytesToHex(randomBytes(33)),
       });
     });
 

--- a/src/tests-2.5/pox-4-rosetta-segwit.ts
+++ b/src/tests-2.5/pox-4-rosetta-segwit.ts
@@ -187,7 +187,10 @@ describe('PoX-4 - Rosetta - Stacking with segwit', () => {
       include_watchonly: true,
     });
     received = received.filter(r => r.address === btcAddr);
-    expect(received.length).toBe(1);
+    // todo: double-check if multiple rewards are possible/intended for
+    //       this test, since it doesn't happen often
+    expect(received.length).toBeGreaterThanOrEqual(1);
+    expect(received.length).toBe(rewards.results.length);
     expect(received[0].category).toBe('receive');
     expect(received[0].blockhash).toBe(hexToBuffer(firstReward.burn_block_hash).toString('hex'));
     const sats = new bignumber(received[0].amount).shiftedBy(8).toString();

--- a/src/tests-2.5/pox-4-rosetta-segwit.ts
+++ b/src/tests-2.5/pox-4-rosetta-segwit.ts
@@ -7,6 +7,7 @@ import {
   AnchorMode,
   getAddressFromPrivateKey,
   makeSTXTokenTransfer,
+  randomBytes,
   TransactionVersion,
 } from '@stacks/transactions';
 import bignumber from 'bignumber.js';
@@ -26,6 +27,7 @@ import {
   testEnv,
 } from '../test-utils/test-helpers';
 import { hexToBuffer } from '@hirosystems/api-toolkit';
+import { bytesToHex } from '@stacks/common';
 
 describe('PoX-4 - Rosetta - Stacking with segwit', () => {
   let btcAddr: string;
@@ -129,6 +131,7 @@ describe('PoX-4 - Rosetta - Stacking with segwit', () => {
       privateKey: account.secretKey,
       cycleCount: cycleCount,
       ustxAmount: ustxAmount,
+      signerKey: bytesToHex(randomBytes(33)),
     });
 
     expect(stackingResult.constructionMetadata.metadata.contract_name).toBe('pox-4');
@@ -247,6 +250,7 @@ describe('PoX-4 - Rosetta - Stacking with segwit', () => {
       privateKey: account.secretKey,
       cycleCount,
       ustxAmount,
+      signerKey: bytesToHex(randomBytes(33)),
     });
 
     expect(rosettaStackStx.constructionMetadata.metadata.contract_name).toBe('pox-4');

--- a/src/tests-2.5/pox-4-stack-extend-increase.ts
+++ b/src/tests-2.5/pox-4-stack-extend-increase.ts
@@ -17,6 +17,7 @@ import {
   standByForTxSuccess,
   standByUntilBurnBlock,
   testEnv,
+  ZERO_SIGNER_KEY_BYTES,
 } from '../test-utils/test-helpers';
 import { decodeBtcAddress } from '@stacks/stacking';
 import { hexToBuffer } from '@hirosystems/api-toolkit';
@@ -115,13 +116,14 @@ describe('PoX-4 - Stack extend and increase operations', () => {
       contractName,
       functionName: 'stack-stx',
       functionArgs: [
-        uintCV(ustxAmount.toString()),
+        uintCV(ustxAmount.toString()), // amount-ustx
         tupleCV({
           hashbytes: bufferCV(decodedBtcAddr.data),
           version: bufferCV(Buffer.from([decodedBtcAddr.version])),
-        }),
-        uintCV(burnBlockHeight),
-        uintCV(lockPeriod), // lock-period
+        }), // pox-addr
+        uintCV(burnBlockHeight), // start-burn-ht
+        uintCV(lockPeriod), // lock-period,
+        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -308,11 +310,12 @@ describe('PoX-4 - Stack extend and increase operations', () => {
       contractName,
       functionName: 'stack-extend',
       functionArgs: [
-        uintCV(extendCycleAmount),
+        uintCV(extendCycleAmount), // extend-count
         tupleCV({
           hashbytes: bufferCV(decodedBtcAddr.data),
           version: bufferCV(Buffer.from([decodedBtcAddr.version])),
-        }),
+        }), // pox-addr
+        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,

--- a/src/tests-2.5/pox-4-stack-extend-increase.ts
+++ b/src/tests-2.5/pox-4-stack-extend-increase.ts
@@ -8,7 +8,14 @@ import {
   BurnchainRewardSlotHolderListResponse,
   BurnchainRewardsTotal,
 } from '@stacks/stacks-blockchain-api-types';
-import { AnchorMode, bufferCV, makeContractCall, tupleCV, uintCV } from '@stacks/transactions';
+import {
+  AnchorMode,
+  bufferCV,
+  makeContractCall,
+  randomBytes,
+  tupleCV,
+  uintCV,
+} from '@stacks/transactions';
 import bignumber from 'bignumber.js';
 import { DbEventTypeId, DbStxLockEvent } from '../datastore/common';
 import {
@@ -17,7 +24,6 @@ import {
   standByForTxSuccess,
   standByUntilBurnBlock,
   testEnv,
-  ZERO_SIGNER_KEY_BYTES,
 } from '../test-utils/test-helpers';
 import { decodeBtcAddress } from '@stacks/stacking';
 import { hexToBuffer } from '@hirosystems/api-toolkit';
@@ -123,7 +129,7 @@ describe('PoX-4 - Stack extend and increase operations', () => {
         }), // pox-addr
         uintCV(burnBlockHeight), // start-burn-ht
         uintCV(lockPeriod), // lock-period,
-        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
+        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -315,7 +321,7 @@ describe('PoX-4 - Stack extend and increase operations', () => {
           hashbytes: bufferCV(decodedBtcAddr.data),
           version: bufferCV(Buffer.from([decodedBtcAddr.version])),
         }), // pox-addr
-        bufferCV(ZERO_SIGNER_KEY_BYTES), // signer-key
+        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,

--- a/src/tests-2.5/pox-4-stack-extend-increase.ts
+++ b/src/tests-2.5/pox-4-stack-extend-increase.ts
@@ -474,7 +474,10 @@ describe('PoX-4 - Stack extend and increase operations', () => {
       include_watchonly: true,
     });
     received = received.filter(r => r.address === btcAddrRegtest);
-    // expect(received.length).toBe(1);
+    // todo: double-check if multiple rewards are possible/intended for
+    //       this test, since it doesn't happen often
+    expect(received.length).toBeGreaterThanOrEqual(1);
+    expect(received.length).toBe(rewards.results.length);
     expect(received[0].category).toBe('receive');
     expect(received[0].blockhash).toBe(hexToBuffer(firstReward.burn_block_hash).toString('hex'));
     const sats = new bignumber(received[0].amount).shiftedBy(8).toString();

--- a/src/tests-rosetta-construction/construction.ts
+++ b/src/tests-rosetta-construction/construction.ts
@@ -1,66 +1,68 @@
-import { ApiServer, startApiServer } from '../api/init';
-import * as supertest from 'supertest';
-import { DbBlock } from '../datastore/common';
-import * as assert from 'assert';
+import { bufferToHex, timeout } from '@hirosystems/api-toolkit';
+import { hexToBytes } from '@stacks/common';
+import { decodeBtcAddress } from '@stacks/stacking';
 import {
-  AnchorMode,
-  AuthType,
-  bufferCV,
-  ChainID,
-  createStacksPrivateKey,
-  getPublicKey,
-  makeSTXTokenTransfer,
-  makeUnsignedContractCall,
-  makeUnsignedSTXTokenTransfer,
-  noneCV,
-  pubKeyfromPrivKey,
-  publicKeyToString,
-  SignedTokenTransferOptions,
-  someCV,
-  standardPrincipalCV,
-  TransactionSigner,
-  tupleCV,
-  uintCV,
-  UnsignedContractCallOptions,
-  UnsignedTokenTransferOptions,
-} from '@stacks/transactions';
-import { StacksCoreRpcClient } from '../core-rpc/client';
-import {
+  RosettaAccountIdentifier,
   RosettaConstructionCombineRequest,
   RosettaConstructionCombineResponse,
-  RosettaAccountIdentifier,
   RosettaConstructionDeriveRequest,
   RosettaConstructionDeriveResponse,
   RosettaConstructionHashRequest,
   RosettaConstructionHashResponse,
   RosettaConstructionMetadataRequest,
+  RosettaConstructionMetadataResponse,
   RosettaConstructionParseRequest,
   RosettaConstructionParseResponse,
   RosettaConstructionPayloadsRequest,
   RosettaConstructionPreprocessRequest,
   RosettaConstructionPreprocessResponse,
-  RosettaConstructionMetadataResponse,
 } from '@stacks/stacks-blockchain-api-types';
 import {
-  getRosettaNetworkName,
+  AnchorMode,
+  AuthType,
+  ChainID,
+  MessageSignature,
+  SignedTokenTransferOptions,
+  TransactionSigner,
+  UnsignedContractCallOptions,
+  UnsignedTokenTransferOptions,
+  bufferCV,
+  createStacksPrivateKey,
+  getPublicKey,
+  makeSTXTokenTransfer,
+  makeSigHashPreSign,
+  makeUnsignedContractCall,
+  makeUnsignedSTXTokenTransfer,
+  noneCV,
+  pubKeyfromPrivKey,
+  publicKeyToString,
+  someCV,
+  standardPrincipalCV,
+  tupleCV,
+  uintCV,
+} from '@stacks/transactions';
+import * as assert from 'assert';
+import * as supertest from 'supertest';
+import { ApiServer, startApiServer } from '../api/init';
+import {
   RosettaConstants,
   RosettaErrors,
   RosettaErrorsTypes,
   RosettaOperationStatuses,
   RosettaOperationTypes,
+  getRosettaNetworkName,
 } from '../api/rosetta-constants';
 import { getStacksTestnetNetwork, testnetKeys } from '../api/routes/debug';
-import { getSignature, getStacksNetwork } from '../rosetta/rosetta-helpers';
-import { makeSigHashPreSign, MessageSignature } from '@stacks/transactions';
+import { StacksCoreRpcClient } from '../core-rpc/client';
+import { DbBlock } from '../datastore/common';
 import { PgWriteStore } from '../datastore/pg-write-store';
-import { decodeBtcAddress } from '@stacks/stacking';
+import { FoundOrNot } from '../helpers';
+import { getSignature, getStacksNetwork } from '../rosetta/rosetta-helpers';
 import {
   standByForPoxCycle,
   standByForTx as standByForTxShared,
   standByUntilBurnBlock,
 } from '../test-utils/test-helpers';
-import { bufferToHex, timeout } from '@hirosystems/api-toolkit';
-import { FoundOrNot } from '../helpers';
 
 describe('Rosetta Construction', () => {
   let db: PgWriteStore;
@@ -1010,6 +1012,7 @@ describe('Rosetta Construction', () => {
           metadata: {
             number_of_cycles: number_of_cycles,
             pox_addr: '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3',
+            signer_key: '01'.repeat(33),
           },
         },
       ],
@@ -1019,6 +1022,7 @@ describe('Rosetta Construction', () => {
         contract_address: contract_address,
         contract_name: contract_name,
         burn_block_height: burn_block_height,
+        signer_key: '01'.repeat(33),
       },
       public_keys: [
         {
@@ -1048,6 +1052,7 @@ describe('Rosetta Construction', () => {
         poxAddressCV,
         uintCV(burn_block_height),
         uintCV(number_of_cycles),
+        bufferCV(hexToBytes('01'.repeat(33))),
       ],
       validateWithAbi: false,
       nonce: 0,
@@ -1057,7 +1062,6 @@ describe('Rosetta Construction', () => {
     };
     const transaction = await makeUnsignedContractCall(stackingTx);
     const unsignedTransaction = Buffer.from(transaction.serialize());
-    // const hexBytes = digestSha512_256(unsignedTransaction).toString('hex');
 
     const signer = new TransactionSigner(transaction);
 
@@ -1695,7 +1699,7 @@ describe('Rosetta Construction', () => {
     const sender = deriveResult.body.account_identifier.address;
     const number_of_cycles = 1;
     const pox_addr = '2MtzNEqm2D9jcbPJ5mW7Z3AUNwqt3afZH66';
-    const size = 260;
+    const size = 298;
     const max_fee = '12380898';
     const preprocessRequest: RosettaConstructionPreprocessRequest = {
       network_identifier: {
@@ -1725,6 +1729,7 @@ describe('Rosetta Construction', () => {
           metadata: {
             number_of_cycles: number_of_cycles,
             pox_addr: pox_addr,
+            signer_key: '02'.repeat(33),
           },
         },
         {
@@ -1780,6 +1785,7 @@ describe('Rosetta Construction', () => {
         size: size,
         number_of_cycles: number_of_cycles,
         pox_addr: pox_addr,
+        signer_key: '02'.repeat(33),
       },
       required_public_keys: [
         {
@@ -1808,7 +1814,7 @@ describe('Rosetta Construction', () => {
     expect(JSON.parse(resultMetadata.text).metadata).toHaveProperty('contract_address');
     expect(JSON.parse(resultMetadata.text).metadata).toHaveProperty('contract_name');
     expect(JSON.parse(resultMetadata.text).metadata).toHaveProperty('burn_block_height');
-    expect(JSON.parse(resultMetadata.text).suggested_fee[0].value).toBe('390');
+    expect(JSON.parse(resultMetadata.text).suggested_fee[0].value).toBe('447');
 
     //payloads
     const contract_address = resultMetadata.body.metadata.contract_address;
@@ -1846,6 +1852,7 @@ describe('Rosetta Construction', () => {
         poxAddressCV,
         uintCV(burn_block_height),
         uintCV(number_of_cycles),
+        bufferCV(hexToBytes('02'.repeat(33))),
       ],
       validateWithAbi: false,
       nonce: nonce,
@@ -2114,7 +2121,7 @@ describe('Rosetta Construction', () => {
     expect(deriveResult.body).toEqual(deriveExpectResponse);
 
     //preprocess
-    const fee = '260';
+    const fee = '293';
     const stacking_amount = '1250180000000000'; //minimum stacking
     const sender = deriveResult.body.account_identifier.address;
     const pox_addr = '2MtzNEqm2D9jcbPJ5mW7Z3AUNwqt3afZH66';

--- a/src/tests-rosetta/offline-api-tests.ts
+++ b/src/tests-rosetta/offline-api-tests.ts
@@ -464,7 +464,7 @@ describe('Rosetta offline API', () => {
         symbol: 'STX',
         decimals: 6,
         max_fee: '12380898',
-        size: 291,
+        size: 253,
         pox_addr: '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3',
       },
       required_public_keys: [

--- a/src/tests-rosetta/offline-api-tests.ts
+++ b/src/tests-rosetta/offline-api-tests.ts
@@ -53,6 +53,7 @@ import * as nock from 'nock';
 import { PgStore } from '../datastore/pg-store';
 import { decodeBtcAddress } from '@stacks/stacking';
 import { bufferToHex } from '@hirosystems/api-toolkit';
+import { hexToBytes } from '@stacks/common';
 
 describe('Rosetta offline API', () => {
   let db: PgStore;
@@ -329,7 +330,8 @@ describe('Rosetta offline API', () => {
           },
           metadata: {
             number_of_cycles: 3,
-            pox_addr: '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3'
+            pox_addr: '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3',
+            signer_key: "00".repeat(33),
           },
         },
       ],
@@ -364,9 +366,10 @@ describe('Rosetta offline API', () => {
         symbol: 'STX',
         decimals: 6,
         max_fee: '12380898',
-        size: 260,
+        size: 298,
         number_of_cycles: 3,
-        pox_addr: '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3'
+        pox_addr: '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3',
+        signer_key: "00".repeat(33),
       },
       required_public_keys: [
         {
@@ -425,7 +428,7 @@ describe('Rosetta offline API', () => {
           },
           metadata: {
             pox_addr: '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3',
-            delegate_to: testnetKeys[1].stacksAddress
+            delegate_to: testnetKeys[1].stacksAddress,
           },
         },
       ],
@@ -461,8 +464,8 @@ describe('Rosetta offline API', () => {
         symbol: 'STX',
         decimals: 6,
         max_fee: '12380898',
-        size: 253,
-        pox_addr: '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3'
+        size: 291,
+        pox_addr: '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3',
       },
       required_public_keys: [
         {
@@ -873,6 +876,7 @@ describe('Rosetta offline API', () => {
           metadata: {
             number_of_cycles: number_of_cycles,
             pox_addr : '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3',
+            signer_key: "02".repeat(33),
           }
         },
       ],
@@ -911,6 +915,7 @@ describe('Rosetta offline API', () => {
         poxAddressCV,
         uintCV(burn_block_height),
         uintCV(number_of_cycles),
+        bufferCV(hexToBytes("02".repeat(33)))
       ],
       validateWithAbi: false,
       nonce: 0,
@@ -978,7 +983,7 @@ describe('Rosetta offline API', () => {
         contract_name: contract_name,
         account_sequence: 0,
         recent_block_hash: '0x969e494d5aee0166016836f97bbeb3d9473bea8427e477e9de253f78d3212354',
-        burn_block_height: burn_block_height
+        burn_block_height: burn_block_height,
       },
       suggested_fee: [ { value: '390', currency: {symbol: 'STX', decimals: 6} } ]
     }

--- a/stacks-blockchain/docker/Dockerfile
+++ b/stacks-blockchain/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Pointed to stacks-blockchain `2.1.0.0.0` git tag
-FROM --platform=linux/amd64 hirosystems/stacks-api-e2e:stacks3.0-800259e as build
+FROM --platform=linux/amd64 hirosystems/stacks-api-e2e:stacks3.0-e6330cf as build
 
 FROM --platform=linux/amd64 debian:bookworm
 

--- a/stacks-blockchain/docker/Dockerfile
+++ b/stacks-blockchain/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Pointed to stacks-blockchain `2.1.0.0.0` git tag
-FROM --platform=linux/amd64 hirosystems/stacks-api-e2e:stacks3.0-e6330cf as build
+FROM --platform=linux/amd64 hirosystems/stacks-api-e2e:stacks3.0-204ab4c as build
 
 FROM --platform=linux/amd64 debian:bookworm
 

--- a/stacks-blockchain/docker/Dockerfile
+++ b/stacks-blockchain/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Pointed to stacks-blockchain `2.1.0.0.0` git tag
-FROM --platform=linux/amd64 hirosystems/stacks-api-e2e:stacks3.0-204ab4c as build
+FROM --platform=linux/amd64 hirosystems/stacks-api-e2e:stacks3.0-1d675fd as build
 
 FROM --platform=linux/amd64 debian:bookworm
 


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/1761

- updates rosetta for signer-key
- updates tests for signer-key
- adds helper for using descriptor wallet for address format tests
- adds timeouts to flaky tests
- some assumptions I'm not 100% certain about, but tests are green 😶