### PR TITLE
fix: log message when sql migration is performed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "9.0.9",
-        "@hirosystems/api-toolkit": "1.3.3",
+        "@hirosystems/api-toolkit": "1.5.0",
         "@promster/express": "6.0.0",
         "@promster/server": "6.0.6",
         "@promster/types": "3.2.3",
@@ -1248,9 +1248,9 @@
       }
     },
     "node_modules/@hirosystems/api-toolkit": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@hirosystems/api-toolkit/-/api-toolkit-1.3.3.tgz",
-      "integrity": "sha512-0/JjQ54twLdVqf8+hB+8IAKn8JdCdlMfT3BqUWha5qMrjlC3KX+kAl+88+CqpoibY/lgYJ9fs+70KG/weHt3LQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@hirosystems/api-toolkit/-/api-toolkit-1.5.0.tgz",
+      "integrity": "sha512-f7rL2Bct+tW5gtYEZwCFQYQnkEIgGH+yoBYe807c+/gYItfWa9bPdY8KAFo+5AD1TbvP1bECrUClhK2TCCc1tA==",
       "dependencies": {
         "@fastify/cors": "^8.0.0",
         "@fastify/swagger": "^8.3.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "9.0.9",
-    "@hirosystems/api-toolkit": "1.3.3",
+    "@hirosystems/api-toolkit": "1.5.0",
     "@promster/express": "6.0.0",
     "@promster/server": "6.0.6",
     "@promster/types": "3.2.3",

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -157,7 +157,18 @@ export class PgWriteStore extends PgStore {
       connectionConfig: getConnectionConfig(PgServer.primary),
     });
     if (!skipMigrations) {
-      await runMigrations(MIGRATIONS_DIR, 'up', getConnectionArgs(PgServer.primary));
+      await runMigrations(MIGRATIONS_DIR, 'up', getConnectionArgs(PgServer.primary), {
+        logger: {
+          debug: _ => {},
+          info: msg => {
+            if (msg.includes('Migrating files')) {
+              logger.info(`Performing SQL migration, this may take a while...`);
+            }
+          },
+          warn: msg => logger.warn(msg),
+          error: msg => logger.error(msg),
+        },
+      });
     }
     const notifier = withNotifier ? await PgNotifier.create(usageName) : undefined;
     const store = new PgWriteStore(sql, notifier, isEventReplay);


### PR DESCRIPTION
Add logging message when sql migration is performed. Fixes the issue where it looks like the API boot is stalled during a long migration.

Example of the logs:
```json
{"level":"info","msg":"PgNotifier connected, listening on channel: stacks-api-pg-notifier"}
{"level":"info","msg":"Performing SQL migration, this may take a while..."}
{"level":"info","msg":"Event observer listening at: http://127.0.0.1:3700"}
```