### PR TITLE
fix: query param `until_block` not working in several endpoints

### DIFF
--- a/src/api/query-helpers.ts
+++ b/src/api/query-helpers.ts
@@ -41,10 +41,10 @@ export function parseUntilBlockQuery(
 ): undefined | number | string {
   if (!untilBlock) return;
   if (typeof untilBlock === 'string') {
-    if (unanchored !== undefined) {
+    if (unanchored) {
       // if mutually exclusive unachored is also specified, throw bad request error
       throw new InvalidRequestError(
-        `can't handle both 'unanchored' and 'until_block' in the same request`,
+        `can't handle both 'unanchored=true' and 'until_block' in the same request`,
         InvalidRequestErrorType.bad_request
       );
     }

--- a/src/tests/address-tests.ts
+++ b/src/tests/address-tests.ts
@@ -2614,16 +2614,6 @@ describe('address tests', () => {
       );
       expect(response.status).toBe(400);
     }
-
-    const addressEndpoints1 = ['/transactions', '/transactions_with_transfers', '/stx_inbound'];
-
-    /// check for mutually exclusive until_block adn height params
-    for (const path of addressEndpoints1) {
-      const response1 = await supertest(api.server).get(
-        `/extended/v1/address/STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6${path}?until_block=5&height=0`
-      );
-      expect(response1.status).toBe(400);
-    }
   });
 
   test('/transactions materialized view separates anchored and unanchored counts correctly', async () => {

--- a/src/tests/address-tests.ts
+++ b/src/tests/address-tests.ts
@@ -1570,6 +1570,12 @@ describe('address tests', () => {
     };
     expect(JSON.parse(fetchAddrBalance1.text)).toEqual(expectedResp1);
 
+    const fetchAddrBalance1AtBlock = await supertest(api.server).get(
+      `/extended/v1/address/${testAddr2}/balances?until_block=1`
+    );
+    expect(fetchAddrBalance1AtBlock.status).toBe(200);
+    expect(fetchAddrBalance1AtBlock.type).toBe('application/json');
+
     const fetchAddrBalance2 = await supertest(api.server).get(
       `/extended/v1/address/${testContractAddr}/balances`
     );


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/2099

The mutually-exclusive query param check for `unanchored` and `until_block` check had a regression from the Fastify refactor when `unanchored` was changed to default to `false`. This hotfix checks if the value is set to `true` rather than `!== undefined`.
