### PR TITLE
fix: rosetta account endpoint should assume chain tip if block not specified

### DIFF
--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -39,7 +39,10 @@ export function createRosettaAccountRouter(db: PgStore, chainId: ChainID): expre
           let blockHash: string = '0x';
           // we need to return the block height/hash in the response, so we
           // need to fetch the block first.
-          if (blockIdentifier === undefined) {
+          if (
+            (!blockIdentifier?.hash && !blockIdentifier?.index) ||
+            (blockIdentifier && blockIdentifier.index <= 0)
+          ) {
             blockQuery = await db.getCurrentBlock();
           } else if (blockIdentifier.index > 0) {
             blockQuery = await db.getBlock({ height: blockIdentifier.index });

--- a/src/tests-rosetta/account-tests.ts
+++ b/src/tests-rosetta/account-tests.ts
@@ -74,17 +74,7 @@ describe('/account tests', () => {
       .build();
     await db.update(block2);
 
-    const query1 = await supertest(api.server)
-      .post(`/rosetta/v1/account/balance`)
-      .send({
-        network_identifier: { blockchain: 'stacks', network: 'testnet' },
-        block_identifier: { index: 2, hash: '0xf1f1' },
-        account_identifier: { address: addr2 },
-      });
-    expect(query1.status).toBe(200);
-    expect(query1.type).toBe('application/json');
-    const result1 = JSON.parse(query1.text);
-    expect(result1.balances).toEqual([
+    const expectedBalance = [
       {
         currency: {
           decimals: 6,
@@ -99,7 +89,30 @@ describe('/account tests', () => {
         },
         value: '7500'
       }
-    ]);
+    ];
+    const query1 = await supertest(api.server)
+      .post(`/rosetta/v1/account/balance`)
+      .send({
+        network_identifier: { blockchain: 'stacks', network: 'testnet' },
+        block_identifier: { index: 2, hash: '0xf1f1' },
+        account_identifier: { address: addr2 },
+      });
+    expect(query1.status).toBe(200);
+    expect(query1.type).toBe('application/json');
+    expect(JSON.parse(query1.text).balances).toEqual(expectedBalance);
+
+    // ensure query works with block identifier omitted
+    const query2 = await supertest(api.server)
+      .post(`/rosetta/v1/account/balance`)
+      .send({
+        network_identifier: { blockchain: 'stacks', network: 'testnet' },
+        account_identifier: { address: addr2 },
+      });
+    expect(query2.status).toBe(200);
+    expect(query2.type).toBe('application/json');
+    expect(JSON.parse(query2.text).balances).toEqual(expectedBalance);
+
     nock.cleanAll();
   });
+
 });

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -1239,32 +1239,6 @@ describe('Rosetta API', () => {
     expect(JSON.parse(result.text)).toEqual(expectResponse);
   });
 
-  test('account/balance - empty block identifier', async () => {
-    const request: RosettaAccountBalanceRequest = {
-      network_identifier: {
-        blockchain: 'stacks',
-        network: 'testnet',
-      },
-      account_identifier: {
-        address: 'SP2QXJDSWYFGT9022M6NCA9SS4XNQM79D8E7EDSPQ',
-        metadata: {},
-      },
-      block_identifier: {},
-    };
-
-    const result = await supertest(api.server).post(`/rosetta/v1/account/balance/`).send(request);
-    expect(result.status).toBe(400);
-    expect(result.type).toBe('application/json');
-
-    const expectResponse = {
-      code: 615,
-      message: 'Block identifier is null.',
-      retriable: false,
-    };
-
-    expect(JSON.parse(result.text)).toEqual(expectResponse);
-  });
-
   test('account/balance - invalid block hash', async () => {
     const request: RosettaAccountBalanceRequest = {
       network_identifier: {


### PR DESCRIPTION
Fixes https://github.com/hirosystems/stacks-blockchain-api/issues/1955