### PR TITLE
fix: a few pox4 properties missing in various endpoints

### DIFF
--- a/src/api/routes/v2/helpers.ts
+++ b/src/api/routes/v2/helpers.ts
@@ -198,5 +198,12 @@ export function parseDbPoxSignerStacker(stacker: DbPoxCycleSignerStacker): PoxSt
     stacked_amount: stacker.locked,
     pox_address: stacker.pox_addr,
   };
+  // Special handling for pool operator stackers
+  if (
+    stacker.name === 'stack-aggregation-commit-indexed' ||
+    stacker.name === 'stack-aggregation-commit'
+  ) {
+    result.stacked_amount = stacker.amount_ustx;
+  }
   return result;
 }

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -1094,6 +1094,8 @@ export interface DbPoxCycleSignerStacker {
   stacker: string;
   locked: string;
   pox_addr: string;
+  name: string;
+  amount_ustx: string;
 }
 
 interface ReOrgEntities {

--- a/src/datastore/pg-store-v2.ts
+++ b/src/datastore/pg-store-v2.ts
@@ -688,7 +688,7 @@ export class PgStoreV2 extends BasePgStoreModule {
         );
       const results = await sql<(DbPoxCycleSignerStacker & { total: number })[]>`
         WITH stackers AS (
-          SELECT DISTINCT ON (stacker) stacker, locked, pox_addr
+          SELECT DISTINCT ON (stacker) stacker, locked, pox_addr, amount_ustx, name
           FROM pox4_events
           WHERE canonical = true
             AND microblock_canonical = true

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -1938,8 +1938,10 @@ export class PgStore extends BasePgStore {
       if (!dbTx.found) {
         return { found: false };
       }
+      const cols =
+        poxTable === 'pox4_events' ? POX4_SYNTHETIC_EVENT_COLUMNS : POX_SYNTHETIC_EVENT_COLUMNS;
       const queryResults = await sql<PoxSyntheticEventQueryResult[]>`
-        SELECT ${sql(POX_SYNTHETIC_EVENT_COLUMNS)}
+        SELECT ${sql(cols)}
         FROM ${sql(poxTable)}
         WHERE canonical = true AND microblock_canonical = true AND tx_id = ${txId}
         ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
@@ -1957,8 +1959,10 @@ export class PgStore extends BasePgStore {
     poxTable: PoxSyntheticEventTable;
   }): Promise<FoundOrNot<DbPoxSyntheticEvent[]>> {
     return await this.sqlTransaction(async sql => {
+      const cols =
+        poxTable === 'pox4_events' ? POX4_SYNTHETIC_EVENT_COLUMNS : POX_SYNTHETIC_EVENT_COLUMNS;
       const queryResults = await sql<PoxSyntheticEventQueryResult[]>`
-        SELECT ${sql(POX_SYNTHETIC_EVENT_COLUMNS)}
+        SELECT ${sql(cols)}
         FROM ${sql(poxTable)}
         WHERE canonical = true AND microblock_canonical = true AND stacker = ${principal}
         ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
@@ -2349,7 +2353,7 @@ export class PgStore extends BasePgStore {
     // Special case for `handle-unlock` which should be returned if it is the last received event.
 
     const pox4EventQuery = await sql<PoxSyntheticEventQueryResult[]>`
-        SELECT ${sql(POX_SYNTHETIC_EVENT_COLUMNS)}
+        SELECT ${sql(POX4_SYNTHETIC_EVENT_COLUMNS)}
         FROM pox4_events
         WHERE canonical = true AND microblock_canonical = true AND stacker = ${stxAddress}
         AND block_height <= ${blockHeight}
@@ -4243,7 +4247,7 @@ export class PgStore extends BasePgStore {
 
     let poxV4Unlocks: StxLockEventResult[] = [];
     const pox4EventQuery = await sql<PoxSyntheticEventQueryResult[]>`
-        SELECT DISTINCT ON (stacker) stacker, ${sql(POX_SYNTHETIC_EVENT_COLUMNS)}
+        SELECT DISTINCT ON (stacker) stacker, ${sql(POX4_SYNTHETIC_EVENT_COLUMNS)}
         FROM pox4_events
         WHERE canonical = true AND microblock_canonical = true
         AND block_height <= ${block.block_height}

--- a/src/tests-2.5/pox-4-delegate-aggregation.ts
+++ b/src/tests-2.5/pox-4-delegate-aggregation.ts
@@ -319,6 +319,26 @@ describe('PoX-4 - Delegate aggregation increase operations', () => {
         name: 'stack-aggregation-commit-indexed',
         pox_addr: delegateeAccount.btcTestnetAddr,
         stacker: delegatorAccount.stxAddr,
+        data: expect.objectContaining({
+          signer_key: `0x${signerPubKey}`,
+          end_cycle_id: expect.stringMatching(/\d+/),
+          start_cycle_id: expect.stringMatching(/\d+/),
+        }),
+      })
+    );
+
+    const stackerRes: any = await fetchGet(`/extended/v1/pox4/stacker/${delegatorAccount.stxAddr}`);
+    expect(stackerRes).toBeDefined();
+    expect(stackerRes.results[0]).toEqual(
+      expect.objectContaining({
+        name: 'stack-aggregation-commit-indexed',
+        pox_addr: delegateeAccount.btcTestnetAddr,
+        stacker: delegatorAccount.stxAddr,
+        data: expect.objectContaining({
+          signer_key: `0x${signerPubKey}`,
+          end_cycle_id: expect.stringMatching(/\d+/),
+          start_cycle_id: expect.stringMatching(/\d+/),
+        }),
       })
     );
   });


### PR DESCRIPTION
Closes #1978

A few pox endpoints are missing some new pox4 data. 

For example `signer_key`, `end_cycle_id`, and `start_cycle_id` missing from `/extended/v1/pox4/stacker/<address>`.

And `stacked_amount` missing for pool addresses in the `/extended/v2/pox/cycles/<id>/signers/<key>/stackers` endpoint.