### PR TITLE
feat: cursor-based pagination on blocks endpoint

### DIFF
--- a/src/api/routes/v2/blocks.ts
+++ b/src/api/routes/v2/blocks.ts
@@ -7,10 +7,11 @@ import { FastifyPluginAsync } from 'fastify';
 import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Server } from 'node:http';
 import { LimitParam, OffsetParam } from '../../schemas/params';
-import { ResourceType } from '../../pagination';
+import { getPagingQueryLimit, ResourceType } from '../../pagination';
 import { PaginatedResponse } from '../../schemas/util';
 import { NakamotoBlock, NakamotoBlockSchema } from '../../schemas/entities/block';
 import { TransactionSchema } from '../../schemas/entities/transactions';
+import { BlockListV2ResponseSchema } from '../../schemas/responses/responses';
 
 export const BlockRoutesV2: FastifyPluginAsync<
   Record<never, never>,
@@ -29,20 +30,25 @@ export const BlockRoutesV2: FastifyPluginAsync<
         querystring: Type.Object({
           limit: LimitParam(ResourceType.Block),
           offset: OffsetParam(),
+          cursor: Type.Optional(Type.String({ description: 'Cursor for pagination' })),
         }),
         response: {
-          200: PaginatedResponse(NakamotoBlockSchema),
+          200: BlockListV2ResponseSchema,
         },
       },
     },
     async (req, reply) => {
       const query = req.query;
-      const { limit, offset, results, total } = await fastify.db.v2.getBlocks(query);
-      const blocks: NakamotoBlock[] = results.map(r => parseDbNakamotoBlock(r));
+      const limit = getPagingQueryLimit(ResourceType.Block, req.query.limit);
+      const blockQuery = await fastify.db.v2.getBlocks({ ...query, limit });
+      const blocks: NakamotoBlock[] = blockQuery.results.map(r => parseDbNakamotoBlock(r));
       await reply.send({
-        limit,
-        offset,
-        total,
+        limit: blockQuery.limit,
+        offset: blockQuery.offset,
+        total: blockQuery.total,
+        next_cursor: blockQuery.next_cursor,
+        prev_cursor: blockQuery.prev_cursor,
+        cursor: blockQuery.current_cursor,
         results: blocks,
       });
     }

--- a/src/api/routes/v2/blocks.ts
+++ b/src/api/routes/v2/blocks.ts
@@ -29,7 +29,13 @@ export const BlockRoutesV2: FastifyPluginAsync<
         tags: ['Blocks'],
         querystring: Type.Object({
           limit: LimitParam(ResourceType.Block),
-          offset: OffsetParam(),
+          offset: Type.Optional(
+            Type.Integer({
+              default: 0,
+              title: 'Offset',
+              description: 'Result offset',
+            })
+          ),
           cursor: Type.Optional(Type.String({ description: 'Cursor for pagination' })),
         }),
         response: {

--- a/src/api/routes/v2/blocks.ts
+++ b/src/api/routes/v2/blocks.ts
@@ -41,6 +41,9 @@ export const BlockRoutesV2: FastifyPluginAsync<
       const query = req.query;
       const limit = getPagingQueryLimit(ResourceType.Block, req.query.limit);
       const blockQuery = await fastify.db.v2.getBlocks({ ...query, limit });
+      if (query.cursor && !blockQuery.current_cursor) {
+        throw new NotFoundError('Cursor not found');
+      }
       const blocks: NakamotoBlock[] = blockQuery.results.map(r => parseDbNakamotoBlock(r));
       await reply.send({
         limit: blockQuery.limit,

--- a/src/api/routes/v2/blocks.ts
+++ b/src/api/routes/v2/blocks.ts
@@ -6,7 +6,7 @@ import { parseDbTx } from '../../../api/controllers/db-controller';
 import { FastifyPluginAsync } from 'fastify';
 import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Server } from 'node:http';
-import { LimitParam, OffsetParam } from '../../schemas/params';
+import { CursorOffsetParam, LimitParam, OffsetParam } from '../../schemas/params';
 import { getPagingQueryLimit, pagingQueryLimits, ResourceType } from '../../pagination';
 import { PaginatedResponse } from '../../schemas/util';
 import { NakamotoBlock, NakamotoBlockSchema } from '../../schemas/entities/block';
@@ -29,15 +29,7 @@ export const BlockRoutesV2: FastifyPluginAsync<
         tags: ['Blocks'],
         querystring: Type.Object({
           limit: LimitParam(ResourceType.Block),
-          offset: Type.Optional(
-            Type.Integer({
-              default: 0,
-              maximum: pagingQueryLimits[ResourceType.Block].maxLimit * 10, // Random access up to 10 pages
-              minimum: -pagingQueryLimits[ResourceType.Block].maxLimit * 10,
-              title: 'Offset',
-              description: 'Result offset',
-            })
-          ),
+          offset: CursorOffsetParam({ resource: ResourceType.Block }),
           cursor: Type.Optional(Type.String({ description: 'Cursor for pagination' })),
         }),
         response: {

--- a/src/api/routes/v2/blocks.ts
+++ b/src/api/routes/v2/blocks.ts
@@ -7,7 +7,7 @@ import { FastifyPluginAsync } from 'fastify';
 import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Server } from 'node:http';
 import { LimitParam, OffsetParam } from '../../schemas/params';
-import { getPagingQueryLimit, ResourceType } from '../../pagination';
+import { getPagingQueryLimit, pagingQueryLimits, ResourceType } from '../../pagination';
 import { PaginatedResponse } from '../../schemas/util';
 import { NakamotoBlock, NakamotoBlockSchema } from '../../schemas/entities/block';
 import { TransactionSchema } from '../../schemas/entities/transactions';
@@ -32,6 +32,8 @@ export const BlockRoutesV2: FastifyPluginAsync<
           offset: Type.Optional(
             Type.Integer({
               default: 0,
+              maximum: pagingQueryLimits[ResourceType.Block].maxLimit * 10, // Random access up to 10 pages
+              minimum: -pagingQueryLimits[ResourceType.Block].maxLimit * 10,
               title: 'Offset',
               description: 'Result offset',
             })

--- a/src/api/schemas/params.ts
+++ b/src/api/schemas/params.ts
@@ -28,6 +28,23 @@ export const LimitParam = (
     })
   );
 
+export const CursorOffsetParam = (args: {
+  resource: ResourceType;
+  title?: string;
+  description?: string;
+  limitOverride?: number;
+  maxPages?: number;
+}) =>
+  Type.Optional(
+    Type.Integer({
+      default: 0,
+      maximum: pagingQueryLimits[args.resource].maxLimit * (args.maxPages ?? 10),
+      minimum: -pagingQueryLimits[args.resource].maxLimit * (args.maxPages ?? 10),
+      title: args.title ?? 'Offset',
+      description: args.description ?? 'Result offset',
+    })
+  );
+
 export const UnanchoredParamSchema = Type.Optional(
   Type.Boolean({
     default: false,

--- a/src/api/schemas/responses/responses.ts
+++ b/src/api/schemas/responses/responses.ts
@@ -1,5 +1,5 @@
 import { Static, Type } from '@sinclair/typebox';
-import { OptionalNullable, PaginatedResponse } from '../util';
+import { Nullable, OptionalNullable, PaginatedResponse } from '../util';
 import { MempoolStatsSchema } from '../entities/mempool-transactions';
 import { MempoolTransactionSchema, TransactionSchema } from '../entities/transactions';
 import { MicroblockSchema } from '../entities/microblock';
@@ -12,6 +12,7 @@ import {
   BurnchainRewardSchema,
   BurnchainRewardSlotHolderSchema,
 } from '../entities/burnchain-rewards';
+import { NakamotoBlockSchema } from '../entities/block';
 
 export const ErrorResponseSchema = Type.Object(
   {
@@ -178,3 +179,14 @@ export const RunFaucetResponseSchema = Type.Object(
   }
 );
 export type RunFaucetResponse = Static<typeof RunFaucetResponseSchema>;
+
+export const BlockListV2ResponseSchema = Type.Object({
+  limit: Type.Integer({ examples: [20] }),
+  offset: Type.Integer({ examples: [0] }),
+  total: Type.Integer({ examples: [1] }),
+  next_cursor: Nullable(Type.String({ description: 'Next page cursor' })),
+  prev_cursor: Nullable(Type.String({ description: 'Previous page cursor' })),
+  cursor: Nullable(Type.String({ description: 'Current page cursor' })),
+  results: Type.Array(NakamotoBlockSchema),
+});
+export type BlockListV2Response = Static<typeof BlockListV2ResponseSchema>;

--- a/src/api/schemas/responses/responses.ts
+++ b/src/api/schemas/responses/responses.ts
@@ -1,5 +1,5 @@
 import { Static, Type } from '@sinclair/typebox';
-import { Nullable, OptionalNullable, PaginatedResponse } from '../util';
+import { Nullable, OptionalNullable, PaginatedCursorResponse, PaginatedResponse } from '../util';
 import { MempoolStatsSchema } from '../entities/mempool-transactions';
 import { MempoolTransactionSchema, TransactionSchema } from '../entities/transactions';
 import { MicroblockSchema } from '../entities/microblock';
@@ -180,13 +180,5 @@ export const RunFaucetResponseSchema = Type.Object(
 );
 export type RunFaucetResponse = Static<typeof RunFaucetResponseSchema>;
 
-export const BlockListV2ResponseSchema = Type.Object({
-  limit: Type.Integer({ examples: [20] }),
-  offset: Type.Integer({ examples: [0] }),
-  total: Type.Integer({ examples: [1] }),
-  next_cursor: Nullable(Type.String({ description: 'Next page cursor' })),
-  prev_cursor: Nullable(Type.String({ description: 'Previous page cursor' })),
-  cursor: Nullable(Type.String({ description: 'Current page cursor' })),
-  results: Type.Array(NakamotoBlockSchema),
-});
+export const BlockListV2ResponseSchema = PaginatedCursorResponse(NakamotoBlockSchema);
 export type BlockListV2Response = Static<typeof BlockListV2ResponseSchema>;

--- a/src/api/schemas/util.ts
+++ b/src/api/schemas/util.ts
@@ -12,3 +12,17 @@ export const PaginatedResponse = <T extends TSchema>(type: T, options?: ObjectOp
     },
     options
   );
+
+export const PaginatedCursorResponse = <T extends TSchema>(type: T, options?: ObjectOptions) =>
+  Type.Object(
+    {
+      limit: Type.Integer({ examples: [20] }),
+      offset: Type.Integer({ examples: [0] }),
+      total: Type.Integer({ examples: [1] }),
+      next_cursor: Nullable(Type.String({ description: 'Next page cursor' })),
+      prev_cursor: Nullable(Type.String({ description: 'Previous page cursor' })),
+      cursor: Nullable(Type.String({ description: 'Current page cursor' })),
+      results: Type.Array(type),
+    },
+    options
+  );

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -1143,6 +1143,16 @@ export type DbPaginatedResult<T> = {
   results: T[];
 };
 
+export type DbCursorPaginatedResult<T> = {
+  limit: number;
+  offset: number;
+  next_cursor: string | null;
+  prev_cursor: string | null;
+  current_cursor: string | null;
+  total: number;
+  results: T[];
+};
+
 export interface BlocksWithMetadata {
   results: {
     block: DbBlock;

--- a/src/datastore/pg-store-v2.ts
+++ b/src/datastore/pg-store-v2.ts
@@ -82,7 +82,7 @@ export class PgStoreV2 extends BasePgStoreModule {
         )
         SELECT offset_block_height as block_height
         FROM ordered_blocks 
-        WHERE block_hash = ${cursor ? cursor : sql`(SELECT block_hash FROM chain_tip LIMIT 1)`}
+        WHERE index_block_hash = ${cursor ?? sql`(SELECT index_block_hash FROM chain_tip LIMIT 1)`}
         LIMIT 1
       ),
       selected_blocks AS (
@@ -94,7 +94,7 @@ export class PgStoreV2 extends BasePgStoreModule {
         LIMIT ${limit}
       ),
       prev_page AS (
-        SELECT block_hash as prev_block_hash
+        SELECT index_block_hash as prev_block_hash
         FROM blocks
         WHERE canonical = true
         AND block_height < (
@@ -108,7 +108,7 @@ export class PgStoreV2 extends BasePgStoreModule {
         LIMIT 1
       ),
       next_page AS (
-        SELECT block_hash as next_block_hash
+        SELECT index_block_hash as next_block_hash
         FROM blocks
         WHERE canonical = true
         AND block_height > (
@@ -139,7 +139,7 @@ export class PgStoreV2 extends BasePgStoreModule {
       // Determine cursors
       const nextCursor = blocksQuery[0]?.next_block_hash ?? null;
       const prevCursor = blocksQuery[0]?.prev_block_hash ?? null;
-      const currentCursor = blocksQuery[0]?.block_hash ?? null;
+      const currentCursor = blocksQuery[0]?.index_block_hash ?? null;
 
       const result: DbCursorPaginatedResult<DbBlock> = {
         limit,

--- a/src/tests/block-tests.ts
+++ b/src/tests/block-tests.ts
@@ -846,6 +846,26 @@ describe('block tests', () => {
         results: [expect.objectContaining({ height: 2 }), expect.objectContaining({ height: 1 })],
       })
     );
+
+    // Offset + cursor works
+    ({ body } = await supertest(api.server).get(
+      `/extended/v2/blocks?limit=3&cursor=0x0000000000000000000000000000000000000000000000000000000000000011&offset=2`
+    ));
+    expect(body).toEqual(
+      expect.objectContaining({
+        limit: 3,
+        offset: 0,
+        total: 14,
+        cursor: '0x0000000000000000000000000000000000000000000000000000000000000009',
+        next_cursor: '0x0000000000000000000000000000000000000000000000000000000000000012',
+        prev_cursor: '0x0000000000000000000000000000000000000000000000000000000000000006',
+        results: [
+          expect.objectContaining({ height: 9 }),
+          expect.objectContaining({ height: 8 }),
+          expect.objectContaining({ height: 7 }),
+        ],
+      })
+    );
   });
 
   test('blocks v2 retrieved by hash or height', async () => {

--- a/src/tests/block-tests.ts
+++ b/src/tests/block-tests.ts
@@ -759,9 +759,9 @@ describe('block tests', () => {
     for (let i = 1; i <= 14; i++) {
       const block = new TestBlockBuilder({
         block_height: i,
-        block_hash: `0x${i.toString().padStart(64, '0')}`,
-        index_block_hash: `0x11${i.toString().padStart(62, '0')}`,
-        parent_index_block_hash: `0x11${(i - 1).toString().padStart(62, '0')}`,
+        block_hash: `0x11${i.toString().padStart(62, '0')}`,
+        index_block_hash: `0x${i.toString().padStart(64, '0')}`,
+        parent_index_block_hash: `0x${(i - 1).toString().padStart(64, '0')}`,
         parent_block_hash: `0x${(i - 1).toString().padStart(64, '0')}`,
         burn_block_height: 700000,
         burn_block_hash: '0x00000000000000000001e2ee7f0c6bd5361b5e7afd76156ca7d6f524ee5ca3d8',

--- a/src/tests/block-tests.ts
+++ b/src/tests/block-tests.ts
@@ -854,7 +854,7 @@ describe('block tests', () => {
     expect(body).toEqual(
       expect.objectContaining({
         limit: 3,
-        offset: 0,
+        offset: 2,
         total: 14,
         cursor: '0x0000000000000000000000000000000000000000000000000000000000000009',
         next_cursor: '0x0000000000000000000000000000000000000000000000000000000000000012',
@@ -867,14 +867,14 @@ describe('block tests', () => {
       })
     );
 
-    // Test with negative offset
+    // Negative offset + cursor
     ({ body } = await supertest(api.server).get(
       `/extended/v2/blocks?limit=3&cursor=0x0000000000000000000000000000000000000000000000000000000000000008&offset=-2`
     ));
     expect(body).toEqual(
       expect.objectContaining({
         limit: 3,
-        offset: 0,
+        offset: -2,
         total: 14,
         cursor: '0x0000000000000000000000000000000000000000000000000000000000000010',
         next_cursor: '0x0000000000000000000000000000000000000000000000000000000000000013',
@@ -883,6 +883,24 @@ describe('block tests', () => {
           expect.objectContaining({ height: 10 }),
           expect.objectContaining({ height: 9 }),
           expect.objectContaining({ height: 8 }),
+        ],
+      })
+    );
+
+    // Offset (no cursor) works, has original behavior
+    ({ body } = await supertest(api.server).get(`/extended/v2/blocks?limit=3&offset=5`));
+    expect(body).toEqual(
+      expect.objectContaining({
+        limit: 3,
+        offset: 5,
+        total: 14,
+        cursor: '0x0000000000000000000000000000000000000000000000000000000000000009',
+        next_cursor: '0x0000000000000000000000000000000000000000000000000000000000000012',
+        prev_cursor: '0x0000000000000000000000000000000000000000000000000000000000000006',
+        results: [
+          expect.objectContaining({ height: 9 }),
+          expect.objectContaining({ height: 8 }),
+          expect.objectContaining({ height: 7 }),
         ],
       })
     );

--- a/src/tests/block-tests.ts
+++ b/src/tests/block-tests.ts
@@ -771,10 +771,10 @@ describe('block tests', () => {
       await db.update(block);
     }
 
+    let body: BlockListV2Response;
+
     // Fetch latest page
-    let { body }: { body: BlockListV2Response } = await supertest(api.server).get(
-      `/extended/v2/blocks?limit=3`
-    );
+    ({ body } = await supertest(api.server).get(`/extended/v2/blocks?limit=3`));
     expect(body).toEqual(
       expect.objectContaining({
         limit: 3,
@@ -863,6 +863,26 @@ describe('block tests', () => {
           expect.objectContaining({ height: 9 }),
           expect.objectContaining({ height: 8 }),
           expect.objectContaining({ height: 7 }),
+        ],
+      })
+    );
+
+    // Test with negative offset
+    ({ body } = await supertest(api.server).get(
+      `/extended/v2/blocks?limit=3&cursor=0x0000000000000000000000000000000000000000000000000000000000000008&offset=-2`
+    ));
+    expect(body).toEqual(
+      expect.objectContaining({
+        limit: 3,
+        offset: 0,
+        total: 14,
+        cursor: '0x0000000000000000000000000000000000000000000000000000000000000010',
+        next_cursor: '0x0000000000000000000000000000000000000000000000000000000000000013',
+        prev_cursor: '0x0000000000000000000000000000000000000000000000000000000000000007',
+        results: [
+          expect.objectContaining({ height: 10 }),
+          expect.objectContaining({ height: 9 }),
+          expect.objectContaining({ height: 8 }),
         ],
       })
     );


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/2043

Supports a new `cursor` query param. The `offset` param continues to work but with a max page limit. Page random-access is possible when using both together.

This approach is generalizable and should work with other listing endpoints like transactions in future PRs.

Example usage:

`GET /extended/v2/blocks?limit=3`
```js
{
  limit: 3,
  offset: 0,
  total: 14,
  cursor: '0x0000000000000000000000000000000000000000000000000000000000000014',
  next_cursor: null,
  prev_cursor: '0x0000000000000000000000000000000000000000000000000000000000000011',
  results: [
   { height: 14, ... },
   { height: 13, ... },
   { height: 12, ... }
  ],
}
```

`GET /extended/v2/blocks?limit=3&cursor=0x0000000000000000000000000000000000000000000000000000000000000011`
```js
{
  limit: 3,
  offset: 0,
  total: 14,
  cursor: '0x0000000000000000000000000000000000000000000000000000000000000011',
  next_cursor: '0x0000000000000000000000000000000000000000000000000000000000000014',
  prev_cursor: '0x0000000000000000000000000000000000000000000000000000000000000008',
  results: [
   { height: 11, ... },
   { height: 10, ... },
   { height: 9, ... }
  ],
}
```

`GET /extended/v2/blocks?limit=3&cursor=0x0000000000000000000000000000000000000000000000000000000000000011&offset=2`
```js
{
  limit: 3,
  offset: 0,
  total: 14,
  cursor: '0x0000000000000000000000000000000000000000000000000000000000000009',
  next_cursor: '0x0000000000000000000000000000000000000000000000000000000000000012',
  prev_cursor: '0x0000000000000000000000000000000000000000000000000000000000000006',
  results: [
   { height: 9, ... },
   { height: 8, ... },
   { height: 7, ... }
  ],
}
```

`GET /extended/v2/blocks?limit=3&cursor=0x0000000000000000000000000000000000000000000000000000000000000008&offset=-2`
```js
{
  limit: 3,
  offset: 0,
  total: 14,
  cursor: '0x0000000000000000000000000000000000000000000000000000000000000010',
  next_cursor: '0x0000000000000000000000000000000000000000000000000000000000000013',
  prev_cursor: '0x0000000000000000000000000000000000000000000000000000000000000007',
  results: [
   { height: 10, ... },
   { height: 9, ... },
   { height: 8, ... }
  ],
}
```