### PR TITLE
feat: tx list contract id/name filter options

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -254,6 +254,20 @@ paths:
           schema:
             type: integer
             example: 1706745599
+        - name: contract_id
+          in: query
+          description: Filter by contract call transactions involving this contract ID
+          required: false
+          schema:
+            type: string
+            example: "SP000000000000000000002Q6VF78.pox-4"
+        - name: function_name
+          in: query
+          description: Filter by contract call transactions involving this function name
+          required: false
+          schema:
+            type: string
+            example: "delegate-stx"
         - name: order
           in: query
           description: Option to sort results in ascending or descending order

--- a/migrations/1718887498565_tx-contract-call-indexes.js
+++ b/migrations/1718887498565_tx-contract-call-indexes.js
@@ -1,0 +1,9 @@
+/** @param { import("node-pg-migrate").MigrationBuilder } pgm */
+exports.up = pgm => {
+  pgm.createIndex('txs', 'contract_call_function_name');
+};
+
+/** @param { import("node-pg-migrate").MigrationBuilder } pgm */
+exports.down = pgm => {
+  pgm.dropIndex('txs', 'contract_call_function_name');
+};

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -124,6 +124,22 @@ export function createTxRouter(db: PgStore): express.Router {
         endTime = parseInt(req.query.end_time);
       }
 
+      let contractId: string | undefined;
+      if (typeof req.query.contract_id === 'string') {
+        if (!isValidPrincipal(req.query.contract_id)) {
+          throw new InvalidRequestError(
+            `Invalid query parameter for "contract_id": "${req.query.contract_id}" is not a valid principal`,
+            InvalidRequestErrorType.invalid_param
+          );
+        }
+        contractId = req.query.contract_id;
+      }
+
+      let functionName: string | undefined;
+      if (typeof req.query.function_name === 'string') {
+        functionName = req.query.function_name;
+      }
+
       let sortBy: 'block_height' | 'burn_block_time' | 'fee' | undefined;
       if (req.query.sort_by) {
         if (
@@ -148,6 +164,8 @@ export function createTxRouter(db: PgStore): express.Router {
         toAddress,
         startTime,
         endTime,
+        contractId,
+        functionName,
         order,
         sortBy,
       });

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -1420,6 +1420,8 @@ export class PgStore extends BasePgStore {
     toAddress,
     startTime,
     endTime,
+    contractId,
+    functionName,
     order,
     sortBy,
   }: {
@@ -1431,6 +1433,8 @@ export class PgStore extends BasePgStore {
     toAddress?: string;
     startTime?: number;
     endTime?: number;
+    contractId?: string;
+    functionName?: string;
     order?: 'desc' | 'asc';
     sortBy?: 'block_height' | 'burn_block_time' | 'fee';
   }): Promise<{ results: DbTx[]; total: number }> {
@@ -1464,6 +1468,12 @@ export class PgStore extends BasePgStore {
         : sql``;
       const startTimeFilterSql = startTime ? sql`AND burn_block_time >= ${startTime}` : sql``;
       const endTimeFilterSql = endTime ? sql`AND burn_block_time <= ${endTime}` : sql``;
+      const contractIdFilterSql = contractId
+        ? sql`AND contract_call_contract_id = ${contractId}`
+        : sql``;
+      const contractFuncFilterSql = functionName
+        ? sql`AND contract_call_function_name = ${functionName}`
+        : sql``;
       const noFilters =
         txTypeFilter.length === 0 && !fromAddress && !toAddress && !startTime && !endTime;
 
@@ -1481,6 +1491,8 @@ export class PgStore extends BasePgStore {
         ${toAddressFilterSql}
         ${startTimeFilterSql}
         ${endTimeFilterSql}
+        ${contractIdFilterSql}
+        ${contractFuncFilterSql}
       `;
 
       const resultQuery: ContractTxQueryResult[] = await sql<ContractTxQueryResult[]>`
@@ -1492,6 +1504,8 @@ export class PgStore extends BasePgStore {
         ${toAddressFilterSql}
         ${startTimeFilterSql}
         ${endTimeFilterSql}
+        ${contractIdFilterSql}
+        ${contractFuncFilterSql}
         ${orderBySql}
         LIMIT ${limit}
         OFFSET ${offset}

--- a/src/test-utils/test-builders.ts
+++ b/src/test-utils/test-builders.ts
@@ -256,6 +256,20 @@ function testTx(args?: TestTxArgs): DataStoreTxEventData {
     pox3Events: [],
     pox4Events: [],
   };
+  if (
+    data.tx.type_id === DbTxTypeId.SmartContract ||
+    data.tx.type_id === DbTxTypeId.VersionedSmartContract
+  ) {
+    data.smartContracts.push({
+      tx_id: data.tx.tx_id,
+      canonical: data.tx.canonical,
+      contract_id: data.tx.smart_contract_contract_id as string,
+      block_height: data.tx.block_height,
+      clarity_version: data.tx.smart_contract_clarity_version as number,
+      source_code: data.tx.smart_contract_source_code as string,
+      abi: data.tx.abi as string,
+    });
+  }
   return data;
 }
 

--- a/src/tests/smart-contract-tests.ts
+++ b/src/tests/smart-contract-tests.ts
@@ -1740,12 +1740,8 @@ describe('smart contract tests', () => {
         type_id: DbTxTypeId.SmartContract,
         smart_contract_contract_id: 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.contract-1',
         smart_contract_source_code: '(some-contract-src)',
-      })
-      .addTxSmartContract({
-        tx_id: '0x1234',
-        block_height: 1,
-        contract_id: 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.contract-1',
-        contract_source: '(some-contract-src)',
+        smart_contract_clarity_version: 1,
+        abi: JSON.stringify({ some: 'abi' }),
       })
       .build();
     await db.update(block1);
@@ -1759,12 +1755,8 @@ describe('smart contract tests', () => {
         type_id: DbTxTypeId.SmartContract,
         smart_contract_contract_id: 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.contract-2',
         smart_contract_source_code: '(some-contract-src)',
-      })
-      .addTxSmartContract({
-        tx_id: '0x1222',
-        block_height: 2,
-        contract_id: 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.contract-2',
-        contract_source: '(some-contract-src)',
+        smart_contract_clarity_version: 1,
+        abi: JSON.stringify({ some: 'abi' }),
       })
       .build();
     await db.update(block2);


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/1999

Add query params to the tx list endpoint that filter by contract-call `contract_id` and `function_name`.

Example usage: `/tx?contract_id=SP000000000000000000002Q6VF78.pox-4&function_name=delegate-stx`