### PR TITLE
fix: report placeholder in prom metrics for invalid request paths

### DIFF
--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -120,7 +120,7 @@ export async function startApiServer(opts: {
                 break;
               }
             }
-            return pathTemplate;
+            return '<invalid_path>';
           } catch (error) {
             logger.warn(`Warning: ${error}`);
             return path;

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -110,14 +110,13 @@ export async function startApiServer(opts: {
           // Get the url pathname without a query string or fragment
           // (note base url doesn't matter, but required by URL constructor)
           try {
-            let pathTemplate = new URL(path, 'http://x').pathname;
+            const pathTemplate = new URL(path, 'http://x').pathname;
             // Match request url to the Express route, e.g.:
             // `/extended/v1/address/ST26DR4VGV507V1RZ1JNM7NN4K3DTGX810S62SBBR/stx` to
             // `/extended/v1/address/:stx_address/stx`
             for (const pathRegex of routes) {
               if (pathRegex.regexp.test(pathTemplate)) {
-                pathTemplate = pathRegex.path;
-                break;
+                return pathRegex.path;
               }
             }
             return '<invalid_path>';


### PR DESCRIPTION
Fixes #1826

When a request path is invalid because it doesn't have a route handler, change the prometheus reporting so that the path name is the placeholder `<invalid_path>`. This fixes the issue of very long path names, and fixes the issue of log spam from many unique invalid paths.