### PR TITLE
feat: add docker build for arm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -886,6 +886,9 @@ jobs:
             @semantic-release/exec@6.0.3
             conventional-changelog-conventionalcommits@6.1.0
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -927,6 +930,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: ${{ github.ref == 'refs/heads/master' && 'linux/amd64,linux/arm64' ||  'linux/amd64'  }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)


### PR DESCRIPTION
## Description

I added arm docker builds support so I can run a node on my arm server. Right now you will get an error when trying to run the amd image on an arm server. The work was already started on other prs but never merged. I followed the approach mentioned in https://github.com/hirosystems/stacks-blockchain-api/pull/1578 to keep amd build only on prs to not increase the build time and build both arm + amd on the master branch.

Following up the following prs:
- https://github.com/hirosystems/stacks-blockchain-api/pull/1248
- https://github.com/hirosystems/stacks-blockchain-api/pull/1578

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @rafaelcr or @zone117x for review
