### PR TITLE
update to new url path

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -10,7 +10,7 @@ info:
   title: Stacks Blockchain API
   version: 'STACKS_API_VERSION'
   description: |
-    Welcome to the API reference overview for the [Stacks Blockchain API](https://docs.hiro.so/get-started/stacks-blockchain-api).
+    Welcome to the API reference overview for the [Stacks Blockchain API](https://docs.hiro.so/stacks-blockchain-api).
 
     [Download Postman collection](https://hirosystems.github.io/stacks-blockchain-api/collection.json)
 tags:


### PR DESCRIPTION
## Description

Main API overview page [here](https://docs.hiro.so/api) currently references an old url path. This change updates to the new path that renders the proper sidebar in docs.