### PR TITLE
Clarify missing nonce use

### DIFF
--- a/content/feature-guides/nonce-handling.md
+++ b/content/feature-guides/nonce-handling.md
@@ -22,8 +22,8 @@ curl 'https://api.testnet.hiro.so/extended/v1/address/<principal>/nonces'
 }
 ```
 
-The `possible_next_nonce` property is the predicted nonce required for subsequent transactions, which is derived from inspecting the latest transaction nonces from both anchor blocks, microblocks, and mempool.
+The `possible_next_nonce` property is the nonce suggested for a given principal's next transaction. It is derived as the next integer to the largest nonce found in blocks and mempool. It does not take into account missing nonces.
 
-The `detected_missing_nonces` property finds any non-contiguous nonces after inspecting transactions from anchor blocks, microblocks, and the mempool. For example, if the latest anchor/microblock transaction nonce for an account is 5, but the next nonce in the mempool is 7, then it indicates that something likely went wrong with transaction with nonce 6 (either it was not created or broadcasted correctly by a client, or it was dropped for whatever reason). This is a strong indication that the mempool transaction with nonce 7 will never be mined since the previous nonce is missing.
+The `detected_missing_nonces` property finds any non-contiguous nonces after inspecting transactions from blocks and the mempool. For example, for a given principal, if the latest transaction included in a block has a nonce of 5, and the's only one transaction in the mempool with nonce 7, then it indicates that something likely went wrong with transaction with nonce 6 (either it was not created or broadcasted correctly by a client, or it was dropped for whatever reason). This is a strong indication that the mempool transaction with nonce 7 will never be mined since the previous nonce is missing.
 
-Clients that continue to broadcast transactions with the `possible_next_nonce` property of 8, then 9, then 10, will likely result in all of their pending/mempool transactions never going through.
+Clients that continue to broadcast transactions with the `possible_next_nonce` property of 8, then 9, then 10, will likely result in all of their pending/mempool transactions never going through. For all transactions go through, clients should first use any missing nonces before using the suggested `possible_next_nonce`.


### PR DESCRIPTION
## Description

The way `possible_next_nonce` is calculated wasn't explicitly defined, previously using the term "derived", making it harder to understand whether missing nonces should be inspected when creating new transaction or trying to get existing transactions unstuck.

The changes include more explicit language, as well as minor changes more aligned with how Nakamoto works (no more mention of microblcks).

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No, just docs were updated

## Are documentation updates required?
It would be nice if the API docs were updated too, since the reason I came here (and asked on [Discord](https://discord.com/channels/621759717756370964/1050158923170197604/1278327229176086651)) was because the API docs didn't seem to be clear enough

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @rafaelcr or @zone117x for review
