### PR TITLE
ci: remove unsupported standalone image build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -851,13 +851,6 @@ jobs:
 
   build-publish:
     runs-on: ubuntu-latest
-    needs:
-      - lint
-      - lint-docs
-      - test
-      - test-bns
-      - test-rosetta
-      - test-rosetta-cli-construction
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -906,20 +906,6 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.semantic.outputs.new_release_version }},enable=${{ steps.semantic.outputs.new_release_version != '' }}
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Docker Standalone Meta
-        id: meta_standalone
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            blockstack/${{ github.event.repository.name }}-standalone
-            hirosystems/${{ github.event.repository.name }}-standalone
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}},value=${{ steps.semantic.outputs.new_release_version }},enable=${{ steps.semantic.outputs.new_release_version != '' }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ steps.semantic.outputs.new_release_version }},enable=${{ steps.semantic.outputs.new_release_version != '' }}
-            type=raw,value=latest,enable={{is_default_branch}}
-
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -933,18 +919,6 @@ jobs:
           platforms: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
-          push: ${{ (github.ref != 'refs/heads/master' || steps.semantic.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-
-      - name: Build/Tag/Push Standalone Image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          build-args: |
-            STACKS_API_VERSION=${{ github.head_ref || github.ref_name }}
-          file: docker/rosetta.Dockerfile
-          tags: ${{ steps.meta_standalone.outputs.tags }}
-          labels: ${{ steps.meta_standalone.outputs.labels }}
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
           push: ${{ (github.ref != 'refs/heads/master' || steps.semantic.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
 


### PR DESCRIPTION
Part of https://github.com/hirosystems/stacks-blockchain-api/issues/1902
Speeds up CI