### PR TITLE
fix: line spacing in `/v2/fees/transaction`

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3367,10 +3367,12 @@ paths:
           endpoint with an estimation of the final length (in bytes)
           of the transaction, including any post-conditions and
           signatures
+
         If the node cannot provide an estimate for the transaction
         (e.g., if the node has never seen a contract-call for the
         given contract and function) or if estimation is not
         configured on this node, a 400 response is returned.
+
         The 400 response will be a JSON error containing a `reason`
         field which can be one of the following:
         * `DatabaseError` - this Stacks node has had an internal
@@ -3382,6 +3384,7 @@ paths:
         * `CostEstimationDisabled` - this Stacks node does not perform
           fee or cost estimation, and it cannot respond on this
           endpoint.
+
         The 200 response contains the following data:
         * `estimated_cost` - the estimated multi-dimensional cost of
           executing the Clarity VM on the provided transaction.
@@ -3410,6 +3413,7 @@ paths:
               If the estimated fees are less than the minimum relay
               fee `(1 ustx x estimated_len)`, then that minimum relay
               fee will be returned here instead.
+
         Note: If the final transaction's byte size is larger than
         supplied to `estimated_len`, then applications should increase
         this fee amount by:


### PR DESCRIPTION
## Description

This fixes some line spacing issues in the documentation.

1. The formatting is not as intended due to the treatment of line-breaks

Example:
<img width="748" alt="image" src="https://github.com/hirosystems/stacks-blockchain-api/assets/1473715/3fe5f754-1499-4e17-b547-30c63efcca61">

In the screenshot above, it is clear that the information about 200 responses is not intended to be in the bullet about `CostEstimationDisabled`.