### PR TITLE
test: fix flaky postgres teardown in tests

### DIFF
--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -141,10 +141,12 @@ export class PgStore extends BasePgStore {
     return store;
   }
 
-  async close(): Promise<void> {
+  async close(args?: { timeout?: number }): Promise<void> {
     await this.notifier?.close();
     await super.close({
-      timeout: parseInt(getPgConnectionEnvValue('CLOSE_TIMEOUT', PgServer.default) ?? '5'),
+      timeout:
+        args?.timeout ??
+        parseInt(getPgConnectionEnvValue('CLOSE_TIMEOUT', PgServer.default) ?? '5'),
     });
   }
 

--- a/src/tests-2.5/env-setup.ts
+++ b/src/tests-2.5/env-setup.ts
@@ -51,7 +51,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   console.log('Jest - teardown..');
-  await testEnv.api.terminate();
-  await testEnv.db?.close();
+  await testEnv.api.forceKill();
+  await testEnv.db?.close({ timeout: 0 });
   console.log('Jest - teardown done');
 });

--- a/src/tests-2.5/global-setup.ts
+++ b/src/tests-2.5/global-setup.ts
@@ -40,6 +40,7 @@ export default async (): Promise<void> => {
   process.env.PG_DATABASE = 'postgres';
   process.env.STACKS_CHAIN_ID = '0x80000000';
 
+  await migrate('down');
   await migrate('up');
   const db = await PgWriteStore.connect({ usageName: 'tests' });
   const eventServer = await startEventServer({ datastore: db, chainId: ChainID.Testnet });

--- a/src/tests-2.5/global-teardown.ts
+++ b/src/tests-2.5/global-teardown.ts
@@ -1,4 +1,3 @@
-import { migrate } from '../test-utils/test-helpers';
 import type { GlobalTestEnv } from './global-setup';
 
 // ts-unused-exports:disable-next-line
@@ -6,9 +5,8 @@ export default async (): Promise<void> => {
   console.log('Jest - global teardown..');
   const testEnv: GlobalTestEnv = (global as any).globalTestEnv;
 
-  await migrate('down');
   await testEnv.eventServer.closeAsync();
-  await testEnv.db.close();
+  await testEnv.db.close({ timeout: 0 });
 
   console.log('Jest - global teardown done');
 };


### PR DESCRIPTION
* Move postgres down-migration logic out of teardown
* Remove timeouts in postgres shutdown call

These changes appear to remove the error log messages (which are sometimes fatal deadlocks) that would appear after tests finished.