### PR TITLE
fix: socket-io client must only use websocket transport

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -45,14 +45,12 @@ await sub.unsubscribe();
 ### Socket.io
 
 ```js
-import { io } from "socket.io-client";
-import * as stacks from '@stacks/blockchain-api-client';
+import { StacksApiSocketClient } from '@stacks/blockchain-api-client';
 
-// for testnet, replace with https://api.testnet.hiro.so/
-const socketUrl = "https://api.mainnet.hiro.so/";
+// for testnet, replace with https://api.testnet.hiro.so
+const socketUrl = "https://api.mainnet.hiro.so";
 
-const socket = io(socketUrl);
-const sc = new stacks.StacksApiSocketClient(socket);
+const sc = new StacksApiSocketClient({ url: socketUrl });
 
 sc.subscribeAddressTransactions('ST3GQB6WGCWKDNFNPSQRV8DY93JN06XPZ2ZE9EVMA', (address, tx) => {
   console.log('address:', address);

--- a/client/src/socket-io/index.ts
+++ b/client/src/socket-io/index.ts
@@ -46,6 +46,9 @@ function createStacksApiSocket(opts?: StacksApiSocketConnectionOptions) {
       subscriptions: Array.from(new Set(opts?.subscriptions)).join(','),
     },
   };
+  if (!socketOpts.transports) {
+    socketOpts.transports = ['websocket'];
+  }
   const socket: StacksApiSocket = io(getWsUrl(opts?.url ?? BASE_PATH).href, socketOpts);
   return socket;
 }


### PR DESCRIPTION
Closes #1885

Ensure only `websocket` transport is used in the socket-io client. This fixes connectivity when using a load-balanced API endpoint that doesn't use sticky sessions.