### PR TITLE
feat: add signer-keys from pox4 events

### DIFF
--- a/docker/docker-compose.dev.stacks-blockchain.yml
+++ b/docker/docker-compose.dev.stacks-blockchain.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   stacks-blockchain:
-    image: 'hirosystems/stacks-api-e2e:stacks3.0-1d675fd'
+    image: 'hirosystems/stacks-api-e2e:stacks3.0-457f270'
     restart: on-failure
     environment:
       STACKS_EVENT_OBSERVER: host.docker.internal:3700

--- a/docker/docker-compose.dev.stacks-krypton.yml
+++ b/docker/docker-compose.dev.stacks-krypton.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   stacks-blockchain:
-    image: 'hirosystems/stacks-api-e2e:stacks3.0-1d675fd'
+    image: 'hirosystems/stacks-api-e2e:stacks3.0-457f270'
     ports:
       - '18443:18443' # bitcoin regtest JSON-RPC interface
       - '18444:18444' # bitcoin regtest p2p

--- a/migrations/1706886038615_update-pox4-signer-key.js
+++ b/migrations/1706886038615_update-pox4-signer-key.js
@@ -1,0 +1,132 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+/** @param { import("node-pg-migrate").MigrationBuilder } pgm */
+exports.up = pgm => {
+  pgm.dropConstraint('pox4_events', 'valid_event_specific_columns', { ifExists: true });
+
+  pgm.addColumn('pox4_events', {
+    signer_key: {
+      type: 'bytea',
+    }
+  });
+
+  pgm.createIndex('pox4_events', 'signer_key');
+
+  pgm.addConstraint(
+    'pox4_events',
+    'valid_event_specific_columns',
+    `CHECK (
+    CASE name
+      WHEN 'handle-unlock' THEN
+        first_cycle_locked IS NOT NULL AND
+        first_unlocked_cycle IS NOT NULL
+      WHEN 'stack-stx' THEN
+        lock_period IS NOT NULL AND
+        lock_amount IS NOT NULL AND
+        start_burn_height IS NOT NULL AND
+        unlock_burn_height IS NOT NULL AND
+        signer_key IS NOT NULL
+      WHEN 'stack-increase' THEN
+        increase_by IS NOT NULL AND
+        total_locked IS NOT NULL
+      WHEN 'stack-extend' THEN
+        extend_count IS NOT NULL AND
+        unlock_burn_height IS NOT NULL AND
+        signer_key IS NOT NULL
+      WHEN 'delegate-stx' THEN
+        amount_ustx IS NOT NULL AND
+        delegate_to IS NOT NULL
+      WHEN 'delegate-stack-stx' THEN
+        lock_period IS NOT NULL AND
+        lock_amount IS NOT NULL AND
+        start_burn_height IS NOT NULL AND
+        unlock_burn_height IS NOT NULL AND
+        delegator IS NOT NULL
+      WHEN 'delegate-stack-increase' THEN
+        increase_by IS NOT NULL AND
+        total_locked IS NOT NULL AND
+        delegator IS NOT NULL
+      WHEN 'delegate-stack-extend' THEN
+        extend_count IS NOT NULL AND
+        unlock_burn_height IS NOT NULL AND
+        delegator IS NOT NULL
+      WHEN 'stack-aggregation-commit' THEN
+        reward_cycle IS NOT NULL AND
+        amount_ustx IS NOT NULL AND
+        signer_key IS NOT NULL
+      WHEN 'stack-aggregation-commit-indexed' THEN
+        reward_cycle IS NOT NULL AND
+        amount_ustx IS NOT NULL AND
+        signer_key IS NOT NULL
+      WHEN 'stack-aggregation-increase' THEN
+        reward_cycle IS NOT NULL AND
+        amount_ustx IS NOT NULL
+      WHEN 'revoke-delegate-stx' THEN
+        delegate_to IS NOT NULL
+      ELSE false
+    END
+  )`
+  );
+};
+
+/** @param { import("node-pg-migrate").MigrationBuilder } pgm */
+exports.down = pgm => {
+  pgm.dropConstraint('pox4_events', 'valid_event_specific_columns', { ifExists: true });
+
+  pgm.dropIndex('pox4_events', 'signer_key');
+  pgm.dropColumn('pox4_events', 'signer_key');
+
+  pgm.addConstraint(
+    'pox4_events',
+    'valid_event_specific_columns',
+    `CHECK (
+    CASE name
+      WHEN 'handle-unlock' THEN
+        first_cycle_locked IS NOT NULL AND
+        first_unlocked_cycle IS NOT NULL
+      WHEN 'stack-stx' THEN
+        lock_period IS NOT NULL AND
+        lock_amount IS NOT NULL AND
+        start_burn_height IS NOT NULL AND
+        unlock_burn_height IS NOT NULL
+      WHEN 'stack-increase' THEN
+        increase_by IS NOT NULL AND
+        total_locked IS NOT NULL
+      WHEN 'stack-extend' THEN
+        extend_count IS NOT NULL AND
+        unlock_burn_height IS NOT NULL
+      WHEN 'delegate-stx' THEN
+        amount_ustx IS NOT NULL AND
+        delegate_to IS NOT NULL
+      WHEN 'delegate-stack-stx' THEN
+        lock_period IS NOT NULL AND
+        lock_amount IS NOT NULL AND
+        start_burn_height IS NOT NULL AND
+        unlock_burn_height IS NOT NULL AND
+        delegator IS NOT NULL
+      WHEN 'delegate-stack-increase' THEN
+        increase_by IS NOT NULL AND
+        total_locked IS NOT NULL AND
+        delegator IS NOT NULL
+      WHEN 'delegate-stack-extend' THEN
+        extend_count IS NOT NULL AND
+        unlock_burn_height IS NOT NULL AND
+        delegator IS NOT NULL
+      WHEN 'stack-aggregation-commit' THEN
+        reward_cycle IS NOT NULL AND
+        amount_ustx IS NOT NULL
+      WHEN 'stack-aggregation-commit-indexed' THEN
+        reward_cycle IS NOT NULL AND
+        amount_ustx IS NOT NULL
+      WHEN 'stack-aggregation-increase' THEN
+        reward_cycle IS NOT NULL AND
+        amount_ustx IS NOT NULL
+      WHEN 'revoke-delegate-stx' THEN
+        delegate_to IS NOT NULL
+      ELSE false
+    END
+  )`
+  );
+};

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -231,6 +231,7 @@ export function parsePoxSyntheticEvent(poxEvent: DbPoxSyntheticEvent) {
           lock_period: poxEvent.data.lock_period.toString(),
           start_burn_height: poxEvent.data.start_burn_height.toString(),
           unlock_burn_height: poxEvent.data.unlock_burn_height.toString(),
+          signer_key: poxEvent.data.signer_key,
         },
       };
     }
@@ -249,6 +250,7 @@ export function parsePoxSyntheticEvent(poxEvent: DbPoxSyntheticEvent) {
         data: {
           extend_count: poxEvent.data.extend_count.toString(),
           unlock_burn_height: poxEvent.data.unlock_burn_height.toString(),
+          signer_key: poxEvent.data.signer_key,
         },
       };
     }
@@ -300,6 +302,7 @@ export function parsePoxSyntheticEvent(poxEvent: DbPoxSyntheticEvent) {
         data: {
           reward_cycle: poxEvent.data.reward_cycle.toString(),
           amount_ustx: poxEvent.data.amount_ustx.toString(),
+          signer_key: poxEvent.data.signer_key,
         },
       };
     }
@@ -309,6 +312,7 @@ export function parsePoxSyntheticEvent(poxEvent: DbPoxSyntheticEvent) {
         data: {
           reward_cycle: poxEvent.data.reward_cycle.toString(),
           amount_ustx: poxEvent.data.amount_ustx.toString(),
+          signer_key: poxEvent.data.signer_key,
         },
       };
     }

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -1282,7 +1282,7 @@ export interface PoxSyntheticEventQueryResult {
   amount_ustx: string | null;
 
   // [pox4] unique to stacks-stx, stack-extend, stack-aggregation-commit, stack-aggregation-commit-indexed
-  signer_key: string | null;
+  signer_key?: string | null;
 }
 
 export interface PoxSyntheticEventInsertValues {
@@ -1343,7 +1343,7 @@ export interface PoxSyntheticEventInsertValues {
   amount_ustx: PgNumeric | null;
 
   // [pox4] unique to stacks-stx, stack-extend, stack-aggregation-commit, stack-aggregation-commit-indexed
-  signer_key: PgBytea | null;
+  signer_key?: PgBytea | null;
 }
 
 export interface NftEventInsertValues {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -367,6 +367,7 @@ export interface DbPoxSyntheticStackStxEvent extends DbPoxSyntheticBaseEventData
     lock_period: bigint;
     start_burn_height: bigint;
     unlock_burn_height: bigint;
+    signer_key: string | null;
   };
 }
 
@@ -383,6 +384,7 @@ export interface DbPoxSyntheticStackExtendEvent extends DbPoxSyntheticBaseEventD
   data: {
     extend_count: bigint;
     unlock_burn_height: bigint;
+    signer_key: string | null;
   };
 }
 
@@ -429,6 +431,7 @@ export interface DbPoxSyntheticStackAggregationCommitEvent extends DbPoxSyntheti
   data: {
     reward_cycle: bigint;
     amount_ustx: bigint;
+    signer_key: string | null;
   };
 }
 
@@ -438,6 +441,7 @@ export interface DbPoxSyntheticStackAggregationCommitIndexedEvent
   data: {
     reward_cycle: bigint;
     amount_ustx: bigint;
+    signer_key: string | null;
   };
 }
 
@@ -1276,6 +1280,9 @@ export interface PoxSyntheticEventQueryResult {
 
   // unique to stack-aggregation-commit, delegate-stx
   amount_ustx: string | null;
+
+  // [pox4] unique to stacks-stx, stack-extend, stack-aggregation-commit, stack-aggregation-commit-indexed
+  signer_key: string | null;
 }
 
 export interface PoxSyntheticEventInsertValues {
@@ -1334,6 +1341,9 @@ export interface PoxSyntheticEventInsertValues {
 
   // unique to stack-aggregation-commit, delegate-stx
   amount_ustx: PgNumeric | null;
+
+  // [pox4] unique to stacks-stx, stack-extend, stack-aggregation-commit, stack-aggregation-commit-indexed
+  signer_key: PgBytea | null;
 }
 
 export interface NftEventInsertValues {

--- a/src/datastore/helpers.ts
+++ b/src/datastore/helpers.ts
@@ -656,7 +656,7 @@ export function parseDbPoxSyntheticEvent(row: PoxSyntheticEventQueryResult): DbP
           lock_period: BigInt(unwrapOptionalProp(row, 'lock_period')),
           start_burn_height: BigInt(unwrapOptionalProp(row, 'start_burn_height')),
           unlock_burn_height: BigInt(unwrapOptionalProp(row, 'unlock_burn_height')),
-          signer_key: row.signer_key,
+          signer_key: row.signer_key ?? null,
         },
       };
       return {
@@ -685,7 +685,7 @@ export function parseDbPoxSyntheticEvent(row: PoxSyntheticEventQueryResult): DbP
         data: {
           extend_count: BigInt(unwrapOptionalProp(row, 'extend_count')),
           unlock_burn_height: BigInt(unwrapOptionalProp(row, 'unlock_burn_height')),
-          signer_key: row.signer_key,
+          signer_key: row.signer_key ?? null,
         },
       };
       return {
@@ -764,7 +764,7 @@ export function parseDbPoxSyntheticEvent(row: PoxSyntheticEventQueryResult): DbP
         data: {
           reward_cycle: BigInt(unwrapOptionalProp(row, 'reward_cycle')),
           amount_ustx: BigInt(unwrapOptionalProp(row, 'amount_ustx')),
-          signer_key: row.signer_key,
+          signer_key: row.signer_key ?? null,
         },
       };
       return {
@@ -779,7 +779,7 @@ export function parseDbPoxSyntheticEvent(row: PoxSyntheticEventQueryResult): DbP
         data: {
           reward_cycle: BigInt(unwrapOptionalProp(row, 'reward_cycle')),
           amount_ustx: BigInt(unwrapOptionalProp(row, 'amount_ustx')),
-          signer_key: row.signer_key,
+          signer_key: row.signer_key ?? null,
         },
       };
       return {

--- a/src/datastore/helpers.ts
+++ b/src/datastore/helpers.ts
@@ -656,6 +656,7 @@ export function parseDbPoxSyntheticEvent(row: PoxSyntheticEventQueryResult): DbP
           lock_period: BigInt(unwrapOptionalProp(row, 'lock_period')),
           start_burn_height: BigInt(unwrapOptionalProp(row, 'start_burn_height')),
           unlock_burn_height: BigInt(unwrapOptionalProp(row, 'unlock_burn_height')),
+          signer_key: row.signer_key,
         },
       };
       return {
@@ -684,6 +685,7 @@ export function parseDbPoxSyntheticEvent(row: PoxSyntheticEventQueryResult): DbP
         data: {
           extend_count: BigInt(unwrapOptionalProp(row, 'extend_count')),
           unlock_burn_height: BigInt(unwrapOptionalProp(row, 'unlock_burn_height')),
+          signer_key: row.signer_key,
         },
       };
       return {
@@ -762,6 +764,7 @@ export function parseDbPoxSyntheticEvent(row: PoxSyntheticEventQueryResult): DbP
         data: {
           reward_cycle: BigInt(unwrapOptionalProp(row, 'reward_cycle')),
           amount_ustx: BigInt(unwrapOptionalProp(row, 'amount_ustx')),
+          signer_key: row.signer_key,
         },
       };
       return {
@@ -776,6 +779,7 @@ export function parseDbPoxSyntheticEvent(row: PoxSyntheticEventQueryResult): DbP
         data: {
           reward_cycle: BigInt(unwrapOptionalProp(row, 'reward_cycle')),
           amount_ustx: BigInt(unwrapOptionalProp(row, 'amount_ustx')),
+          signer_key: row.signer_key,
         },
       };
       return {

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -1910,8 +1910,12 @@ export class PgStore extends BasePgStore {
     poxTable: PoxSyntheticEventTable;
   }): Promise<DbPoxSyntheticEvent[]> {
     return await this.sqlTransaction(async sql => {
+      const cols =
+        poxTable === 'pox4_events'
+          ? [...POX_SYNTHETIC_EVENT_COLUMNS, 'signer_key']
+          : POX_SYNTHETIC_EVENT_COLUMNS;
       const queryResults = await sql<PoxSyntheticEventQueryResult[]>`
-        SELECT ${sql(POX_SYNTHETIC_EVENT_COLUMNS)}
+        SELECT ${sql(cols)}
         FROM ${sql(poxTable)}
         WHERE canonical = true AND microblock_canonical = true
         ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -812,8 +812,10 @@ export class PgWriteStore extends PgStore {
           extend_count: null,
           reward_cycle: null,
           amount_ustx: null,
-          signer_key: null,
         };
+        if (poxTable === 'pox4_events') {
+          value.signer_key = null;
+        }
 
         // Set event-specific columns
         switch (event.name) {
@@ -827,7 +829,9 @@ export class PgWriteStore extends PgStore {
             value.lock_amount = event.data.lock_amount.toString();
             value.start_burn_height = event.data.start_burn_height.toString();
             value.unlock_burn_height = event.data.unlock_burn_height.toString();
-            value.signer_key = event.data.signer_key;
+            if (poxTable === 'pox4_events') {
+              value.signer_key = event.data.signer_key;
+            }
             break;
           }
           case SyntheticPoxEventName.StackIncrease: {
@@ -838,7 +842,9 @@ export class PgWriteStore extends PgStore {
           case SyntheticPoxEventName.StackExtend: {
             value.extend_count = event.data.extend_count.toString();
             value.unlock_burn_height = event.data.unlock_burn_height.toString();
-            value.signer_key = event.data.signer_key;
+            if (poxTable === 'pox4_events') {
+              value.signer_key = event.data.signer_key;
+            }
             break;
           }
           case SyntheticPoxEventName.DelegateStx: {
@@ -870,13 +876,17 @@ export class PgWriteStore extends PgStore {
           case SyntheticPoxEventName.StackAggregationCommit: {
             value.reward_cycle = event.data.reward_cycle.toString();
             value.amount_ustx = event.data.amount_ustx.toString();
-            value.signer_key = event.data.signer_key;
+            if (poxTable === 'pox4_events') {
+              value.signer_key = event.data.signer_key;
+            }
             break;
           }
           case SyntheticPoxEventName.StackAggregationCommitIndexed: {
             value.reward_cycle = event.data.reward_cycle.toString();
             value.amount_ustx = event.data.amount_ustx.toString();
-            value.signer_key = event.data.signer_key;
+            if (poxTable === 'pox4_events') {
+              value.signer_key = event.data.signer_key;
+            }
             break;
           }
           case SyntheticPoxEventName.StackAggregationIncrease: {

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -812,6 +812,7 @@ export class PgWriteStore extends PgStore {
           extend_count: null,
           reward_cycle: null,
           amount_ustx: null,
+          signer_key: null,
         };
 
         // Set event-specific columns
@@ -826,6 +827,7 @@ export class PgWriteStore extends PgStore {
             value.lock_amount = event.data.lock_amount.toString();
             value.start_burn_height = event.data.start_burn_height.toString();
             value.unlock_burn_height = event.data.unlock_burn_height.toString();
+            value.signer_key = event.data.signer_key;
             break;
           }
           case SyntheticPoxEventName.StackIncrease: {
@@ -836,6 +838,7 @@ export class PgWriteStore extends PgStore {
           case SyntheticPoxEventName.StackExtend: {
             value.extend_count = event.data.extend_count.toString();
             value.unlock_burn_height = event.data.unlock_burn_height.toString();
+            value.signer_key = event.data.signer_key;
             break;
           }
           case SyntheticPoxEventName.DelegateStx: {
@@ -867,11 +870,13 @@ export class PgWriteStore extends PgStore {
           case SyntheticPoxEventName.StackAggregationCommit: {
             value.reward_cycle = event.data.reward_cycle.toString();
             value.amount_ustx = event.data.amount_ustx.toString();
+            value.signer_key = event.data.signer_key;
             break;
           }
           case SyntheticPoxEventName.StackAggregationCommitIndexed: {
             value.reward_cycle = event.data.reward_cycle.toString();
             value.amount_ustx = event.data.amount_ustx.toString();
+            value.signer_key = event.data.signer_key;
             break;
           }
           case SyntheticPoxEventName.StackAggregationIncrease: {

--- a/src/event-stream/pox-event-parsing.ts
+++ b/src/event-stream/pox-event-parsing.ts
@@ -97,6 +97,7 @@ interface PoxSyntheticPrintEventTypes {
     'pox-addr': PoxSyntheticEventAddr;
     'start-burn-height': ClarityValueUInt;
     'unlock-burn-height': ClarityValueUInt;
+    'signer-key'?: ClarityValueBuffer | ClarityValueOptionalNone;
   };
   [SyntheticPoxEventName.StackIncrease]: {
     'increase-by': ClarityValueUInt;
@@ -106,6 +107,7 @@ interface PoxSyntheticPrintEventTypes {
     'extend-count': ClarityValueUInt;
     'unlock-burn-height': ClarityValueUInt;
     'pox-addr': PoxSyntheticEventAddr;
+    'signer-key'?: ClarityValueBuffer | ClarityValueOptionalNone;
   };
   [SyntheticPoxEventName.DelegateStx]: {
     'amount-ustx': ClarityValueUInt;
@@ -132,16 +134,19 @@ interface PoxSyntheticPrintEventTypes {
     'unlock-burn-height': ClarityValueUInt;
     'extend-count': ClarityValueUInt;
     delegator: ClarityValuePrincipalStandard | ClarityValuePrincipalContract;
+    'signer-key'?: ClarityValueBuffer | ClarityValueOptionalNone;
   };
   [SyntheticPoxEventName.StackAggregationCommit]: {
     'pox-addr': PoxSyntheticEventAddr;
     'reward-cycle': ClarityValueUInt;
     'amount-ustx': ClarityValueUInt;
+    'signer-key'?: ClarityValueBuffer | ClarityValueOptionalNone;
   };
   [SyntheticPoxEventName.StackAggregationCommitIndexed]: {
     'pox-addr': PoxSyntheticEventAddr;
     'reward-cycle': ClarityValueUInt;
     'amount-ustx': ClarityValueUInt;
+    'signer-key'?: ClarityValueBuffer | ClarityValueOptionalNone;
   };
   [SyntheticPoxEventName.StackAggregationIncrease]: {
     'pox-addr': PoxSyntheticEventAddr;
@@ -252,6 +257,8 @@ export function decodePoxSyntheticPrintEvent(
           lock_period: BigInt(d['lock-period'].value),
           start_burn_height: BigInt(d['start-burn-height'].value),
           unlock_burn_height: BigInt(d['unlock-burn-height'].value),
+          signer_key:
+            d['signer-key']?.type_id === ClarityTypeID.Buffer ? d['signer-key'].buffer : null,
         },
       };
       if (PATCH_EVENT_BALANCES) {
@@ -285,6 +292,8 @@ export function decodePoxSyntheticPrintEvent(
         data: {
           extend_count: BigInt(d['extend-count'].value),
           unlock_burn_height: BigInt(d['unlock-burn-height'].value),
+          signer_key:
+            d['signer-key']?.type_id === ClarityTypeID.Buffer ? d['signer-key'].buffer : null,
         },
       };
       if (PATCH_EVENT_BALANCES) {
@@ -374,6 +383,8 @@ export function decodePoxSyntheticPrintEvent(
         data: {
           reward_cycle: BigInt(d['reward-cycle'].value),
           amount_ustx: BigInt(d['amount-ustx'].value),
+          signer_key:
+            d['signer-key']?.type_id === ClarityTypeID.Buffer ? d['signer-key'].buffer : null,
         },
       };
       return parsedData;
@@ -386,6 +397,8 @@ export function decodePoxSyntheticPrintEvent(
         data: {
           reward_cycle: BigInt(d['reward-cycle'].value),
           amount_ustx: BigInt(d['amount-ustx'].value),
+          signer_key:
+            d['signer-key']?.type_id === ClarityTypeID.Buffer ? d['signer-key'].buffer : null,
         },
       };
       return parsedData;

--- a/src/tests-2.5/pox-4-burnchain-delegate-stx.ts
+++ b/src/tests-2.5/pox-4-burnchain-delegate-stx.ts
@@ -403,7 +403,6 @@ describe('PoX-4 - Stack using Bitcoin-chain delegate ops', () => {
         poxAddrPayoutAccount.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(1), // lock-period
-        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,

--- a/src/tests-2.5/pox-4-delegate-aggregation.ts
+++ b/src/tests-2.5/pox-4-delegate-aggregation.ts
@@ -204,7 +204,6 @@ describe('PoX-4 - Delegate aggregation increase operations', () => {
         delegateeAccount.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(1), // lock-period,
-        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -261,6 +260,7 @@ describe('PoX-4 - Delegate aggregation increase operations', () => {
       functionArgs: [
         delegateeAccount.poxAddrClar, // pox-addr
         uintCV(rewardCycle), // reward-cycle
+        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,

--- a/src/tests-2.5/pox-4-delegate-revoked-stacking.ts
+++ b/src/tests-2.5/pox-4-delegate-revoked-stacking.ts
@@ -127,7 +127,6 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
         STACKER.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(1), // lock-period
-        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -214,7 +213,6 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
         STACKER.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(3), // lock-period
-        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -319,7 +317,6 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
         STACKER.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(1), // lock-period
-        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -370,7 +367,6 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
         standardPrincipalCV(STACKER.stxAddr), // stacker
         STACKER.poxAddrClar, // pox-addr
         uintCV(2), // extend-count
-        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -400,7 +396,6 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
         STACKER.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(1), // lock-period
-        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -427,6 +422,7 @@ describe('PoX-4 - Delegate Revoked Stacking', () => {
       functionArgs: [
         STACKER.poxAddrClar, // pox-addr
         uintCV(rewardCycle), // reward-cycle
+        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,

--- a/src/tests-2.5/pox-4-delegate-stacking.ts
+++ b/src/tests-2.5/pox-4-delegate-stacking.ts
@@ -220,7 +220,6 @@ describe('PoX-4 - Delegate Stacking operations', () => {
         delegateeAccount.poxAddrClar, // pox-addr
         uintCV(startBurnHt), // start-burn-ht
         uintCV(1), // lock-period,
-        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -346,7 +345,6 @@ describe('PoX-4 - Delegate Stacking operations', () => {
         standardPrincipalCV(delegateeAccount.stxAddr), // stacker
         delegateeAccount.poxAddrClar, // pox-addr
         uintCV(extendCount), // extend-count
-        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,
@@ -405,6 +403,7 @@ describe('PoX-4 - Delegate Stacking operations', () => {
       functionArgs: [
         delegateeAccount.poxAddrClar, // pox-addr
         uintCV(rewardCycle), // reward-cycle
+        bufferCV(randomBytes(33)), // signer-key
       ],
       network: testEnv.stacksNetwork,
       anchorMode: AnchorMode.OnChainOnly,

--- a/stacks-blockchain/docker/Dockerfile
+++ b/stacks-blockchain/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Pointed to stacks-blockchain `2.1.0.0.0` git tag
-FROM --platform=linux/amd64 hirosystems/stacks-api-e2e:stacks3.0-1d675fd as build
+FROM --platform=linux/amd64 hirosystems/stacks-api-e2e:stacks3.0-457f270 as build
 
 FROM --platform=linux/amd64 debian:bookworm
 


### PR DESCRIPTION
Parse `signer-key` arg from pox events (when they are available / in pox4).

Example `GET /extended/v1/pox4/events`
```json
{
  "limit": 96,
  "offset": 0,
  "results": [
    {
      "block_height": 7,
      "tx_id": "0x6acc6a9a560eedc7be41b645677196ef581c02b039a1ae3e80669af04af67fc4",
      "tx_index": 1,
      "event_index": 1,
      "stacker": "ST18MDW2PDTBSCR1ACXYRJP2JX70FWNM6YY2VX4SS",
      "locked": "3000225000000000",
      "balance": "6999774999999000",
      "burnchain_unlock_height": "140",
      "pox_addr": "mnvi1WQb3cm2QMeeKe6G9D7L1GsjmmGTda",
      "pox_addr_raw": "0x005146f0566e9796602a677d895852e9c0fe5686f7",
      "name": "stack-stx",
      "data": {
        "lock_amount": "3000225000000000",
        "lock_period": "2",
        "start_burn_height": "110",
        "unlock_burn_height": "140",
        "signer_key": "0xc6f48a7ea4fa4919b5135ac37eb1d33900cea5ddb63c4fd1fe4dd02d0749566135"
      }
    }
  ]
}
```

Backwards compatible with pox1-3
`GET /extended/v1/pox3/events`
```
{
  "limit": 96,
  "offset": 0,
  "results": [
    {
      "block_height": 18,
      "tx_id": "0xc4eb4d0962caa87bdb1e85bca8f9d6ff0e1724f5d540afdcbae991bc0a7ac986",
      "tx_index": 0,
      "event_index": 1,
      "stacker": "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6",
      "locked": "2062698000000000",
      "balance": "7937301999990000",
      "burnchain_unlock_height": "125",
      "pox_addr": "mmf4gs6mwBYpudc2agd7MomJo8HJd6XksD",
      "pox_addr_raw": "0x0043596b5386f466863e25658ddf94bd0fadab0048",
      "name": "stack-stx",
      "data": {
        "lock_amount": "2062698000000000",
        "lock_period": "1",
        "start_burn_height": "118",
        "unlock_burn_height": "125",
        "signer_key": null
      }
    }
  ]
}
```