### PR TITLE
feat: rosetta pox4 support

### DIFF
--- a/docs/entities/rosetta/rosetta-construction-options.schema.json
+++ b/docs/entities/rosetta/rosetta-construction-options.schema.json
@@ -102,7 +102,7 @@
     },
     "pox_max_amount": {
       "type": "string",
-      "description": "The maximum amount of STX to stack for PoX"
+      "description": "The maximum amount of STX to stack for PoX. If not specified, the `amount` will be used as the `max-amount` for the PoX transaction."
     },
     "pox_auth_id": {
       "type": "string",

--- a/docs/entities/rosetta/rosetta-construction-options.schema.json
+++ b/docs/entities/rosetta/rosetta-construction-options.schema.json
@@ -94,11 +94,11 @@
     },
     "signer_private_key": {
       "type": "string",
-      "description": "The hex-encoded signer private key for PoX. Must be specified for PoX transactions if `signer_signature` is not specified"
+      "description": "The hex-encoded signer private key for PoX. Specify either this or `signer_signature`, otherwise the PoX transaction requires allow-listing from the signer."
     },
     "signer_signature": {
       "type": "string",
-      "description": "The hex-encoded signer signature for PoX. Must be specified for PoX transactions if `signer_key` is not specified."
+      "description": "The hex-encoded signer signature for PoX. Specify either this or `signer_private_key`, otherwise the PoX transaction requires allow-listing from the signer."
     },
     "pox_max_amount": {
       "type": "string",
@@ -106,7 +106,7 @@
     },
     "pox_auth_id": {
       "type": "string",
-      "description": "The auth ID for the PoX transaction"
+      "description": "The auth ID for the PoX transaction. If not specified, a random value will be generated."
     }
   }
 }

--- a/docs/entities/rosetta/rosetta-construction-options.schema.json
+++ b/docs/entities/rosetta/rosetta-construction-options.schema.json
@@ -76,6 +76,10 @@
       "type": "integer",
       "description": "Set the burnchain (BTC) block for stacking lock to start."
     },
+    "reward_cycle_id": {
+      "type": "integer",
+      "description": "The reward cycle ID for stacking transaction."
+    },
     "delegate_to": {
       "type": "string",
       "description": "Delegator address for when calling `delegate-stacking`."
@@ -87,6 +91,22 @@
     "signer_key": {
       "type": "string",
       "description": "The hex-encoded signer key (buff 33) for PoX."
+    },
+    "signer_private_key": {
+      "type": "string",
+      "description": "The hex-encoded signer private key for PoX. Must be specified for PoX transactions if `signer_signature` is not specified"
+    },
+    "signer_signature": {
+      "type": "string",
+      "description": "The hex-encoded signer signature for PoX. Must be specified for PoX transactions if `signer_key` is not specified."
+    },
+    "pox_max_amount": {
+      "type": "string",
+      "description": "The maximum amount of STX to stack for PoX"
+    },
+    "pox_auth_id": {
+      "type": "string",
+      "description": "The auth ID for the PoX transaction"
     }
   }
 }

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -2703,7 +2703,7 @@ export interface RosettaOptions {
    */
   signer_signature?: string;
   /**
-   * The maximum amount of STX to stack for PoX
+   * The maximum amount of STX to stack for PoX. If not specified, the `amount` will be used as the `max-amount` for the PoX transaction.
    */
   pox_max_amount?: string;
   /**

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -2695,11 +2695,11 @@ export interface RosettaOptions {
    */
   signer_key?: string;
   /**
-   * The hex-encoded signer private key for PoX. Must be specified for PoX transactions if `signer_signature` is not specified
+   * The hex-encoded signer private key for PoX. Specify either this or `signer_signature`, otherwise the PoX transaction requires allow-listing from the signer.
    */
   signer_private_key?: string;
   /**
-   * The hex-encoded signer signature for PoX. Must be specified for PoX transactions if `signer_key` is not specified.
+   * The hex-encoded signer signature for PoX. Specify either this or `signer_private_key`, otherwise the PoX transaction requires allow-listing from the signer.
    */
   signer_signature?: string;
   /**
@@ -2707,7 +2707,7 @@ export interface RosettaOptions {
    */
   pox_max_amount?: string;
   /**
-   * The auth ID for the PoX transaction
+   * The auth ID for the PoX transaction. If not specified, a random value will be generated.
    */
   pox_auth_id?: string;
 }

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -2679,6 +2679,10 @@ export interface RosettaOptions {
    */
   burn_block_height?: number;
   /**
+   * The reward cycle ID for stacking transaction.
+   */
+  reward_cycle_id?: number;
+  /**
    * Delegator address for when calling `delegate-stacking`.
    */
   delegate_to?: string;
@@ -2690,6 +2694,22 @@ export interface RosettaOptions {
    * The hex-encoded signer key (buff 33) for PoX.
    */
   signer_key?: string;
+  /**
+   * The hex-encoded signer private key for PoX. Must be specified for PoX transactions if `signer_signature` is not specified
+   */
+  signer_private_key?: string;
+  /**
+   * The hex-encoded signer signature for PoX. Must be specified for PoX transactions if `signer_key` is not specified.
+   */
+  signer_signature?: string;
+  /**
+   * The maximum amount of STX to stack for PoX
+   */
+  pox_max_amount?: string;
+  /**
+   * The auth ID for the PoX transaction
+   */
+  pox_auth_id?: string;
 }
 /**
  * The ConstructionMetadataResponse returns network-specific metadata used for transaction construction. Optionally, the implementer can return the suggested fee associated with the transaction being constructed. The caller may use this info to adjust the intent of the transaction or to create a transaction with a different account that can pay the suggested fee. Suggested fee is an array in case fee payment must occur in multiple currencies.

--- a/src/api/routes/debug.ts
+++ b/src/api/routes/debug.ts
@@ -32,6 +32,7 @@ import {
   deserializeTransaction,
   makeRandomPrivKey,
   privateKeyToString,
+  someCV,
 } from '@stacks/transactions';
 import { StacksTestnet } from '@stacks/network';
 import { SampleContracts } from '../../sample-data/broadcast-contract-default';
@@ -56,8 +57,10 @@ import {
   RosettaOperation,
 } from '@stacks/stacks-blockchain-api-types';
 import { getRosettaNetworkName, RosettaConstants } from '../rosetta-constants';
-import { decodeBtcAddress } from '@stacks/stacking';
+import { StackingClient, decodeBtcAddress, poxAddressToTuple } from '@stacks/stacking';
 import { getPublicKeyFromPrivate } from '@stacks/encryption';
+import { randomBytes } from 'node:crypto';
+import { hexToBytes } from '@stacks/common';
 
 const testnetAccounts = [
   {
@@ -731,21 +734,38 @@ export function createDebugRouter(db: PgStore): express.Router {
         ));
       } else {
         const [contractAddress, contractName] = poxInfo.contract_id.split('.');
-        const decodedBtcAddr = decodeBtcAddress(recipient_address);
+        const poxAddrTuple = poxAddressToTuple(recipient_address);
         burnBlockHeight = poxInfo.current_burnchain_block_height as number;
+
+        const stackingRpc = new StackingClient('', stacksNetwork);
+        const signerPrivKey = makeRandomPrivKey();
+        const signerPubKey = getPublicKeyFromPrivate(signerPrivKey.data);
+        const authId = `0x${randomBytes(16).toString('hex')}`;
+
+        const signerSig = stackingRpc.signPoxSignature({
+          topic: 'stack-stx',
+          poxAddress: recipient_address,
+          rewardCycle: poxInfo.current_cycle.id,
+          period: cycles,
+          signerPrivateKey: signerPrivKey,
+          maxAmount: ustxAmount,
+          authId: authId,
+        });
+
         const txOptions: SignedContractCallOptions = {
           senderKey: sender.secretKey,
           contractAddress,
           contractName,
           functionName: 'stack-stx',
           functionArgs: [
-            uintCV(ustxAmount.toString()),
-            tupleCV({
-              hashbytes: bufferCV(decodedBtcAddr.data),
-              version: bufferCV(Buffer.from([decodedBtcAddr.version])),
-            }),
-            uintCV(burnBlockHeight),
-            uintCV(cycles),
+            uintCV(ustxAmount), // amount-ustx
+            poxAddrTuple, // pox-addr
+            uintCV(burnBlockHeight), // start-burn-ht
+            uintCV(cycles), // lock-period
+            someCV(bufferCV(hexToBytes(signerSig))), // signer-sig
+            bufferCV(hexToBytes(signerPubKey)), // signer-key
+            uintCV(ustxAmount), // max-amount
+            uintCV(authId), // auth-id
           ],
           network: stacksNetwork,
           anchorMode: AnchorMode.Any,

--- a/src/api/routes/debug.ts
+++ b/src/api/routes/debug.ts
@@ -30,6 +30,8 @@ import {
   bufferCV,
   AnchorMode,
   deserializeTransaction,
+  makeRandomPrivKey,
+  privateKeyToString,
 } from '@stacks/transactions';
 import { StacksTestnet } from '@stacks/network';
 import { SampleContracts } from '../../sample-data/broadcast-contract-default';
@@ -55,6 +57,7 @@ import {
 } from '@stacks/stacks-blockchain-api-types';
 import { getRosettaNetworkName, RosettaConstants } from '../rosetta-constants';
 import { decodeBtcAddress } from '@stacks/stacking';
+import { getPublicKeyFromPrivate } from '@stacks/encryption';
 
 const testnetAccounts = [
   {
@@ -587,6 +590,9 @@ export function createDebugRouter(db: PgStore): express.Router {
     btcAddr: string,
     cycleCount: number
   ): Promise<{ txId: string; burnBlockHeight: number }> {
+    const signerPrivKey = privateKeyToString(makeRandomPrivKey());
+    const signerPubKey = getPublicKeyFromPrivate(signerPrivKey);
+
     const stackingOperations: RosettaOperation[] = [
       {
         operation_identifier: {
@@ -607,6 +613,8 @@ export function createDebugRouter(db: PgStore): express.Router {
         metadata: {
           number_of_cycles: cycleCount,
           pox_addr: btcAddr,
+          signer_key: signerPubKey,
+          signer_private_key: signerPrivKey,
         },
       },
       {

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -2,6 +2,7 @@ import { has0xPrefix, hexToBuffer } from '@hirosystems/api-toolkit';
 import { hexToBytes } from '@stacks/common';
 import { StacksMainnet, StacksTestnet } from '@stacks/network';
 import { StackingClient, decodeBtcAddress, poxAddressToTuple } from '@stacks/stacking';
+import { getPublicKeyFromPrivate } from '@stacks/encryption';
 import {
   NetworkIdentifier,
   RosettaAccountIdentifier,
@@ -36,9 +37,11 @@ import {
   UnsignedTokenTransferOptions,
   bufferCV,
   createMessageSignature,
+  createStacksPrivateKey,
   deserializeTransaction,
   emptyMessageSignature,
   isSingleSig,
+  makeRandomPrivKey,
   makeSigHashPreSign,
   makeUnsignedContractCall,
   makeUnsignedSTXTokenTransfer,
@@ -85,6 +88,7 @@ import {
   RosettaOperationType,
 } from '../../rosetta-constants';
 import { ValidSchema, makeRosettaError, rosettaValidateRequest } from './../../rosetta-validate';
+import { randomBytes } from 'node:crypto';
 
 export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): express.Router {
   const router = express.Router();
@@ -216,8 +220,17 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
           transaction = await makeUnsignedSTXTokenTransfer(dummyTokenTransferTx);
           break;
         case RosettaOperationType.StackStx: {
+          const poxContract = await stackingRpc.getStackingContract();
+          const [contractAddress, contractName] = poxContract.split('.');
+          const isPox4 = contractName === 'pox-4';
+
           const poxAddr = options.pox_addr;
-          if (!options.number_of_cycles || !options.signer_key || !poxAddr) {
+          if (!options.number_of_cycles || !poxAddr) {
+            res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+            return;
+          }
+
+          if (isPox4 && (!options.signer_key || !options.pox_max_amount)) {
             res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
             return;
           }
@@ -231,25 +244,63 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
             res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
             return;
           }
+
           // dummy transaction to calculate size
-          const dummyStackingTx: UnsignedContractCallOptions = {
-            publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
-            contractAddress: 'ST000000000000000000002AMW42H',
-            contractName: 'pox',
-            functionName: 'stack-stx',
-            functionArgs: [
-              uintCV(options.amount),
-              poxAddressToTuple(poxAddr),
-              uintCV(0),
-              uintCV(options.number_of_cycles),
-              bufferCV(hexToBytes(options.signer_key)),
-            ],
-            validateWithAbi: false,
-            network: getStacksNetwork(),
-            fee: 0,
-            nonce: 0,
-            anchorMode: AnchorMode.Any,
-          };
+          let dummyStackingTx: UnsignedContractCallOptions;
+          if (isPox4) {
+            const signerPrivKey = makeRandomPrivKey();
+            // const signerPubKey = getPublicKeyFromPrivate(signerPrivKey.data);
+            const signerSig = hexToBytes(
+              stackingRpc.signPoxSignature({
+                topic: 'stack-stx',
+                poxAddress: poxAddr,
+                rewardCycle: 0,
+                period: options.number_of_cycles,
+                signerPrivateKey: signerPrivKey,
+                maxAmount: 0,
+                authId: 0,
+              })
+            );
+            dummyStackingTx = {
+              publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
+              contractAddress: contractAddress,
+              contractName: contractName,
+              functionName: 'stack-stx',
+              functionArgs: [
+                uintCV(options.amount), // amount-ustx
+                poxAddressToTuple(poxAddr), // pox-addr
+                uintCV(0), // start-burn-ht
+                uintCV(options.number_of_cycles), // lock-period
+                someCV(bufferCV(signerSig)), // signer-sig
+                bufferCV(hexToBytes(options.signer_key as string)), // signer-key
+                uintCV(1), // max-amount
+                uintCV(0), // auth-id
+              ],
+              validateWithAbi: false,
+              network: getStacksNetwork(),
+              fee: 0,
+              nonce: 0,
+              anchorMode: AnchorMode.Any,
+            };
+          } else {
+            dummyStackingTx = {
+              publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
+              contractAddress: contractAddress,
+              contractName: contractName,
+              functionName: 'stack-stx',
+              functionArgs: [
+                uintCV(options.amount), // amount-ustx
+                poxAddressToTuple(poxAddr), // pox-addr
+                uintCV(0), // start-burn-ht
+                uintCV(options.number_of_cycles), // lock-period
+              ],
+              validateWithAbi: false,
+              network: getStacksNetwork(),
+              fee: 0,
+              nonce: 0,
+              anchorMode: AnchorMode.Any,
+            };
+          }
           transaction = await makeUnsignedContractCall(dummyStackingTx);
           break;
         }
@@ -306,7 +357,7 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
     makeValidationMiddleware(chainId),
     asyncHandler(async (req, res) => {
       const request: RosettaConstructionMetadataRequest = req.body;
-      const options: RosettaOptions = request.options;
+      const options: RosettaOptions | undefined = request.options;
 
       let dummyTransaction: StacksTransaction;
 
@@ -355,36 +406,87 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
         case RosettaOperationType.StackStx: {
           // Getting PoX info
           const poxInfo = await stackingRpc.getPoxInfo();
-          const poxOperationInfo = await stackingRpc.getPoxOperationInfo();
-          // todo: update stacks.js once released to use the latest stacking contract
-          const contract = await stackingRpc.getStackingContract(poxOperationInfo);
-          const [contractAddress, contractName] = contract.split('.');
+          const [contractAddress, contractName] = poxInfo.contract_id.split('.');
 
-          let burnBlockHeight = poxInfo.current_burnchain_block_height;
+          if (!options.number_of_cycles) {
+            res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+            return;
+          }
+
+          let burnBlockHeight =
+            options?.burn_block_height ?? poxInfo.current_burnchain_block_height;
           // In Stacks 2.1, the burn block height is included in `/v2/pox` so we can skip the extra network request
           burnBlockHeight ??= (await new StacksCoreRpcClient().getInfo()).burn_block_height;
 
           options.contract_address = contractAddress;
           options.contract_name = contractName;
           options.burn_block_height = burnBlockHeight;
+          options.reward_cycle_id ??= poxInfo.current_cycle.id;
 
           // dummy transaction to calculate fee
-          const dummyStackingTx: UnsignedContractCallOptions = {
-            publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
-            contractAddress: contractAddress,
-            contractName: contractName,
-            functionName: 'stack-stx',
-            functionArgs: [
-              uintCV(0),
-              poxAddressToTuple('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'), // placeholder
-              uintCV(0),
-              uintCV(1),
-            ],
-            validateWithAbi: false,
-            network: getStacksNetwork(),
-            nonce: 0,
-            anchorMode: AnchorMode.Any,
-          };
+          let dummyStackingTx: UnsignedContractCallOptions;
+          const poxAddr = options?.pox_addr ?? 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+          if (contractName === 'pox-4') {
+            // fields required for pox4
+            if (!options.signer_key || !options.pox_max_amount) {
+              res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+              return;
+            }
+            options.pox_auth_id ??= BigInt(`0x${randomBytes(16).toString('hex')}`).toString();
+            let signerSigCV: OptionalCV = noneCV();
+            if (options?.signer_signature) {
+              signerSigCV = someCV(bufferCV(hexToBytes(options.signer_signature)));
+            } else if (options?.signer_private_key) {
+              const signerSig = stackingRpc.signPoxSignature({
+                topic: 'stack-stx',
+                poxAddress: poxAddr,
+                rewardCycle: options.reward_cycle_id,
+                period: options.number_of_cycles,
+                signerPrivateKey: createStacksPrivateKey(options.signer_private_key),
+                maxAmount: options.pox_max_amount,
+                authId: options.pox_auth_id,
+              });
+              options.signer_signature = signerSig;
+              signerSigCV = someCV(bufferCV(hexToBytes(signerSig)));
+            }
+            dummyStackingTx = {
+              publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
+              contractAddress: contractAddress,
+              contractName: contractName,
+              functionName: 'stack-stx',
+              functionArgs: [
+                uintCV(0), // amount-ustx
+                poxAddressToTuple(poxAddr), // pox-addr
+                uintCV(options.burn_block_height), // start-burn-ht
+                uintCV(options.number_of_cycles), // lock-period
+                signerSigCV, // signer-sig
+                bufferCV(hexToBytes(options.signer_key)), // signer-key
+                uintCV(options.pox_max_amount), // max-amount
+                uintCV(options.pox_auth_id), // auth-id
+              ],
+              validateWithAbi: false,
+              network: getStacksNetwork(),
+              nonce: 0,
+              anchorMode: AnchorMode.Any,
+            };
+          } else {
+            dummyStackingTx = {
+              publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
+              contractAddress: contractAddress,
+              contractName: contractName,
+              functionName: 'stack-stx',
+              functionArgs: [
+                uintCV(0),
+                poxAddressToTuple(poxAddr), // placeholder
+                uintCV(0),
+                uintCV(1),
+              ],
+              validateWithAbi: false,
+              network: getStacksNetwork(),
+              nonce: 0,
+              anchorMode: AnchorMode.Any,
+            };
+          }
           // Do not set fee so that the fee is calculated
           dummyTransaction = await makeUnsignedContractCall(dummyStackingTx);
 
@@ -687,54 +789,114 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
           break;
         }
         case RosettaOperationType.StackStx: {
-          if (!options.pox_addr) {
+          const contractAddress = options.contract_address ?? req.body.metadata.contract_address;
+          const contractName = options.contract_name ?? req.body.metadata.contract_name;
+          const poxAddr = options.pox_addr ?? req.body.metadata.pox_addr;
+          const burnBlockHeight = options.burn_block_height ?? req.body.metadata.burn_block_height;
+          const numberOfCycles = options.number_of_cycles ?? req.body.metadata.number_of_cycles;
+
+          // pox4 fields
+          const authID = options.pox_auth_id ?? req.body.metadata.pox_auth_id;
+          const signerKey = options.signer_key ?? req.body.metadata.signer_key;
+          const rewardCycleID = options.reward_cycle_id ?? req.body.metadata.reward_cycle_id;
+          const poxMaxAmount = options.pox_max_amount ?? req.body.metadata.pox_max_amount;
+          const signerPrivKey = options.signer_private_key ?? req.body.metadata.signer_private_key;
+          const signerSignature = options.signer_signature ?? req.body.metadata.signer_signature;
+
+          if (!poxAddr) {
             res.status(400).json(RosettaErrorsTypes.invalidOperation);
             return;
           }
-          const poxBTCAddress = options.pox_addr;
-          const { version: hashMode, data } = decodeBtcAddress(poxBTCAddress);
-          const hashModeBuffer = bufferCV(Buffer.from([hashMode]));
-          const hashbytes = bufferCV(data);
-          const poxAddressCV = tupleCV({
-            hashbytes,
-            version: hashModeBuffer,
-          });
 
-          if (!req.body.metadata.contract_address) {
+          if (!contractAddress) {
             res.status(400).json(RosettaErrors[RosettaErrorsTypes.missingContractAddress]);
             return;
           }
-          if (!req.body.metadata.contract_name) {
+          if (!contractName) {
             res.status(400).json(RosettaErrors[RosettaErrorsTypes.missingContractName]);
             return;
           }
-          if (!req.body.metadata.burn_block_height) {
+          if (!burnBlockHeight) {
             res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
             return;
           }
-          if (!options.number_of_cycles || !options.amount || !options.signer_key) {
+          if (!numberOfCycles || !options.amount) {
             res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
             return;
           }
 
-          const stackingTx: UnsignedContractCallOptions = {
-            contractAddress: req.body.metadata.contract_address,
-            contractName: req.body.metadata.contract_name,
-            functionName: 'stack-stx',
-            publicKey: publicKeys[0].hex_bytes,
-            functionArgs: [
-              uintCV(options.amount),
-              poxAddressCV,
-              uintCV(req.body.metadata.burn_block_height),
-              uintCV(options.number_of_cycles),
-              bufferCV(hexToBytes(options.signer_key)),
-            ],
-            fee: txFee,
-            nonce: nonce,
-            validateWithAbi: false,
-            network: getStacksNetwork(),
-            anchorMode: AnchorMode.Any,
-          };
+          const isPox4 = contractName === 'pox-4';
+          // fields required for pox4
+          if (isPox4 && (!signerKey || !poxMaxAmount || !rewardCycleID || !signerKey)) {
+            res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+            return;
+          }
+          // either signer-private-key or signer-sig required for pox4, cannot specify both
+          if (
+            isPox4 &&
+            ((!signerPrivKey && !signerSignature) || (signerPrivKey && signerSignature))
+          ) {
+            res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+            return;
+          }
+
+          let stackingTx: UnsignedContractCallOptions;
+          if (isPox4) {
+            let signerSig: string;
+            if (signerSignature) {
+              signerSig = signerSignature;
+            } else {
+              signerSig = stackingRpc.signPoxSignature({
+                topic: 'stack-stx',
+                poxAddress: poxAddr,
+                rewardCycle: Number(BigInt(rewardCycleID).toString()),
+                period: numberOfCycles,
+                signerPrivateKey: createStacksPrivateKey(signerPrivKey),
+                maxAmount: poxMaxAmount,
+                authId: authID,
+              });
+            }
+
+            stackingTx = {
+              contractAddress: contractAddress,
+              contractName: contractName,
+              functionName: 'stack-stx',
+              publicKey: publicKeys[0].hex_bytes,
+              functionArgs: [
+                uintCV(options.amount), // amount-ustx
+                poxAddressToTuple(poxAddr), // pox-addr
+                uintCV(burnBlockHeight), // start-burn-ht
+                uintCV(numberOfCycles), // lock-period
+                someCV(bufferCV(hexToBuffer(signerSig))), // signer-sig
+                bufferCV(hexToBytes(signerKey)), // signer-key
+                uintCV(options.pox_max_amount as string), // max-amount
+                uintCV(authID), // auth-id
+              ],
+              fee: txFee,
+              nonce: nonce,
+              validateWithAbi: false,
+              network: getStacksNetwork(),
+              anchorMode: AnchorMode.Any,
+            };
+          } else {
+            stackingTx = {
+              contractAddress: req.body.metadata.contract_address,
+              contractName: req.body.metadata.contract_name,
+              functionName: 'stack-stx',
+              publicKey: publicKeys[0].hex_bytes,
+              functionArgs: [
+                uintCV(options.amount),
+                poxAddressToTuple(poxAddr),
+                uintCV(burnBlockHeight),
+                uintCV(numberOfCycles),
+              ],
+              fee: txFee,
+              nonce: nonce,
+              validateWithAbi: false,
+              network: getStacksNetwork(),
+              anchorMode: AnchorMode.Any,
+            };
+          }
           transaction = await makeUnsignedContractCall(stackingTx);
           break;
         }

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -229,7 +229,7 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
             return;
           }
 
-          if (isPox4 && (!options.signer_key || !options.pox_max_amount)) {
+          if (isPox4 && !options.signer_key) {
             res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
             return;
           }
@@ -256,7 +256,7 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
                 rewardCycle: 0,
                 period: options.number_of_cycles ?? 1,
                 signerPrivateKey: signerPrivKey,
-                maxAmount: options.pox_max_amount ?? 1,
+                maxAmount: options.pox_max_amount ?? options.amount ?? 1,
                 authId: options.pox_auth_id ?? 0,
               })
             );
@@ -272,7 +272,7 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
                 uintCV(options.number_of_cycles ?? 1), // lock-period
                 someCV(bufferCV(signerSig)), // signer-sig
                 bufferCV(hexToBytes(options.signer_key as string)), // signer-key
-                uintCV(options.pox_max_amount ?? 1), // max-amount
+                uintCV(options.pox_max_amount ?? options.amount ?? 1), // max-amount
                 uintCV(options.pox_auth_id ?? 0), // auth-id
               ],
               validateWithAbi: false,
@@ -427,7 +427,7 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
           const poxAddr = options?.pox_addr ?? 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
           if (contractName === 'pox-4') {
             // fields required for pox4
-            if (!options.signer_key || !options.pox_max_amount) {
+            if (!options.signer_key) {
               res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
               return;
             }
@@ -444,7 +444,7 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
                 signerPrivateKey: options.signer_private_key
                   ? createStacksPrivateKey(options.signer_private_key)
                   : makeRandomPrivKey(),
-                maxAmount: options?.pox_max_amount ?? 0,
+                maxAmount: options?.pox_max_amount ?? options?.amount ?? 0,
                 authId: options?.pox_auth_id ?? 0,
               });
               options.signer_signature = signerSig;
@@ -462,7 +462,7 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
                 uintCV(options?.number_of_cycles ?? 0), // lock-period
                 signerSigCV, // signer-sig
                 bufferCV(hexToBytes(options.signer_key)), // signer-key
-                uintCV(options.pox_max_amount), // max-amount
+                uintCV(options?.pox_max_amount ?? options?.amount ?? 1), // max-amount
                 uintCV(options?.pox_auth_id ?? 0), // auth-id
               ],
               validateWithAbi: false,
@@ -800,7 +800,8 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
           const authID = options.pox_auth_id ?? req.body.metadata.pox_auth_id;
           const signerKey = options.signer_key ?? req.body.metadata.signer_key;
           const rewardCycleID = options.reward_cycle_id ?? req.body.metadata.reward_cycle_id;
-          const poxMaxAmount = options.pox_max_amount ?? req.body.metadata.pox_max_amount;
+          const poxMaxAmount =
+            options.pox_max_amount ?? req.body.metadata.pox_max_amount ?? options.amount;
           const signerPrivKey = options.signer_private_key ?? req.body.metadata.signer_private_key;
           const signerSignature = options.signer_signature ?? req.body.metadata.signer_signature;
 
@@ -867,7 +868,7 @@ export function createRosettaConstructionRouter(db: PgStore, chainId: ChainID): 
                 uintCV(numberOfCycles), // lock-period
                 signerSig ? someCV(bufferCV(hexToBuffer(signerSig))) : noneCV(), // signer-sig
                 bufferCV(hexToBytes(signerKey)), // signer-key
-                uintCV(options.pox_max_amount as string), // max-amount
+                uintCV(poxMaxAmount), // max-amount
                 uintCV(authID), // auth-id
               ],
               fee: txFee,

--- a/src/rosetta/rosetta-helpers.ts
+++ b/src/rosetta/rosetta-helpers.ts
@@ -774,17 +774,21 @@ export function getOptionsFromOperations(operations: RosettaOperation[]): Rosett
         if (!operation.metadata || typeof operation.metadata.number_of_cycles !== 'number') {
           return null;
         }
-        if (!operation.metadata || typeof operation.metadata.signer_key !== 'string') {
-          return null;
-        }
         options.sender_address = operation.account?.address;
         options.type = operation.type;
         options.number_of_cycles = operation.metadata.number_of_cycles;
-        options.signer_key = operation.metadata.signer_key;
         options.amount = operation.amount?.value.replace('-', '');
         options.symbol = operation.amount?.currency.symbol;
         options.decimals = operation.amount?.currency.decimals;
         options.pox_addr = operation.metadata?.pox_addr as string;
+
+        options.signer_private_key = operation.metadata?.signer_private_key as string;
+        options.signer_signature = operation.metadata?.signer_signature as string;
+        options.signer_key = operation.metadata.signer_key as string;
+        options.pox_max_amount = operation.metadata?.pox_max_amount as string;
+        options.pox_auth_id = operation.metadata?.pox_auth_id as string;
+        options.reward_cycle_id = operation.metadata?.reward_cycle_id as number;
+
         break;
       case RosettaOperationType.DelegateStx:
         if (operation.amount && BigInt(operation.amount.value) > 0) {

--- a/src/test-utils/test-helpers.ts
+++ b/src/test-utils/test-helpers.ts
@@ -518,6 +518,7 @@ export async function stackStxWithRosetta(opts: {
   cycleCount: number;
   ustxAmount: bigint;
   signerKey: string;
+  signerPrivKey: string;
 }) {
   const rosettaNetwork: NetworkIdentifier = {
     blockchain: RosettaConstants.blockchain,
@@ -539,6 +540,7 @@ export async function stackStxWithRosetta(opts: {
         number_of_cycles: opts.cycleCount,
         pox_addr: opts.btcAddr,
         signer_key: opts.signerKey,
+        signer_private_key: opts.signerPrivKey,
       },
     },
     {

--- a/src/tests-2.5/pox-4-rosetta-btc-addr-types.ts
+++ b/src/tests-2.5/pox-4-rosetta-btc-addr-types.ts
@@ -30,6 +30,8 @@ describe.each(BTC_ADDRESS_CASES)(
     const account = testnetKeys[1];
     let bitcoinAddress: string;
 
+    const cycleCount = 2;
+
     const signerPrivKey = '929c9b8581473c67df8a21c2a4a12f74762d913dd39d91295ee96e779124bca9';
     const signerPubKey = '033b67384665cbc3a36052a2d1c739a6cd1222cd451c499400c9d42e2041a56161';
 
@@ -54,7 +56,6 @@ describe.each(BTC_ADDRESS_CASES)(
       );
 
       const ustxAmount = BigInt(Math.round(Number(poxInfo.min_amount_ustx) * 1.1).toString());
-      const cycleCount = 1;
 
       const rosettaStackStx = await stackStxWithRosetta({
         btcAddr: bitcoinAddress,
@@ -71,18 +72,21 @@ describe.each(BTC_ADDRESS_CASES)(
     });
 
     test('Validate reward set received', async () => {
-      const nextCycleStart = poxInfo.next_cycle.reward_phase_start_block_height;
+      for (let i = 0; i < cycleCount; i++) {
+        poxInfo = await testEnv.client.getPox();
+        const nextCycleStart = poxInfo.next_cycle.reward_phase_start_block_height;
+        await standByUntilBurnBlock(nextCycleStart); // time to check reward sets after a few blocks
+      }
 
-      await standByUntilBurnBlock(nextCycleStart); // time to check reward sets after a few blocks
       await timeout(3000); // make sure rewards have been processed
 
       poxInfo = await testEnv.client.getPox();
       const rewardSlotHolders = await fetchGet<BurnchainRewardSlotHolderListResponse>(
         `/extended/v1/burnchain/reward_slot_holders/${bitcoinAddress}`
       );
-      expect(rewardSlotHolders.total).toBe(1);
+      expect(rewardSlotHolders.total).toBeGreaterThan(0);
       expect(rewardSlotHolders.results[0].address).toBe(bitcoinAddress);
-      expect(rewardSlotHolders.results[0].burn_block_height).toBe(nextCycleStart + 1);
+      // expect(rewardSlotHolders.results[0].burn_block_height).toBe(nextCycleStart + 1);
       // todo: is it correct that the reware slot is for the 2nd block of a reward phase?
     });
   }

--- a/src/tests-2.5/pox-4-rosetta-btc-addr-types.ts
+++ b/src/tests-2.5/pox-4-rosetta-btc-addr-types.ts
@@ -30,6 +30,9 @@ describe.each(BTC_ADDRESS_CASES)(
     const account = testnetKeys[1];
     let bitcoinAddress: string;
 
+    const signerPrivKey = '929c9b8581473c67df8a21c2a4a12f74762d913dd39d91295ee96e779124bca9';
+    const signerPubKey = '033b67384665cbc3a36052a2d1c739a6cd1222cd451c499400c9d42e2041a56161';
+
     beforeAll(() => {
       bitcoinAddress = getBitcoinAddressFromKey({
         privateKey: account.secretKey,
@@ -60,7 +63,8 @@ describe.each(BTC_ADDRESS_CASES)(
         privateKey: account.secretKey,
         cycleCount,
         ustxAmount,
-        signerKey: bytesToHex(randomBytes(33)),
+        signerKey: signerPubKey,
+        signerPrivKey: signerPrivKey,
       });
       expect(rosettaStackStx.tx.status).toBe(DbTxStatus.Success);
       expect(rosettaStackStx.constructionMetadata.metadata.contract_name).toBe('pox-4');

--- a/src/tests-2.5/pox-4-rosetta-cycle-phases.ts
+++ b/src/tests-2.5/pox-4-rosetta-cycle-phases.ts
@@ -12,6 +12,9 @@ for (let shift = 0; shift < REWARD_CYCLE_LENGTH; shift++) {
 const account = testnetKeys[1];
 const btcAddr = '2N74VLxyT79VGHiBK2zEg3a9HJG7rEc5F3o';
 
+const signerPrivKey = '929c9b8581473c67df8a21c2a4a12f74762d913dd39d91295ee96e779124bca9';
+const signerPubKey = '033b67384665cbc3a36052a2d1c739a6cd1222cd451c499400c9d42e2041a56161';
+
 describe.each(BLOCK_SHIFT_COUNT)(
   'PoX-4 - Rosetta - Stack on any phase of cycle $shift',
   ({ shift }) => {
@@ -43,7 +46,8 @@ describe.each(BLOCK_SHIFT_COUNT)(
         cycleCount: 1,
         ustxAmount,
         btcAddr,
-        signerKey: bytesToHex(randomBytes(33)),
+        signerKey: signerPubKey,
+        signerPrivKey: signerPrivKey,
       });
     });
 

--- a/src/tests-2.5/pox-4-rosetta-segwit.ts
+++ b/src/tests-2.5/pox-4-rosetta-segwit.ts
@@ -120,7 +120,7 @@ describe('PoX-4 - Rosetta - Stacking with segwit', () => {
     // This should be investigated further, but is not the purpose of this test
     await standByForPoxCycle();
 
-    const cycleCount = 1;
+    const cycleCount = 2;
 
     const poxInfo = await testEnv.client.getPox();
     ustxAmount = BigInt(Math.round(Number(poxInfo.min_amount_ustx) * 1.1).toString());
@@ -235,7 +235,9 @@ describe('PoX-4 - Rosetta - Stacking with segwit', () => {
     expect(sats).toBe(firstReward.reward_amount);
   });
 
-  test('Stack below threshold to trigger early auto-unlock', async () => {
+  // NOTE: auto-unlock has been removed in pox-4
+  // See https://github.com/stacks-network/stacks-core/pull/4576
+  test.skip('Stack below threshold to trigger early auto-unlock', async () => {
     const cycleCount = 5;
 
     const poxInfo = await testEnv.client.getPox();
@@ -276,7 +278,7 @@ describe('PoX-4 - Rosetta - Stacking with segwit', () => {
   });
 
   let earlyUnlockBurnHeight: number;
-  test('Ensure account unlocks early', async () => {
+  test.skip('Ensure account unlocks early', async () => {
     const initialAccountInfo = await testEnv.client.getAccount(account.stxAddr);
     await standByForAccountUnlock(account.stxAddr);
 
@@ -301,7 +303,7 @@ describe('PoX-4 - Rosetta - Stacking with segwit', () => {
     expect(BigInt(rosettaBalance.locked.balances[0].value)).toBe(0n);
   });
 
-  test('Ensure unlock operation generated after auto-unlock', async () => {
+  test.skip('Ensure unlock operation generated after auto-unlock', async () => {
     await standByUntilBurnBlock(earlyUnlockBurnHeight + 2);
 
     // Get Stacks block associated with the burn block `unlock_height` reported by RPC

--- a/src/tests-2.5/pox-4-rosetta-segwit.ts
+++ b/src/tests-2.5/pox-4-rosetta-segwit.ts
@@ -40,8 +40,10 @@ describe('PoX-4 - Rosetta - Stacking with segwit', () => {
     pubKey: string;
   };
   let testAccountBalance: bigint;
-  let lastPoxInfo: CoreRpcPoxInfo;
   let ustxAmount: bigint;
+
+  const signerPrivKey = '929c9b8581473c67df8a21c2a4a12f74762d913dd39d91295ee96e779124bca9';
+  const signerPubKey = '033b67384665cbc3a36052a2d1c739a6cd1222cd451c499400c9d42e2041a56161';
 
   beforeAll(() => {
     const ecPair = ECPair.fromPrivateKey(Buffer.from(accountKey, 'hex').slice(0, 32), {
@@ -121,7 +123,6 @@ describe('PoX-4 - Rosetta - Stacking with segwit', () => {
     const cycleCount = 1;
 
     const poxInfo = await testEnv.client.getPox();
-    lastPoxInfo = poxInfo;
     ustxAmount = BigInt(Math.round(Number(poxInfo.min_amount_ustx) * 1.1).toString());
 
     const stackingResult = await stackStxWithRosetta({
@@ -131,7 +132,8 @@ describe('PoX-4 - Rosetta - Stacking with segwit', () => {
       privateKey: account.secretKey,
       cycleCount: cycleCount,
       ustxAmount: ustxAmount,
-      signerKey: bytesToHex(randomBytes(33)),
+      signerKey: signerPubKey,
+      signerPrivKey: signerPrivKey,
     });
 
     expect(stackingResult.constructionMetadata.metadata.contract_name).toBe('pox-4');
@@ -246,7 +248,8 @@ describe('PoX-4 - Rosetta - Stacking with segwit', () => {
       privateKey: account.secretKey,
       cycleCount,
       ustxAmount,
-      signerKey: bytesToHex(randomBytes(33)),
+      signerKey: signerPubKey,
+      signerPrivKey: signerPrivKey,
     });
 
     expect(rosettaStackStx.constructionMetadata.metadata.contract_name).toBe('pox-4');

--- a/src/tests-rosetta/offline-api-tests.ts
+++ b/src/tests-rosetta/offline-api-tests.ts
@@ -836,7 +836,7 @@ describe('Rosetta offline API', () => {
     const number_of_cycles = 5;
     const reward_cycle_id = 3;
     const pox_auth_id = 234565725;
-    const poxBTCAddress = '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3'
+    const poxBTCAddress = '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3';
 
     const signerPrivKey = '929c9b8581473c67df8a21c2a4a12f74762d913dd39d91295ee96e779124bca9';
     const signerPubKey = '033b67384665cbc3a36052a2d1c739a6cd1222cd451c499400c9d42e2041a56161';
@@ -897,7 +897,7 @@ describe('Rosetta offline API', () => {
           },
           metadata: {
             number_of_cycles: number_of_cycles,
-            pox_addr : poxBTCAddress,
+            pox_addr: poxBTCAddress,
             signer_key: signerPubKey,
             signer_private_key: signerPrivKey,
             reward_cycle_id: reward_cycle_id,

--- a/src/tests-rosetta/offline-api-tests.ts
+++ b/src/tests-rosetta/offline-api-tests.ts
@@ -51,7 +51,7 @@ import { getStacksTestnetNetwork, testnetKeys } from '../api/routes/debug';
 import { getSignature, getStacksNetwork, publicKeyToBitcoinAddress } from '../rosetta/rosetta-helpers';
 import * as nock from 'nock';
 import { PgStore } from '../datastore/pg-store';
-import { decodeBtcAddress } from '@stacks/stacking';
+import { StackingClient, decodeBtcAddress, poxAddressToTuple } from '@stacks/stacking';
 import { bufferToHex } from '@hirosystems/api-toolkit';
 import { hexToBytes } from '@stacks/common';
 
@@ -284,6 +284,9 @@ describe('Rosetta offline API', () => {
   });
 
   test('offline construction/preprocess - stacking', async () => {
+    const signerPrivKey = '929c9b8581473c67df8a21c2a4a12f74762d913dd39d91295ee96e779124bca9';
+    const signerPubKey = '033b67384665cbc3a36052a2d1c739a6cd1222cd451c499400c9d42e2041a56161';
+
     const request: RosettaConstructionPreprocessRequest = {
       network_identifier: {
         blockchain: RosettaConstants.blockchain,
@@ -331,7 +334,8 @@ describe('Rosetta offline API', () => {
           metadata: {
             number_of_cycles: 3,
             pox_addr: '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3',
-            signer_key: "00".repeat(33),
+            signer_key: signerPubKey,
+            signer_private_key: signerPrivKey,
           },
         },
       ],
@@ -366,10 +370,11 @@ describe('Rosetta offline API', () => {
         symbol: 'STX',
         decimals: 6,
         max_fee: '12380898',
-        size: 298,
+        size: 405,
         number_of_cycles: 3,
         pox_addr: '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3',
-        signer_key: "00".repeat(33),
+        signer_key: signerPubKey,
+        signer_private_key: signerPrivKey,
       },
       required_public_keys: [
         {
@@ -820,7 +825,7 @@ describe('Rosetta offline API', () => {
     expect(JSON.parse(result.text)).toEqual(expectedResponse);
   });
 
-  test('Sucess: offline - payloads single sign - stacking', async () => {
+  test('Success: offline - payloads single sign - stacking', async () => {
     const publicKey = publicKeyToString(pubKeyfromPrivKey(testnetKeys[0].secretKey));
     const sender = testnetKeys[0].stacksAddress;
     const fee = '270';
@@ -829,6 +834,23 @@ describe('Rosetta offline API', () => {
     const stacking_amount = 5000;
     const burn_block_height = 200;
     const number_of_cycles = 5;
+    const reward_cycle_id = 3;
+    const pox_auth_id = 234565725;
+    const poxBTCAddress = '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3'
+
+    const signerPrivKey = '929c9b8581473c67df8a21c2a4a12f74762d913dd39d91295ee96e779124bca9';
+    const signerPubKey = '033b67384665cbc3a36052a2d1c739a6cd1222cd451c499400c9d42e2041a56161';
+
+    const stackingClient = new StackingClient('', getStacksTestnetNetwork());
+    const signerSig = stackingClient.signPoxSignature({
+      topic: 'stack-stx',
+      poxAddress: poxBTCAddress,
+      rewardCycle: reward_cycle_id,
+      period: number_of_cycles,
+      signerPrivateKey: createStacksPrivateKey(signerPrivKey),
+      maxAmount: stacking_amount,
+      authId: pox_auth_id,
+    });
 
     const request: RosettaConstructionPayloadsRequest = {
       network_identifier: {
@@ -875,8 +897,12 @@ describe('Rosetta offline API', () => {
           },
           metadata: {
             number_of_cycles: number_of_cycles,
-            pox_addr : '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3',
-            signer_key: "02".repeat(33),
+            pox_addr : poxBTCAddress,
+            signer_key: signerPubKey,
+            signer_private_key: signerPrivKey,
+            reward_cycle_id: reward_cycle_id,
+            pox_auth_id: pox_auth_id,
+            signer_signature: signerSig,
           }
         },
       ],
@@ -894,28 +920,20 @@ describe('Rosetta offline API', () => {
       ],
     };
 
-    const poxBTCAddress = '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3'
-
-    const { version: hashMode, data } = decodeBtcAddress(poxBTCAddress);
-    const hashModeBuffer = bufferCV(Buffer.from([hashMode]));
-    const hashbytes = bufferCV(data);
-    const poxAddressCV = tupleCV({
-      hashbytes,
-      version: hashModeBuffer,
-    });
-
-
     const stackingTx: UnsignedContractCallOptions = {
       contractAddress: contract_address,
       contractName: contract_name,
       functionName: 'stack-stx',
       publicKey: publicKey,
       functionArgs: [
-        uintCV(stacking_amount),
-        poxAddressCV,
-        uintCV(burn_block_height),
-        uintCV(number_of_cycles),
-        bufferCV(hexToBytes("02".repeat(33)))
+        uintCV(stacking_amount), // amount-ustx
+        poxAddressToTuple(poxBTCAddress), // pox-addr
+        uintCV(burn_block_height), // start-burn-ht
+        uintCV(number_of_cycles), // lock-period
+        someCV(bufferCV(hexToBytes(signerSig))), // signer-sig
+        bufferCV(hexToBytes(signerPubKey)), // signer-key
+        uintCV(stacking_amount), // max-amount
+        uintCV(pox_auth_id), // auth-id
       ],
       validateWithAbi: false,
       nonce: 0,
@@ -957,7 +975,7 @@ describe('Rosetta offline API', () => {
     expect(JSON.parse(result.text)).toEqual(expectedResponse);
   });
 
-  test('Sucess: offline - payloads single sign - delegate - stacking', async () => {
+  test('Success: offline - payloads single sign - delegate - stacking', async () => {
     const publicKey = publicKeyToString(pubKeyfromPrivKey(testnetKeys[0].secretKey));
     const sender = testnetKeys[0].stacksAddress;
     const fee = '270';


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/1901
Implement Rosetta pox-4 `stack-stx` support.

This PR introduces three modes to use pox4 `stack-stx` in Rosetta:
1) Specify `signer-private-key` and the Rosetta layer will generate the signer signature used by the stack-stx transaction.
2) Specify `signer-signature` (generated external to the Rosetta layer) and it will be used in the stack-stx transaction.
3) Do not specify `signer-private-key` or `signer-signature`, and the stack-stx transaction will specify `none` for this field -- only works if the signer has added the caller to their allow-list.

Additionally:
* The stack-stx `auth-id` field is optional: if not specified, the Rosetta layer will automatically generate a random ID.
* The `reward-cycle-id` field is optional: if not specified, the Rosetta layer will pick the next cycle similar to how it already does with the `burn-block-height` field.
* The `pox-max-amount` field is optional: if not specified, the STX `amount` will be used.