### PR TITLE
update broken anchors for deprecated endpoints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -123,7 +123,7 @@ paths:
         required: true
         schema:
           type: string
-          example: '2N4M94S1ZPt8HfxydXzL2P7qyzgVq7MHWts'
+          example: "2N4M94S1ZPt8HfxydXzL2P7qyzgVq7MHWts"
     post:
       summary: Add testnet BTC tokens to address
       description: |
@@ -214,15 +214,7 @@ paths:
             example: coinbase
             items:
               type: string
-              enum:
-                [
-                  coinbase,
-                  token_transfer,
-                  smart_contract,
-                  contract_call,
-                  poison_microblock,
-                  tenure_change,
-                ]
+              enum: [coinbase, token_transfer, smart_contract, contract_call, poison_microblock, tenure_change]
         - name: unanchored
           in: query
           description: Include transaction data from unanchored (i.e. unconfirmed) microblocks
@@ -248,9 +240,9 @@ paths:
         - Transactions
       operationId: get_mempool_transaction_list
       description: |
-        Retrieves all transactions that have been recently broadcast to the mempool. These are pending transactions awaiting confirmation.
+          Retrieves all transactions that have been recently broadcast to the mempool. These are pending transactions awaiting confirmation.
 
-        If you need to monitor new transactions, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.
+          If you need to monitor new transactions, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.
       parameters:
         - name: sender_address
           in: query
@@ -258,7 +250,7 @@ paths:
           required: false
           schema:
             type: string
-            example: 'SP1GPBP8NBRXDRJBFQBV7KMAZX1Z7W2RFWJEH0V10'
+            example: "SP1GPBP8NBRXDRJBFQBV7KMAZX1Z7W2RFWJEH0V10"
         - name: recipient_address
           in: query
           description: Filter to only return transactions with this recipient address (only applicable for STX transfer tx types).
@@ -328,7 +320,7 @@ paths:
         - Mempool
       operationId: get_mempool_fee_priorities
       description: |
-        Returns estimated fee priorities (in micro-STX) for all transactions that are currently in the mempool. Also returns priorities separated by transaction type.
+          Returns estimated fee priorities (in micro-STX) for all transactions that are currently in the mempool. Also returns priorities separated by transaction type.
       responses:
         200:
           description: Mempool fee priorities
@@ -407,12 +399,11 @@ paths:
         explode: true
         schema:
           type: array
-          example:
-            [
-              '0x0a411719e3bfde95f9e227a2d7f8fac3d6c646b1e6cc186db0e2838a2c6cd9c0',
-              '0xfbe6412b46e9db87df991a0d043ff47eb58019f770208cf48e2380337cc31785',
-              '0x178b77678a758d9f29a147d6399315c83d0f1baf114431fbe4d3587aa5fbba6f',
-            ]
+          example: [
+            "0x0a411719e3bfde95f9e227a2d7f8fac3d6c646b1e6cc186db0e2838a2c6cd9c0",
+            "0xfbe6412b46e9db87df991a0d043ff47eb58019f770208cf48e2380337cc31785",
+            "0x178b77678a758d9f29a147d6399315c83d0f1baf114431fbe4d3587aa5fbba6f"
+          ]
           items:
             type: string
       - name: event_offset
@@ -466,7 +457,7 @@ paths:
         required: true
         schema:
           type: string
-          example: '0x0a411719e3bfde95f9e227a2d7f8fac3d6c646b1e6cc186db0e2838a2c6cd9c0'
+          example: "0x0a411719e3bfde95f9e227a2d7f8fac3d6c646b1e6cc186db0e2838a2c6cd9c0"
       - name: event_offset
         in: query
         schema:
@@ -516,7 +507,7 @@ paths:
         required: true
         schema:
           type: string
-          example: '0x0a411719e3bfde95f9e227a2d7f8fac3d6c646b1e6cc186db0e2838a2c6cd9c0'
+          example: "0x0a411719e3bfde95f9e227a2d7f8fac3d6c646b1e6cc186db0e2838a2c6cd9c0"
     get:
       summary: Get Raw Transaction
       tags:
@@ -557,7 +548,7 @@ paths:
             text/plain:
               schema:
                 type: string
-                example: 'e161978626f216b2141b156ade10501207ae535fa365a13ef5d7a7c9310a09f2'
+                example: "e161978626f216b2141b156ade10501207ae535fa365a13ef5d7a7c9310a09f2"
         400:
           description: Rejections result in a 400 error
           content:
@@ -574,9 +565,9 @@ paths:
         - Microblocks
       operationId: get_microblock_list
       description: |
-        Retrieves a list of microblocks.
+          Retrieves a list of microblocks.
 
-        If you need to actively monitor new microblocks, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.
+          If you need to actively monitor new microblocks, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.
       parameters:
         - name: limit
           in: query
@@ -610,7 +601,7 @@ paths:
         required: true
         schema:
           type: string
-          example: '0x3bfcdf84b3012adb544cf0f6df4835f93418c2269a3881885e27b3d58eb82d47'
+          example: "0x3bfcdf84b3012adb544cf0f6df4835f93418c2269a3881885e27b3d58eb82d47"
 
     get:
       summary: Get microblock
@@ -651,7 +642,7 @@ paths:
     get:
       summary: Get burn blocks
       description: |
-        Retrieves a list of recent burn blocks
+          Retrieves a list of recent burn blocks
       tags:
         - Burn Blocks
       operationId: get_burn_blocks
@@ -698,7 +689,7 @@ paths:
               - type: integer
                 example: 42000
               - type: string
-                example: '0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79'
+                example: "0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79"
       responses:
         200:
           description: Burn block
@@ -708,7 +699,7 @@ paths:
                 $ref: ./entities/blocks/burn-block.schema.json
               example:
                 $ref: ./entities/blocks/burn-block.example.json
-
+  
   /extended/v2/burn-blocks/{height_or_hash}/blocks:
     get:
       summary: Get blocks by burn block
@@ -727,7 +718,7 @@ paths:
               - type: integer
                 example: 42000
               - type: string
-                example: '0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79'
+                example: "0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79"
         - name: limit
           in: query
           description: max number of blocks to fetch
@@ -784,7 +775,7 @@ paths:
                 $ref: ./api/blocks/get-nakamoto-blocks.schema.json
               example:
                 $ref: ./api/blocks/get-nakamoto-blocks.example.json
-
+  
   /extended/v2/blocks/{height_or_hash}:
     get:
       summary: Get block
@@ -803,7 +794,7 @@ paths:
               - type: integer
                 example: 42000
               - type: string
-                example: '0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79'
+                example: "0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79"
       responses:
         200:
           description: Block
@@ -832,7 +823,7 @@ paths:
               - type: integer
                 example: 42000
               - type: string
-                example: '0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79'
+                example: "0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79"
       responses:
         200:
           description: List of transactions
@@ -848,11 +839,11 @@ paths:
       summary: Get recent blocks
       deprecated: true
       description: |
-        **NOTE:** This endpoint is deprecated in favor of [Get blocks](/api/get-blocks).
+          **NOTE:** This endpoint is deprecated in favor of [Get blocks](/api/get-blocks).
 
-        Retrieves a list of recently mined blocks
+          Retrieves a list of recently mined blocks
 
-        If you need to actively monitor new blocks, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.
+          If you need to actively monitor new blocks, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.
       tags:
         - Blocks
       operationId: get_block_list
@@ -889,13 +880,13 @@ paths:
         required: true
         schema:
           type: string
-          example: '0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79'
+          example: "0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79"
     get:
       deprecated: true
       summary: Get block by hash
       description: |
         **NOTE:** This endpoint is deprecated in favor of [Get block](/api/get-block).
-
+        
         Retrieves block details of a specific block for a given chain height. You can use the hash from your latest block ('get_block_list' API) to get your block details.
       tags:
         - Blocks
@@ -957,7 +948,7 @@ paths:
         required: true
         schema:
           type: string
-          example: '0x00000000000000000002bba732926cf68b6eda3e2cdbc2a85af79f10efeeeb10'
+          example: "0x00000000000000000002bba732926cf68b6eda3e2cdbc2a85af79f10efeeeb10"
     get:
       summary: Get block by burnchain block hash
       deprecated: true
@@ -1066,7 +1057,7 @@ paths:
           required: true
           schema:
             type: string
-            example: '36hQtSEXBMevo5chpxhfAGiCTSC34QKgda'
+            example: "36hQtSEXBMevo5chpxhfAGiCTSC34QKgda"
         - name: limit
           in: query
           description: max number of items to fetch
@@ -1136,7 +1127,7 @@ paths:
           required: true
           schema:
             type: string
-            example: '36hQtSEXBMevo5chpxhfAGiCTSC34QKgda'
+            example: "36hQtSEXBMevo5chpxhfAGiCTSC34QKgda"
         - name: limit
           in: query
           description: max number of rewards to fetch
@@ -1173,7 +1164,7 @@ paths:
           required: true
           schema:
             type: string
-            example: '36hQtSEXBMevo5chpxhfAGiCTSC34QKgda'
+            example: "36hQtSEXBMevo5chpxhfAGiCTSC34QKgda"
       responses:
         200:
           description: List of burnchain reward recipients and amounts
@@ -1209,7 +1200,7 @@ paths:
         required: true
         schema:
           type: string
-          example: 'SP6P4EJF0VG8V0RB3TQQKJBHDQKEF6NVRD1KZE3C.satoshibles'
+          example: "SP6P4EJF0VG8V0RB3TQQKJBHDQKEF6NVRD1KZE3C.satoshibles"
       - name: unanchored
         in: query
         description: Include transaction data from unanchored (i.e. unconfirmed) microblocks
@@ -1270,7 +1261,7 @@ paths:
           required: true
           schema:
             type: string
-            example: 'SP6P4EJF0VG8V0RB3TQQKJBHDQKEF6NVRD1KZE3C.satoshibles'
+            example: "SP6P4EJF0VG8V0RB3TQQKJBHDQKEF6NVRD1KZE3C.satoshibles"
         - name: limit
           in: query
           description: max number of contract events to fetch
@@ -1332,7 +1323,7 @@ paths:
         description: Contract name
         schema:
           type: string
-          example: 'satoshibles'
+          example: "satoshibles"
       - name: tip
         in: query
         schema:
@@ -1369,7 +1360,7 @@ paths:
           description: Stacks address
           schema:
             type: string
-            example: 'SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11'
+            example: "SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11"
         - name: contract_name
           in: path
           required: true
@@ -1402,7 +1393,7 @@ paths:
           application/json:
             schema:
               type: string
-            example:
+            example: 
               $ref: ./entities/contracts/get-specific-data-map-inside-contract.example.json
 
   /v2/contracts/source/{contract_address}/{contract_name}:
@@ -1428,7 +1419,7 @@ paths:
         description: Stacks address
         schema:
           type: string
-          example: 'SP6P4EJF0VG8V0RB3TQQKJBHDQKEF6NVRD1KZE3C'
+          example: "SP6P4EJF0VG8V0RB3TQQKJBHDQKEF6NVRD1KZE3C"
       - name: contract_name
         in: path
         required: true
@@ -1479,7 +1470,7 @@ paths:
           description: Stacks address
           schema:
             type: string
-            example: 'SP187Y7NRSG3T9Z9WTSWNEN3XRV1YSJWS81C7JKV7'
+            example: "SP187Y7NRSG3T9Z9WTSWNEN3XRV1YSJWS81C7JKV7"
         - name: contract_name
           in: path
           required: true
@@ -1524,7 +1515,7 @@ paths:
           required: true
           schema:
             type: string
-            example: 'SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0'
+            example: "SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0"
         - name: unanchored
           in: query
           description: Include transaction data from unanchored (i.e. unconfirmed) microblocks
@@ -1564,7 +1555,7 @@ paths:
           required: true
           schema:
             type: string
-            example: 'SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0'
+            example: "SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0"
         - name: unanchored
           in: query
           description: Include transaction data from unanchored (i.e. unconfirmed) microblocks.
@@ -1594,9 +1585,9 @@ paths:
     get:
       summary: Get account transactions
       description: |
-        Retrieves a list of all Transactions for a given Address or Contract Identifier. More information on Transaction types can be found [here](https://docs.stacks.co/understand-stacks/transactions#types).
+          Retrieves a list of all Transactions for a given Address or Contract Identifier. More information on Transaction types can be found [here](https://docs.stacks.co/understand-stacks/transactions#types).
 
-        If you need to actively monitor new transactions for an address or contract id, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.
+          If you need to actively monitor new transactions for an address or contract id, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.
       tags:
         - Accounts
       operationId: get_account_transactions
@@ -1607,7 +1598,7 @@ paths:
           required: true
           schema:
             type: string
-            example: 'SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0'
+            example: "SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0"
         - name: limit
           in: query
           description: max number of account transactions to fetch
@@ -1668,14 +1659,14 @@ paths:
           required: true
           schema:
             type: string
-            example: 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE'
+            example: "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE"
         - name: tx_id
           in: path
           description: Transaction id
           required: true
           schema:
             type: string
-            example: '0x34d79c7cfc2fe525438736733e501a4bf0308a5556e3e080d1e2c0858aad7448'
+            example: "0x34d79c7cfc2fe525438736733e501a4bf0308a5556e3e080d1e2c0858aad7448"
       responses:
         200:
           description: Success
@@ -1706,7 +1697,7 @@ paths:
           required: true
           schema:
             type: string
-            example: 'SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0'
+            example: "SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0"
         - name: limit
           in: query
           description: max number of account transactions to fetch
@@ -1767,7 +1758,7 @@ paths:
           required: true
           schema:
             type: string
-            example: 'SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0'
+            example: "SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0"
         - name: block_height
           in: query
           description: Optionally get the nonce at a given block height.
@@ -1781,7 +1772,7 @@ paths:
           required: false
           schema:
             type: string
-            example: '0x72d53f3cba39e149dcd42708e535bdae03d73e60d2fe853aaf61c0b392f521e9'
+            example: "0x72d53f3cba39e149dcd42708e535bdae03d73e60d2fe853aaf61c0b392f521e9"
 
       responses:
         200:
@@ -1807,7 +1798,7 @@ paths:
           required: true
           schema:
             type: string
-            example: 'SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0'
+            example: "SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0"
         - name: limit
           in: query
           description: max number of account assets to fetch
@@ -1863,7 +1854,7 @@ paths:
           required: true
           schema:
             type: string
-            example: 'SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0'
+            example: "SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0"
         - name: limit
           in: query
           description: number of items to return
@@ -1927,7 +1918,7 @@ paths:
           required: true
           schema:
             type: string
-            example: 'SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0'
+            example: "SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0"
         - name: proof
           in: query
           description: Returns object without the proof field if set to 0
@@ -2160,7 +2151,7 @@ paths:
           required: true
           schema:
             type: string
-            example: '0xcf8b233f19f6c07d2dc1963302d2436efd36e9afac127bf6582824a13961c06d'
+            example: "0xcf8b233f19f6c07d2dc1963302d2436efd36e9afac127bf6582824a13961c06d"
           description: The hex hash string for a block or transaction, account address, or contract address
         - in: query
           name: include_metadata
@@ -2234,7 +2225,7 @@ paths:
           application/json:
             schema:
               $ref: ./api/rosetta/rosetta-network-options-request.schema.json
-            example:
+            example: 
               $ref: ./api/rosetta/rosetta-account-network-options-request-body.example.json
 
   /rosetta/v1/network/status:
@@ -2265,7 +2256,7 @@ paths:
           application/json:
             schema:
               $ref: ./api/rosetta/rosetta-network-status-request.schema.json
-            example:
+            example: 
               $ref: ./api/rosetta/rosetta-account-network-options-request-body.example.json
 
   /rosetta/v1/account/balance:
@@ -2296,7 +2287,7 @@ paths:
           application/json:
             schema:
               $ref: ./api/rosetta/rosetta-account-balance-request.schema.json
-            example:
+            example: 
               $ref: ./api/rosetta/rosetta-account-balance-request-body.example.json
 
   /rosetta/v1/block:
@@ -2325,7 +2316,7 @@ paths:
           application/json:
             schema:
               $ref: ./api/rosetta/rosetta-block-request.schema.json
-            example:
+            example: 
               $ref: ./api/rosetta/rosetta-block-request-body.example.json
 
   /rosetta/v1/block/transaction:
@@ -2354,7 +2345,7 @@ paths:
           application/json:
             schema:
               $ref: ./api/rosetta/rosetta-block-transaction-request.schema.json
-            example:
+            example: 
               $ref: ./api/rosetta/rosetta-block-transaction-request-body.example.json
 
   /rosetta/v1/mempool:
@@ -2383,7 +2374,7 @@ paths:
           application/json:
             schema:
               $ref: ./api/rosetta/rosetta-mempool-request.schema.json
-            example:
+            example: 
               $ref: ./api/rosetta/rosetta-account-network-options-request-body.example.json
 
   /rosetta/v1/mempool/transaction:
@@ -2439,7 +2430,7 @@ paths:
           application/json:
             schema:
               $ref: ./api/rosetta/rosetta-construction-derive-request.schema.json
-            example:
+            example: 
               $ref: ./api/rosetta/rosetta-account-identifier-publickey-request-body.example.json
 
   /rosetta/v1/construction/hash:
@@ -2852,6 +2843,7 @@ paths:
               example:
                 $ref: ./api/bns/subdomains/subdomains-list.example.json
 
+
   /v1/names/{name}/zonefile:
     get:
       summary: Get Zone File
@@ -2914,7 +2906,7 @@ paths:
           required: true
           schema:
             type: string
-            example: 'b100a68235244b012854a95f9114695679002af9'
+            example: "b100a68235244b012854a95f9114695679002af9"
       responses:
         200:
           description: Success
@@ -2962,7 +2954,7 @@ paths:
           required: true
           schema:
             type: string
-            example: '1QJQxDas5JhdiXhEbNS14iNjr8auFT96GP'
+            example: "1QJQxDas5JhdiXhEbNS14iNjr8auFT96GP"
       responses:
         200:
           description: Success
@@ -2999,7 +2991,7 @@ paths:
           required: true
           schema:
             type: string
-            example: '0x0a83d82a65460a9e711f85a44616350280040b75317dbe486a923c1131b5ff99'
+            example: "0x0a83d82a65460a9e711f85a44616350280040b75317dbe486a923c1131b5ff99"
         - name: limit
           in: query
           description: max number of transactions to fetch
@@ -3089,7 +3081,7 @@ paths:
           required: true
           schema:
             type: string
-            example: 'SP197DVH8KTJGX4STM61QN0WJV8Y9QJWXV83ZGNR9'
+            example: "SP197DVH8KTJGX4STM61QN0WJV8Y9QJWXV83ZGNR9"
         - name: limit
           in: query
           description: max number of transactions to fetch
@@ -3140,7 +3132,7 @@ paths:
           required: true
           schema:
             type: string
-            example: 'SPNWZ5V2TPWGQGVDR6T7B6RQ4XMGZ4PXTEE0VQ0S.marketplace-v3'
+            example: "SPNWZ5V2TPWGQGVDR6T7B6RQ4XMGZ4PXTEE0VQ0S.marketplace-v3"
         - name: asset_identifiers
           in: query
           description: identifiers of the token asset classes to filter for
@@ -3149,7 +3141,7 @@ paths:
           explode: true
           schema:
             type: array
-            example: 'SPQZF23W7SEYBFG5JQ496NMY0G7379SRYEDREMSV.Candy::candy'
+            example: "SPQZF23W7SEYBFG5JQ496NMY0G7379SRYEDREMSV.Candy::candy"
             items:
               type: string
         - name: limit
@@ -3214,14 +3206,14 @@ paths:
           required: true
           schema:
             type: string
-            example: 'SP2X0TZ59D5SZ8ACQ6YMCHHNR2ZN51Z32E2CJ173.the-explorer-guild::The-Explorer-Guild'
+            example: "SP2X0TZ59D5SZ8ACQ6YMCHHNR2ZN51Z32E2CJ173.the-explorer-guild::The-Explorer-Guild"
         - name: value
           in: query
           description: hex representation of the token's unique value
           required: true
           schema:
             type: string
-            example: '0x0100000000000000000000000000000803'
+            example: "0x0100000000000000000000000000000803"
         - name: limit
           in: query
           description: max number of events to fetch
@@ -3284,7 +3276,7 @@ paths:
           required: true
           schema:
             type: string
-            example: 'SP2X0TZ59D5SZ8ACQ6YMCHHNR2ZN51Z32E2CJ173.the-explorer-guild::The-Explorer-Guild'
+            example: "SP2X0TZ59D5SZ8ACQ6YMCHHNR2ZN51Z32E2CJ173.the-explorer-guild::The-Explorer-Guild"
         - name: limit
           in: query
           description: max number of events to fetch
@@ -3442,8 +3434,7 @@ paths:
   /extended/v1/tx/events:
     get:
       summary: Transaction Events
-      description:
-        Retrieves the list of events filtered by principal (STX address or Smart Contract ID), transaction id or event types.
+      description: Retrieves the list of events filtered by principal (STX address or Smart Contract ID), transaction id or event types.
         The list of event types is ('smart_contract_log', 'stx_lock', 'stx_asset', 'fungible_token_asset', 'non_fungible_token_asset').
       tags:
         - Transactions
@@ -3453,7 +3444,7 @@ paths:
           in: query
           description: Hash of transaction
           required: false
-          example: '0x29e25515652dad41ef675bd0670964e3d537b80ec19cf6ca6f1dd65d5bc642c5'
+          example: "0x29e25515652dad41ef675bd0670964e3d537b80ec19cf6ca6f1dd65d5bc642c5"
           schema:
             type: string
         - name: address
@@ -3462,7 +3453,7 @@ paths:
           required: false
           schema:
             type: string
-            example: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4'
+            example: "ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4"
         - name: limit
           in: query
           description: number of items to return
@@ -3488,14 +3479,7 @@ paths:
             example: stx_lock
             items:
               type: string
-              enum:
-                [
-                  smart_contract_log,
-                  stx_lock,
-                  stx_asset,
-                  fungible_token_asset,
-                  non_fungible_token_asset,
-                ]
+              enum: [smart_contract_log, stx_lock, stx_asset, fungible_token_asset, non_fungible_token_asset]
       responses:
         200:
           description: Success
@@ -3517,7 +3501,7 @@ paths:
           in: path
           description: Address principal of the stacking pool delegator
           required: true
-          example: 'SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11'
+          example: "SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11"
           schema:
             type: string
         - name: after_block

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -839,7 +839,7 @@ paths:
       summary: Get recent blocks
       deprecated: true
       description: |
-          **NOTE:** This endpoint is deprecated in favor of [Get blocks](#operation/get_blocks).
+          **NOTE:** This endpoint is deprecated in favor of [Get blocks](https://docs.hiro.so/api/get-blocks).
 
           Retrieves a list of recently mined blocks
 
@@ -885,7 +885,7 @@ paths:
       deprecated: true
       summary: Get block by hash
       description: |
-        **NOTE:** This endpoint is deprecated in favor of [Get block](#operation/get_block).
+        **NOTE:** This endpoint is deprecated in favor of [Get block](https://docs.hiro.so/api/get-block).
         
         Retrieves block details of a specific block for a given chain height. You can use the hash from your latest block ('get_block_list' API) to get your block details.
       tags:
@@ -919,7 +919,7 @@ paths:
       deprecated: true
       summary: Get block by height
       description: |
-        **NOTE:** This endpoint is deprecated in favor of [Get block](#operation/get_block).
+        **NOTE:** This endpoint is deprecated in favor of [Get block](https://docs.hiro.so/api/get-block).
 
         Retrieves block details of a specific block at a given block height
       tags:
@@ -953,7 +953,7 @@ paths:
       summary: Get block by burnchain block hash
       deprecated: true
       description: |
-        **NOTE:** This endpoint is deprecated in favor of [Get blocks](#operation/get_blocks).
+        **NOTE:** This endpoint is deprecated in favor of [Get blocks](https://docs.hiro.so/api/get-blocks).
 
         Retrieves block details of a specific block for a given burnchain block hash
       tags:
@@ -988,7 +988,7 @@ paths:
       summary: Get block by burnchain height
       deprecated: true
       description: |
-        **NOTE:** This endpoint is deprecated in favor of [Get blocks](#operation/get_blocks).
+        **NOTE:** This endpoint is deprecated in favor of [Get blocks](https://docs.hiro.so/api/get-blocks).
 
         Retrieves block details of a specific block for a given burn chain height
       tags:
@@ -2979,7 +2979,7 @@ paths:
       operationId: get_transactions_by_block_hash
       summary: Transactions by block hash
       description: |
-        **NOTE:** This endpoint is deprecated in favor of [Get transactions by block](#operation/get_transactions_by_block).
+        **NOTE:** This endpoint is deprecated in favor of [Get transactions by block](https://docs.hiro.so/api/get-transactions-by-block).
 
         Retrieves a list of all transactions within a block for a given block hash.
       tags:
@@ -3022,7 +3022,7 @@ paths:
       operationId: get_transactions_by_block_height
       summary: Transactions by block height
       description: |
-        **NOTE:** This endpoint is deprecated in favor of [Get transactions by block](#operation/get_transactions_by_block).
+        **NOTE:** This endpoint is deprecated in favor of [Get transactions by block](https://docs.hiro.so/api/get-transactions-by-block).
 
         Retrieves all transactions within a block at a given height
       tags:
@@ -3328,7 +3328,7 @@ paths:
       summary: Fetch fee rate
       deprecated: true
       description: |
-        **NOTE:** This endpoint is deprecated in favor of [Get approximate fees for a given transaction](#operation/post_fee_transaction).
+        **NOTE:** This endpoint is deprecated in favor of [Get approximate fees for a given transaction](https://docs.hiro.so/api/get-approximate-fees-for-a-given-transaction).
 
         Retrieves estimated fee rate.
       tags:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -123,7 +123,7 @@ paths:
         required: true
         schema:
           type: string
-          example: "2N4M94S1ZPt8HfxydXzL2P7qyzgVq7MHWts"
+          example: '2N4M94S1ZPt8HfxydXzL2P7qyzgVq7MHWts'
     post:
       summary: Add testnet BTC tokens to address
       description: |
@@ -214,7 +214,15 @@ paths:
             example: coinbase
             items:
               type: string
-              enum: [coinbase, token_transfer, smart_contract, contract_call, poison_microblock, tenure_change]
+              enum:
+                [
+                  coinbase,
+                  token_transfer,
+                  smart_contract,
+                  contract_call,
+                  poison_microblock,
+                  tenure_change,
+                ]
         - name: unanchored
           in: query
           description: Include transaction data from unanchored (i.e. unconfirmed) microblocks
@@ -240,9 +248,9 @@ paths:
         - Transactions
       operationId: get_mempool_transaction_list
       description: |
-          Retrieves all transactions that have been recently broadcast to the mempool. These are pending transactions awaiting confirmation.
+        Retrieves all transactions that have been recently broadcast to the mempool. These are pending transactions awaiting confirmation.
 
-          If you need to monitor new transactions, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.
+        If you need to monitor new transactions, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.
       parameters:
         - name: sender_address
           in: query
@@ -250,7 +258,7 @@ paths:
           required: false
           schema:
             type: string
-            example: "SP1GPBP8NBRXDRJBFQBV7KMAZX1Z7W2RFWJEH0V10"
+            example: 'SP1GPBP8NBRXDRJBFQBV7KMAZX1Z7W2RFWJEH0V10'
         - name: recipient_address
           in: query
           description: Filter to only return transactions with this recipient address (only applicable for STX transfer tx types).
@@ -320,7 +328,7 @@ paths:
         - Mempool
       operationId: get_mempool_fee_priorities
       description: |
-          Returns estimated fee priorities (in micro-STX) for all transactions that are currently in the mempool. Also returns priorities separated by transaction type.
+        Returns estimated fee priorities (in micro-STX) for all transactions that are currently in the mempool. Also returns priorities separated by transaction type.
       responses:
         200:
           description: Mempool fee priorities
@@ -399,11 +407,12 @@ paths:
         explode: true
         schema:
           type: array
-          example: [
-            "0x0a411719e3bfde95f9e227a2d7f8fac3d6c646b1e6cc186db0e2838a2c6cd9c0",
-            "0xfbe6412b46e9db87df991a0d043ff47eb58019f770208cf48e2380337cc31785",
-            "0x178b77678a758d9f29a147d6399315c83d0f1baf114431fbe4d3587aa5fbba6f"
-          ]
+          example:
+            [
+              '0x0a411719e3bfde95f9e227a2d7f8fac3d6c646b1e6cc186db0e2838a2c6cd9c0',
+              '0xfbe6412b46e9db87df991a0d043ff47eb58019f770208cf48e2380337cc31785',
+              '0x178b77678a758d9f29a147d6399315c83d0f1baf114431fbe4d3587aa5fbba6f',
+            ]
           items:
             type: string
       - name: event_offset
@@ -457,7 +466,7 @@ paths:
         required: true
         schema:
           type: string
-          example: "0x0a411719e3bfde95f9e227a2d7f8fac3d6c646b1e6cc186db0e2838a2c6cd9c0"
+          example: '0x0a411719e3bfde95f9e227a2d7f8fac3d6c646b1e6cc186db0e2838a2c6cd9c0'
       - name: event_offset
         in: query
         schema:
@@ -507,7 +516,7 @@ paths:
         required: true
         schema:
           type: string
-          example: "0x0a411719e3bfde95f9e227a2d7f8fac3d6c646b1e6cc186db0e2838a2c6cd9c0"
+          example: '0x0a411719e3bfde95f9e227a2d7f8fac3d6c646b1e6cc186db0e2838a2c6cd9c0'
     get:
       summary: Get Raw Transaction
       tags:
@@ -548,7 +557,7 @@ paths:
             text/plain:
               schema:
                 type: string
-                example: "e161978626f216b2141b156ade10501207ae535fa365a13ef5d7a7c9310a09f2"
+                example: 'e161978626f216b2141b156ade10501207ae535fa365a13ef5d7a7c9310a09f2'
         400:
           description: Rejections result in a 400 error
           content:
@@ -565,9 +574,9 @@ paths:
         - Microblocks
       operationId: get_microblock_list
       description: |
-          Retrieves a list of microblocks.
+        Retrieves a list of microblocks.
 
-          If you need to actively monitor new microblocks, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.
+        If you need to actively monitor new microblocks, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.
       parameters:
         - name: limit
           in: query
@@ -601,7 +610,7 @@ paths:
         required: true
         schema:
           type: string
-          example: "0x3bfcdf84b3012adb544cf0f6df4835f93418c2269a3881885e27b3d58eb82d47"
+          example: '0x3bfcdf84b3012adb544cf0f6df4835f93418c2269a3881885e27b3d58eb82d47'
 
     get:
       summary: Get microblock
@@ -642,7 +651,7 @@ paths:
     get:
       summary: Get burn blocks
       description: |
-          Retrieves a list of recent burn blocks
+        Retrieves a list of recent burn blocks
       tags:
         - Burn Blocks
       operationId: get_burn_blocks
@@ -689,7 +698,7 @@ paths:
               - type: integer
                 example: 42000
               - type: string
-                example: "0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79"
+                example: '0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79'
       responses:
         200:
           description: Burn block
@@ -699,7 +708,7 @@ paths:
                 $ref: ./entities/blocks/burn-block.schema.json
               example:
                 $ref: ./entities/blocks/burn-block.example.json
-  
+
   /extended/v2/burn-blocks/{height_or_hash}/blocks:
     get:
       summary: Get blocks by burn block
@@ -718,7 +727,7 @@ paths:
               - type: integer
                 example: 42000
               - type: string
-                example: "0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79"
+                example: '0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79'
         - name: limit
           in: query
           description: max number of blocks to fetch
@@ -775,7 +784,7 @@ paths:
                 $ref: ./api/blocks/get-nakamoto-blocks.schema.json
               example:
                 $ref: ./api/blocks/get-nakamoto-blocks.example.json
-  
+
   /extended/v2/blocks/{height_or_hash}:
     get:
       summary: Get block
@@ -794,7 +803,7 @@ paths:
               - type: integer
                 example: 42000
               - type: string
-                example: "0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79"
+                example: '0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79'
       responses:
         200:
           description: Block
@@ -823,7 +832,7 @@ paths:
               - type: integer
                 example: 42000
               - type: string
-                example: "0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79"
+                example: '0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79'
       responses:
         200:
           description: List of transactions
@@ -839,11 +848,11 @@ paths:
       summary: Get recent blocks
       deprecated: true
       description: |
-          **NOTE:** This endpoint is deprecated in favor of [Get blocks](https://docs.hiro.so/api/get-blocks).
+        **NOTE:** This endpoint is deprecated in favor of [Get blocks](/api/get-blocks).
 
-          Retrieves a list of recently mined blocks
+        Retrieves a list of recently mined blocks
 
-          If you need to actively monitor new blocks, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.
+        If you need to actively monitor new blocks, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.
       tags:
         - Blocks
       operationId: get_block_list
@@ -880,13 +889,13 @@ paths:
         required: true
         schema:
           type: string
-          example: "0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79"
+          example: '0x4839a8b01cfb39ffcc0d07d3db31e848d5adf5279d529ed5062300b9f353ff79'
     get:
       deprecated: true
       summary: Get block by hash
       description: |
-        **NOTE:** This endpoint is deprecated in favor of [Get block](https://docs.hiro.so/api/get-block).
-        
+        **NOTE:** This endpoint is deprecated in favor of [Get block](/api/get-block).
+
         Retrieves block details of a specific block for a given chain height. You can use the hash from your latest block ('get_block_list' API) to get your block details.
       tags:
         - Blocks
@@ -919,7 +928,7 @@ paths:
       deprecated: true
       summary: Get block by height
       description: |
-        **NOTE:** This endpoint is deprecated in favor of [Get block](https://docs.hiro.so/api/get-block).
+        **NOTE:** This endpoint is deprecated in favor of [Get block](/api/get-block).
 
         Retrieves block details of a specific block at a given block height
       tags:
@@ -948,12 +957,12 @@ paths:
         required: true
         schema:
           type: string
-          example: "0x00000000000000000002bba732926cf68b6eda3e2cdbc2a85af79f10efeeeb10"
+          example: '0x00000000000000000002bba732926cf68b6eda3e2cdbc2a85af79f10efeeeb10'
     get:
       summary: Get block by burnchain block hash
       deprecated: true
       description: |
-        **NOTE:** This endpoint is deprecated in favor of [Get blocks](https://docs.hiro.so/api/get-blocks).
+        **NOTE:** This endpoint is deprecated in favor of [Get blocks](/api/get-blocks).
 
         Retrieves block details of a specific block for a given burnchain block hash
       tags:
@@ -988,7 +997,7 @@ paths:
       summary: Get block by burnchain height
       deprecated: true
       description: |
-        **NOTE:** This endpoint is deprecated in favor of [Get blocks](https://docs.hiro.so/api/get-blocks).
+        **NOTE:** This endpoint is deprecated in favor of [Get blocks](/api/get-blocks).
 
         Retrieves block details of a specific block for a given burn chain height
       tags:
@@ -1057,7 +1066,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "36hQtSEXBMevo5chpxhfAGiCTSC34QKgda"
+            example: '36hQtSEXBMevo5chpxhfAGiCTSC34QKgda'
         - name: limit
           in: query
           description: max number of items to fetch
@@ -1127,7 +1136,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "36hQtSEXBMevo5chpxhfAGiCTSC34QKgda"
+            example: '36hQtSEXBMevo5chpxhfAGiCTSC34QKgda'
         - name: limit
           in: query
           description: max number of rewards to fetch
@@ -1164,7 +1173,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "36hQtSEXBMevo5chpxhfAGiCTSC34QKgda"
+            example: '36hQtSEXBMevo5chpxhfAGiCTSC34QKgda'
       responses:
         200:
           description: List of burnchain reward recipients and amounts
@@ -1200,7 +1209,7 @@ paths:
         required: true
         schema:
           type: string
-          example: "SP6P4EJF0VG8V0RB3TQQKJBHDQKEF6NVRD1KZE3C.satoshibles"
+          example: 'SP6P4EJF0VG8V0RB3TQQKJBHDQKEF6NVRD1KZE3C.satoshibles'
       - name: unanchored
         in: query
         description: Include transaction data from unanchored (i.e. unconfirmed) microblocks
@@ -1261,7 +1270,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "SP6P4EJF0VG8V0RB3TQQKJBHDQKEF6NVRD1KZE3C.satoshibles"
+            example: 'SP6P4EJF0VG8V0RB3TQQKJBHDQKEF6NVRD1KZE3C.satoshibles'
         - name: limit
           in: query
           description: max number of contract events to fetch
@@ -1323,7 +1332,7 @@ paths:
         description: Contract name
         schema:
           type: string
-          example: "satoshibles"
+          example: 'satoshibles'
       - name: tip
         in: query
         schema:
@@ -1360,7 +1369,7 @@ paths:
           description: Stacks address
           schema:
             type: string
-            example: "SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11"
+            example: 'SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11'
         - name: contract_name
           in: path
           required: true
@@ -1393,7 +1402,7 @@ paths:
           application/json:
             schema:
               type: string
-            example: 
+            example:
               $ref: ./entities/contracts/get-specific-data-map-inside-contract.example.json
 
   /v2/contracts/source/{contract_address}/{contract_name}:
@@ -1419,7 +1428,7 @@ paths:
         description: Stacks address
         schema:
           type: string
-          example: "SP6P4EJF0VG8V0RB3TQQKJBHDQKEF6NVRD1KZE3C"
+          example: 'SP6P4EJF0VG8V0RB3TQQKJBHDQKEF6NVRD1KZE3C'
       - name: contract_name
         in: path
         required: true
@@ -1470,7 +1479,7 @@ paths:
           description: Stacks address
           schema:
             type: string
-            example: "SP187Y7NRSG3T9Z9WTSWNEN3XRV1YSJWS81C7JKV7"
+            example: 'SP187Y7NRSG3T9Z9WTSWNEN3XRV1YSJWS81C7JKV7'
         - name: contract_name
           in: path
           required: true
@@ -1515,7 +1524,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0"
+            example: 'SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0'
         - name: unanchored
           in: query
           description: Include transaction data from unanchored (i.e. unconfirmed) microblocks
@@ -1555,7 +1564,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0"
+            example: 'SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0'
         - name: unanchored
           in: query
           description: Include transaction data from unanchored (i.e. unconfirmed) microblocks.
@@ -1585,9 +1594,9 @@ paths:
     get:
       summary: Get account transactions
       description: |
-          Retrieves a list of all Transactions for a given Address or Contract Identifier. More information on Transaction types can be found [here](https://docs.stacks.co/understand-stacks/transactions#types).
+        Retrieves a list of all Transactions for a given Address or Contract Identifier. More information on Transaction types can be found [here](https://docs.stacks.co/understand-stacks/transactions#types).
 
-          If you need to actively monitor new transactions for an address or contract id, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.
+        If you need to actively monitor new transactions for an address or contract id, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.
       tags:
         - Accounts
       operationId: get_account_transactions
@@ -1598,7 +1607,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0"
+            example: 'SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0'
         - name: limit
           in: query
           description: max number of account transactions to fetch
@@ -1659,14 +1668,14 @@ paths:
           required: true
           schema:
             type: string
-            example: "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE"
+            example: 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE'
         - name: tx_id
           in: path
           description: Transaction id
           required: true
           schema:
             type: string
-            example: "0x34d79c7cfc2fe525438736733e501a4bf0308a5556e3e080d1e2c0858aad7448"
+            example: '0x34d79c7cfc2fe525438736733e501a4bf0308a5556e3e080d1e2c0858aad7448'
       responses:
         200:
           description: Success
@@ -1697,7 +1706,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0"
+            example: 'SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0'
         - name: limit
           in: query
           description: max number of account transactions to fetch
@@ -1758,7 +1767,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0"
+            example: 'SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0'
         - name: block_height
           in: query
           description: Optionally get the nonce at a given block height.
@@ -1772,7 +1781,7 @@ paths:
           required: false
           schema:
             type: string
-            example: "0x72d53f3cba39e149dcd42708e535bdae03d73e60d2fe853aaf61c0b392f521e9"
+            example: '0x72d53f3cba39e149dcd42708e535bdae03d73e60d2fe853aaf61c0b392f521e9'
 
       responses:
         200:
@@ -1798,7 +1807,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0"
+            example: 'SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0'
         - name: limit
           in: query
           description: max number of account assets to fetch
@@ -1854,7 +1863,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0"
+            example: 'SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0'
         - name: limit
           in: query
           description: number of items to return
@@ -1918,7 +1927,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0"
+            example: 'SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0'
         - name: proof
           in: query
           description: Returns object without the proof field if set to 0
@@ -2151,7 +2160,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "0xcf8b233f19f6c07d2dc1963302d2436efd36e9afac127bf6582824a13961c06d"
+            example: '0xcf8b233f19f6c07d2dc1963302d2436efd36e9afac127bf6582824a13961c06d'
           description: The hex hash string for a block or transaction, account address, or contract address
         - in: query
           name: include_metadata
@@ -2225,7 +2234,7 @@ paths:
           application/json:
             schema:
               $ref: ./api/rosetta/rosetta-network-options-request.schema.json
-            example: 
+            example:
               $ref: ./api/rosetta/rosetta-account-network-options-request-body.example.json
 
   /rosetta/v1/network/status:
@@ -2256,7 +2265,7 @@ paths:
           application/json:
             schema:
               $ref: ./api/rosetta/rosetta-network-status-request.schema.json
-            example: 
+            example:
               $ref: ./api/rosetta/rosetta-account-network-options-request-body.example.json
 
   /rosetta/v1/account/balance:
@@ -2287,7 +2296,7 @@ paths:
           application/json:
             schema:
               $ref: ./api/rosetta/rosetta-account-balance-request.schema.json
-            example: 
+            example:
               $ref: ./api/rosetta/rosetta-account-balance-request-body.example.json
 
   /rosetta/v1/block:
@@ -2316,7 +2325,7 @@ paths:
           application/json:
             schema:
               $ref: ./api/rosetta/rosetta-block-request.schema.json
-            example: 
+            example:
               $ref: ./api/rosetta/rosetta-block-request-body.example.json
 
   /rosetta/v1/block/transaction:
@@ -2345,7 +2354,7 @@ paths:
           application/json:
             schema:
               $ref: ./api/rosetta/rosetta-block-transaction-request.schema.json
-            example: 
+            example:
               $ref: ./api/rosetta/rosetta-block-transaction-request-body.example.json
 
   /rosetta/v1/mempool:
@@ -2374,7 +2383,7 @@ paths:
           application/json:
             schema:
               $ref: ./api/rosetta/rosetta-mempool-request.schema.json
-            example: 
+            example:
               $ref: ./api/rosetta/rosetta-account-network-options-request-body.example.json
 
   /rosetta/v1/mempool/transaction:
@@ -2430,7 +2439,7 @@ paths:
           application/json:
             schema:
               $ref: ./api/rosetta/rosetta-construction-derive-request.schema.json
-            example: 
+            example:
               $ref: ./api/rosetta/rosetta-account-identifier-publickey-request-body.example.json
 
   /rosetta/v1/construction/hash:
@@ -2843,7 +2852,6 @@ paths:
               example:
                 $ref: ./api/bns/subdomains/subdomains-list.example.json
 
-
   /v1/names/{name}/zonefile:
     get:
       summary: Get Zone File
@@ -2906,7 +2914,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "b100a68235244b012854a95f9114695679002af9"
+            example: 'b100a68235244b012854a95f9114695679002af9'
       responses:
         200:
           description: Success
@@ -2954,7 +2962,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "1QJQxDas5JhdiXhEbNS14iNjr8auFT96GP"
+            example: '1QJQxDas5JhdiXhEbNS14iNjr8auFT96GP'
       responses:
         200:
           description: Success
@@ -2979,7 +2987,7 @@ paths:
       operationId: get_transactions_by_block_hash
       summary: Transactions by block hash
       description: |
-        **NOTE:** This endpoint is deprecated in favor of [Get transactions by block](https://docs.hiro.so/api/get-transactions-by-block).
+        **NOTE:** This endpoint is deprecated in favor of [Get transactions by block](/api/get-transactions-by-block).
 
         Retrieves a list of all transactions within a block for a given block hash.
       tags:
@@ -2991,7 +2999,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "0x0a83d82a65460a9e711f85a44616350280040b75317dbe486a923c1131b5ff99"
+            example: '0x0a83d82a65460a9e711f85a44616350280040b75317dbe486a923c1131b5ff99'
         - name: limit
           in: query
           description: max number of transactions to fetch
@@ -3022,7 +3030,7 @@ paths:
       operationId: get_transactions_by_block_height
       summary: Transactions by block height
       description: |
-        **NOTE:** This endpoint is deprecated in favor of [Get transactions by block](https://docs.hiro.so/api/get-transactions-by-block).
+        **NOTE:** This endpoint is deprecated in favor of [Get transactions by block](/api/get-transactions-by-block).
 
         Retrieves all transactions within a block at a given height
       tags:
@@ -3081,7 +3089,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "SP197DVH8KTJGX4STM61QN0WJV8Y9QJWXV83ZGNR9"
+            example: 'SP197DVH8KTJGX4STM61QN0WJV8Y9QJWXV83ZGNR9'
         - name: limit
           in: query
           description: max number of transactions to fetch
@@ -3132,7 +3140,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "SPNWZ5V2TPWGQGVDR6T7B6RQ4XMGZ4PXTEE0VQ0S.marketplace-v3"
+            example: 'SPNWZ5V2TPWGQGVDR6T7B6RQ4XMGZ4PXTEE0VQ0S.marketplace-v3'
         - name: asset_identifiers
           in: query
           description: identifiers of the token asset classes to filter for
@@ -3141,7 +3149,7 @@ paths:
           explode: true
           schema:
             type: array
-            example: "SPQZF23W7SEYBFG5JQ496NMY0G7379SRYEDREMSV.Candy::candy"
+            example: 'SPQZF23W7SEYBFG5JQ496NMY0G7379SRYEDREMSV.Candy::candy'
             items:
               type: string
         - name: limit
@@ -3206,14 +3214,14 @@ paths:
           required: true
           schema:
             type: string
-            example: "SP2X0TZ59D5SZ8ACQ6YMCHHNR2ZN51Z32E2CJ173.the-explorer-guild::The-Explorer-Guild"
+            example: 'SP2X0TZ59D5SZ8ACQ6YMCHHNR2ZN51Z32E2CJ173.the-explorer-guild::The-Explorer-Guild'
         - name: value
           in: query
           description: hex representation of the token's unique value
           required: true
           schema:
             type: string
-            example: "0x0100000000000000000000000000000803"
+            example: '0x0100000000000000000000000000000803'
         - name: limit
           in: query
           description: max number of events to fetch
@@ -3276,7 +3284,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "SP2X0TZ59D5SZ8ACQ6YMCHHNR2ZN51Z32E2CJ173.the-explorer-guild::The-Explorer-Guild"
+            example: 'SP2X0TZ59D5SZ8ACQ6YMCHHNR2ZN51Z32E2CJ173.the-explorer-guild::The-Explorer-Guild'
         - name: limit
           in: query
           description: max number of events to fetch
@@ -3328,7 +3336,7 @@ paths:
       summary: Fetch fee rate
       deprecated: true
       description: |
-        **NOTE:** This endpoint is deprecated in favor of [Get approximate fees for a given transaction](https://docs.hiro.so/api/get-approximate-fees-for-a-given-transaction).
+        **NOTE:** This endpoint is deprecated in favor of [Get approximate fees for a given transaction](/api/get-approximate-fees-for-a-given-transaction).
 
         Retrieves estimated fee rate.
       tags:
@@ -3434,7 +3442,8 @@ paths:
   /extended/v1/tx/events:
     get:
       summary: Transaction Events
-      description: Retrieves the list of events filtered by principal (STX address or Smart Contract ID), transaction id or event types.
+      description:
+        Retrieves the list of events filtered by principal (STX address or Smart Contract ID), transaction id or event types.
         The list of event types is ('smart_contract_log', 'stx_lock', 'stx_asset', 'fungible_token_asset', 'non_fungible_token_asset').
       tags:
         - Transactions
@@ -3444,7 +3453,7 @@ paths:
           in: query
           description: Hash of transaction
           required: false
-          example: "0x29e25515652dad41ef675bd0670964e3d537b80ec19cf6ca6f1dd65d5bc642c5"
+          example: '0x29e25515652dad41ef675bd0670964e3d537b80ec19cf6ca6f1dd65d5bc642c5'
           schema:
             type: string
         - name: address
@@ -3453,7 +3462,7 @@ paths:
           required: false
           schema:
             type: string
-            example: "ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4"
+            example: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4'
         - name: limit
           in: query
           description: number of items to return
@@ -3479,7 +3488,14 @@ paths:
             example: stx_lock
             items:
               type: string
-              enum: [smart_contract_log, stx_lock, stx_asset, fungible_token_asset, non_fungible_token_asset]
+              enum:
+                [
+                  smart_contract_log,
+                  stx_lock,
+                  stx_asset,
+                  fungible_token_asset,
+                  non_fungible_token_asset,
+                ]
       responses:
         200:
           description: Success
@@ -3501,7 +3517,7 @@ paths:
           in: path
           description: Address principal of the stacking pool delegator
           required: true
-          example: "SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11"
+          example: 'SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11'
           schema:
             type: string
         - name: after_block


### PR DESCRIPTION
## Description

Caught a few more broken anchors causing some build issues with docs for some of the deprecated endpoints.
 
## Checklist
- [x] Update anchors to point to new active endpoints
- [x] Prioritize `docs.hiro.so` routing and update urls to `/api` 