### PR TITLE
feat: tx list timestamp filter options

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -240,6 +240,20 @@ paths:
             enum: [block_height, burn_block_time, fee]
             example: burn_block_time
             default: block_height
+        - name: start_time
+          in: query
+          description: Filter by transactions after this timestamp (unix timestamp in seconds)
+          required: false
+          schema:
+            type: integer
+            example: 1704067200
+        - name: end_time
+          in: query
+          description: Filter by transactions before this timestamp (unix timestamp in seconds)
+          required: false
+          schema:
+            type: integer
+            example: 1706745599
         - name: order
           in: query
           description: Option to sort results in ascending or descending order

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -102,6 +102,28 @@ export function createTxRouter(db: PgStore): express.Router {
         toAddress = req.query.to_address;
       }
 
+      let startTime: number | undefined;
+      if (typeof req.query.start_time === 'string') {
+        if (!/^\d{10}$/.test(req.query.start_time)) {
+          throw new InvalidRequestError(
+            `Invalid query parameter for "start_time": "${req.query.start_time}" is not a valid timestamp`,
+            InvalidRequestErrorType.invalid_param
+          );
+        }
+        startTime = parseInt(req.query.start_time);
+      }
+
+      let endTime: number | undefined;
+      if (typeof req.query.end_time === 'string') {
+        if (!/^\d{10}$/.test(req.query.end_time)) {
+          throw new InvalidRequestError(
+            `Invalid query parameter for "end_time": "${req.query.end_time}" is not a valid timestamp`,
+            InvalidRequestErrorType.invalid_param
+          );
+        }
+        endTime = parseInt(req.query.end_time);
+      }
+
       let sortBy: 'block_height' | 'burn_block_time' | 'fee' | undefined;
       if (req.query.sort_by) {
         if (
@@ -124,6 +146,8 @@ export function createTxRouter(db: PgStore): express.Router {
         includeUnanchored,
         fromAddress,
         toAddress,
+        startTime,
+        endTime,
         order,
         sortBy,
       });

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -1418,6 +1418,8 @@ export class PgStore extends BasePgStore {
     includeUnanchored,
     fromAddress,
     toAddress,
+    startTime,
+    endTime,
     order,
     sortBy,
   }: {
@@ -1427,6 +1429,8 @@ export class PgStore extends BasePgStore {
     includeUnanchored: boolean;
     fromAddress?: string;
     toAddress?: string;
+    startTime?: number;
+    endTime?: number;
     order?: 'desc' | 'asc';
     sortBy?: 'block_height' | 'burn_block_time' | 'fee';
   }): Promise<{ results: DbTx[]; total: number }> {
@@ -1458,8 +1462,10 @@ export class PgStore extends BasePgStore {
       const toAddressFilterSql = toAddress
         ? sql`AND token_transfer_recipient_address = ${toAddress}`
         : sql``;
-
-      const noFilters = txTypeFilter.length === 0 && !fromAddress && !toAddress;
+      const startTimeFilterSql = startTime ? sql`AND burn_block_time >= ${startTime}` : sql``;
+      const endTimeFilterSql = endTime ? sql`AND burn_block_time <= ${endTime}` : sql``;
+      const noFilters =
+        txTypeFilter.length === 0 && !fromAddress && !toAddress && !startTime && !endTime;
 
       const totalQuery: { count: number }[] = noFilters
         ? await sql<{ count: number }[]>`
@@ -1473,7 +1479,8 @@ export class PgStore extends BasePgStore {
         ${txTypeFilterSql}
         ${fromAddressFilterSql}
         ${toAddressFilterSql}
-    
+        ${startTimeFilterSql}
+        ${endTimeFilterSql}
       `;
 
       const resultQuery: ContractTxQueryResult[] = await sql<ContractTxQueryResult[]>`
@@ -1483,6 +1490,8 @@ export class PgStore extends BasePgStore {
         ${txTypeFilterSql}
         ${fromAddressFilterSql}
         ${toAddressFilterSql}
+        ${startTimeFilterSql}
+        ${endTimeFilterSql}
         ${orderBySql}
         LIMIT ${limit}
         OFFSET ${offset}


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/1996

Add timestamp (by burn_block_time) filter options to `/extended/v1/tx`

Example usage: `/tx?start_time=1704067200&end_time=1706745599` (one or both can be specified)