### PR TITLE
fix: inconsistent block transaction results in Rosetta response

### DIFF
--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -467,15 +467,14 @@ export async function getRosettaBlockFromDataStore(
   blockHeight?: number
 ): Promise<FoundOrNot<RosettaBlock>> {
   return await db.sqlTransaction(async sql => {
-    let query;
+    let blockQuery: FoundOrNot<DbBlock>;
     if (blockHash) {
-      query = db.getBlock({ hash: blockHash });
+      blockQuery = await db.getBlock({ hash: blockHash });
     } else if (blockHeight && blockHeight > 0) {
-      query = db.getBlock({ height: blockHeight });
+      blockQuery = await db.getBlock({ height: blockHeight });
     } else {
-      query = db.getCurrentBlock();
+      blockQuery = await db.getCurrentBlock();
     }
-    const blockQuery = await query;
 
     if (!blockQuery.found) {
       return { found: false };


### PR DESCRIPTION
Fix possible cause of Rosetta block lookups returning inconsistent results. E.g. reports of block response with 0 transactions:

```
curl --location 'https://xxx/block' \
--header 'Content-Type: application/json' \
--data '{
    "network_identifier": {
        "blockchain": "stacks",
        "network": "mainnet"
    },
    "block_identifier": {
        "index": 147250
    }
}'

{
    "block": {
        "block_identifier": {
            "index": 147250,
            "hash": "0x2dc8a524911e12f3c4d14de79ca5893b70c7c34d07d0bef59d31b8568650c07f"
        },
        "parent_block_identifier": {
            "index": 147249,
            "hash": "0x52ae92098398349b936e1b1c29591150566d38b800101dc0dff805c47aca2f0b"
        },
        "timestamp": 1713772872000,
        "transactions": []
    }
}
```