### PR TITLE
feat: add nakamoto block time to v2 endpoints

### DIFF
--- a/docs/entities/blocks/block.example.json
+++ b/docs/entities/blocks/block.example.json
@@ -2,6 +2,8 @@
   "canonical": true,
   "height": 3275,
   "hash": "0xe77ba8cf6bb7c0e4f64adc83356289ed467d31a22354907b4bb814590058430f",
+  "block_time": 1594233639,
+  "block_time_iso": "2020-08-27T16:41:26.000Z",
   "index_block_hash": "0x918697ef63f9d8bdf844c3312b299e72a231cde542f3173f7755bb8c1cdaf3a7",
   "parent_block_hash": "0x75ab21ef25cbff2caa14c27d830ed7886a4d1522e1b6f9e5dc3b59ccf73ed49f",
   "burn_block_time": 1594233639,

--- a/docs/entities/blocks/nakamoto-block.example.json
+++ b/docs/entities/blocks/nakamoto-block.example.json
@@ -2,6 +2,8 @@
   "canonical": true,
   "height": 3275,
   "hash": "0xe77ba8cf6bb7c0e4f64adc83356289ed467d31a22354907b4bb814590058430f",
+  "block_time": 1594233639,
+  "block_time_iso": "2020-08-27T16:41:26.000Z",
   "index_block_hash": "0x918697ef63f9d8bdf844c3312b299e72a231cde542f3173f7755bb8c1cdaf3a7",
   "parent_block_hash": "0x75ab21ef25cbff2caa14c27d830ed7886a4d1522e1b6f9e5dc3b59ccf73ed49f",
   "parent_index_block_hash": "0x4262db117659d1ca9406970c8f44ffd3d8f11f8e18c591d2e3960f4070107756",

--- a/docs/entities/blocks/nakamoto-block.schema.json
+++ b/docs/entities/blocks/nakamoto-block.schema.json
@@ -7,6 +7,8 @@
     "canonical",
     "height",
     "hash",
+    "block_time",
+    "block_time_iso",
     "index_block_hash",
     "parent_block_hash",
     "parent_index_block_hash",
@@ -35,6 +37,14 @@
     "hash": {
       "type": "string",
       "description": "Hash representing the block"
+    },
+    "block_time": {
+      "type": "number",
+      "description": "Unix timestamp (in seconds) indicating when this block was mined."
+    },
+    "block_time_iso": {
+      "type": "string",
+      "description": "An ISO 8601 (YYYY-MM-DDTHH:mm:ss.sssZ) indicating when this block was mined."
     },
     "index_block_hash": {
       "type": "string",

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -1480,6 +1480,14 @@ export interface NakamotoBlock {
    */
   hash: string;
   /**
+   * Unix timestamp (in seconds) indicating when this block was mined.
+   */
+  block_time: number;
+  /**
+   * An ISO 8601 (YYYY-MM-DDTHH:mm:ss.sssZ) indicating when this block was mined.
+   */
+  block_time_iso: string;
+  /**
    * The only hash that can uniquely identify an anchored block or an unconfirmed state trie
    */
   index_block_hash: string;

--- a/src/api/routes/v2/helpers.ts
+++ b/src/api/routes/v2/helpers.ts
@@ -33,6 +33,8 @@ export function parseDbNakamotoBlock(block: DbBlock): NakamotoBlock {
     canonical: block.canonical,
     height: block.block_height,
     hash: block.block_hash,
+    block_time: block.block_time,
+    block_time_iso: unixEpochToIso(block.block_time),
     index_block_hash: block.index_block_hash,
     parent_block_hash: block.parent_block_hash,
     parent_index_block_hash: block.parent_index_block_hash,

--- a/src/tests/block-tests.ts
+++ b/src/tests/block-tests.ts
@@ -672,6 +672,8 @@ describe('block tests', () => {
 
     // Filter by burn hash
     const block5 = {
+      block_time: 94869286,
+      block_time_iso: '1973-01-03T00:34:46.000Z',
       burn_block_hash: '0x00000000000000000001e2ee7f0c6bd5361b5e7afd76156ca7d6f524ee5ca3d8',
       burn_block_height: 700000,
       burn_block_time: 94869286,
@@ -707,6 +709,8 @@ describe('block tests', () => {
 
     // Get latest block
     const block8 = {
+      block_time: 94869286,
+      block_time_iso: '1973-01-03T00:34:46.000Z',
       burn_block_hash: '0x000000000000000000028eacd4e6e58405d5a37d06b5d7b93776f1eab68d2494',
       burn_block_height: 700001,
       burn_block_time: 94869286,
@@ -758,6 +762,8 @@ describe('block tests', () => {
 
     // Get latest
     const block5 = {
+      block_time: 94869286,
+      block_time_iso: '1973-01-03T00:34:46.000Z',
       burn_block_hash: '0x00000000000000000001e2ee7f0c6bd5361b5e7afd76156ca7d6f524ee5ca3d8',
       burn_block_height: 700000,
       burn_block_time: 94869286,


### PR DESCRIPTION
Fixes https://github.com/hirosystems/stacks-blockchain-api/issues/1918

Add block times were to the new NakamotoBlock object returned in many of the new /v2 routes.