### PR TITLE
feat: add signer_address to pox signer endpoints

### DIFF
--- a/docs/api/stacking/get-pox-cycle-signers.example.json
+++ b/docs/api/stacking/get-pox-cycle-signers.example.json
@@ -5,6 +5,7 @@
   "results": [
     {
       "signing_key": "0x038e3c4529395611be9abf6fa3b6987e81d402385e3d605a073f42f407565a4a3d",
+      "signer_address": "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP",
       "stacked_amount": "686251350000000000",
       "stacked_amount_percent": 50,
       "weight": 5,
@@ -12,6 +13,7 @@
     },
     {
       "signing_key": "0x029874497a7952483aa23890e9d0898696f33864d3df90939930a1f45421fe3b09",
+      "signer_address": "STF9B75ADQAVXQHNEQ6KGHXTG7JP305J2GRWF3A2",
       "stacked_amount": "457500900000000000",
       "stacked_amount_percent": 33.333333333333336,
       "weight": 3,
@@ -19,6 +21,7 @@
     },
     {
       "signing_key": "0x02dcde79b38787b72d8e5e0af81cffa802f0a3c8452d6b46e08859165f49a72736",
+      "signer_address": "ST18MDW2PDTBSCR1ACXYRJP2JX70FWNM6YY2VX4SS",
       "stacked_amount": "228750450000000000",
       "stacked_amount_percent": 16.666666666666668,
       "weight": 1,

--- a/docs/entities/stacking/signer.example.json
+++ b/docs/entities/stacking/signer.example.json
@@ -1,5 +1,6 @@
 {
   "signing_key": "0x038e3c4529395611be9abf6fa3b6987e81d402385e3d605a073f42f407565a4a3d",
+  "signer_address": "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP",
   "stacked_amount": "686251350000000000",
   "stacked_amount_percent": 50,
   "weight": 5,

--- a/docs/entities/stacking/signer.schema.json
+++ b/docs/entities/stacking/signer.schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "signing_key",
+    "signer_address",
     "weight",
     "stacked_amount",
     "weight_percent",
@@ -12,6 +13,10 @@
   "properties": {
     "signing_key": {
       "type": "string"
+    },
+    "signer_address": {
+      "type": "string",
+      "description": "The Stacks address derived from the signing_key."
     },
     "weight": {
       "type": "integer"

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -3393,6 +3393,10 @@ export interface PoxCycleSignersListResponse {
 }
 export interface PoxSigner {
   signing_key: string;
+  /**
+   * The Stacks address derived from the signing_key.
+   */
+  signer_address: string;
   weight: number;
   stacked_amount: string;
   weight_percent: number;

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -242,7 +242,7 @@ export async function startApiServer(opts: {
           v2.use('/smart-contracts', createV2SmartContractsRouter(datastore));
           v2.use('/mempool', createMempoolRouter(datastore));
           v2.use('/addresses', createV2AddressesRouter(datastore));
-          v2.use('/pox', createPoxRouter(datastore));
+          v2.use('/pox', createPoxRouter(datastore, chainId));
           return v2;
         })()
       );

--- a/src/api/routes/v2/helpers.ts
+++ b/src/api/routes/v2/helpers.ts
@@ -27,6 +27,7 @@ import {
   parseDbTx,
 } from '../../../api/controllers/db-controller';
 import { decodeClarityValueToRepr } from 'stacks-encoding-native-js';
+import { TransactionVersion, getAddressFromPublicKey } from '@stacks/transactions';
 
 export function parseDbNakamotoBlock(block: DbBlock): NakamotoBlock {
   const apiBlock: NakamotoBlock = {
@@ -175,9 +176,14 @@ export function parseDbPoxCycle(cycle: DbPoxCycle): PoxCycle {
   return result;
 }
 
-export function parseDbPoxSigner(signer: DbPoxCycleSigner): PoxSigner {
+export function parseDbPoxSigner(signer: DbPoxCycleSigner, isMainnet: boolean): PoxSigner {
+  const signerAddress = getAddressFromPublicKey(
+    Buffer.from(signer.signing_key.slice(2), 'hex'),
+    isMainnet ? TransactionVersion.Mainnet : TransactionVersion.Testnet
+  );
   const result: PoxSigner = {
     signing_key: signer.signing_key,
+    signer_address: signerAddress,
     weight: signer.weight,
     stacked_amount: signer.stacked_amount,
     weight_percent: signer.weight_percent,

--- a/src/tests/pox-tests.ts
+++ b/src/tests/pox-tests.ts
@@ -106,6 +106,7 @@ describe('PoX tests', () => {
       results: [
         {
           signing_key: '0x038e3c4529395611be9abf6fa3b6987e81d402385e3d605a073f42f407565a4a3d',
+          signer_address: 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP',
           stacked_amount: '686251350000000000',
           stacked_amount_percent: 50,
           weight: 5,
@@ -113,6 +114,7 @@ describe('PoX tests', () => {
         },
         {
           signing_key: '0x029874497a7952483aa23890e9d0898696f33864d3df90939930a1f45421fe3b09',
+          signer_address: 'STF9B75ADQAVXQHNEQ6KGHXTG7JP305J2GRWF3A2',
           stacked_amount: '457500900000000000',
           stacked_amount_percent: 33.333333333333336,
           weight: 3,
@@ -120,6 +122,7 @@ describe('PoX tests', () => {
         },
         {
           signing_key: '0x02dcde79b38787b72d8e5e0af81cffa802f0a3c8452d6b46e08859165f49a72736',
+          signer_address: 'ST18MDW2PDTBSCR1ACXYRJP2JX70FWNM6YY2VX4SS',
           stacked_amount: '228750450000000000',
           stacked_amount_percent: 16.666666666666668,
           weight: 1,
@@ -135,6 +138,7 @@ describe('PoX tests', () => {
     expect(signer.type).toBe('application/json');
     expect(JSON.parse(signer.text)).toStrictEqual({
       signing_key: '0x038e3c4529395611be9abf6fa3b6987e81d402385e3d605a073f42f407565a4a3d',
+      signer_address: 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP',
       stacked_amount: '686251350000000000',
       stacked_amount_percent: 50,
       weight: 5,
@@ -253,6 +257,7 @@ describe('PoX tests', () => {
         results: [
           {
             signing_key: '0x028efa20fa5706567008ebaf48f7ae891342eeb944d96392f719c505c89f84ed8d',
+            signer_address: 'ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0',
             stacked_amount: '7500510000000000',
             stacked_amount_percent: 42.857142857142854,
             weight: 9,
@@ -260,6 +265,7 @@ describe('PoX tests', () => {
           },
           {
             signing_key: '0x023f19d77c842b675bd8c858e9ac8b0ca2efa566f17accf8ef9ceb5a992dc67836',
+            signer_address: 'ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ',
             stacked_amount: '5000340000000000',
             stacked_amount_percent: 28.571428571428573,
             weight: 6,
@@ -268,6 +274,7 @@ describe('PoX tests', () => {
           {
             // steph doubled the weight of this signer
             signing_key: '0x029fb154a570a1645af3dd43c3c668a979b59d21a46dd717fd799b13be3b2a0dc7',
+            signer_address: 'ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP',
             stacked_amount: '5000340000000000',
             stacked_amount_percent: 28.571428571428573,
             weight: 6,
@@ -284,6 +291,7 @@ describe('PoX tests', () => {
       expect(signer.type).toBe('application/json');
       expect(JSON.parse(signer.text)).toStrictEqual({
         signing_key: '0x029fb154a570a1645af3dd43c3c668a979b59d21a46dd717fd799b13be3b2a0dc7',
+        signer_address: 'ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP',
         stacked_amount: '5000340000000000',
         stacked_amount_percent: 28.571428571428573,
         weight: 6,


### PR DESCRIPTION
Adds the p2pkh stacks address of the signer pubkey, which is used for "vote for aggregate key" txs. Helpful for debugging and matching signers to known identities.

cc @hstove 