### PR TITLE
feat: add block etag

### DIFF
--- a/src/api/routes/v2/blocks.ts
+++ b/src/api/routes/v2/blocks.ts
@@ -1,4 +1,4 @@
-import { handleChainTipCache } from '../../../api/controllers/cache-controller';
+import { handleBlockCache, handleChainTipCache } from '../../../api/controllers/cache-controller';
 import { BlockParamsSchema, cleanBlockHeightOrHashParam, parseBlockParam } from './schemas';
 import { parseDbNakamotoBlock } from './helpers';
 import { InvalidRequestError, NotFoundError } from '../../../errors';
@@ -100,7 +100,7 @@ export const BlockRoutesV2: FastifyPluginAsync<
   fastify.get(
     '/:height_or_hash',
     {
-      preHandler: handleChainTipCache,
+      preHandler: handleBlockCache,
       preValidation: (req, _reply, done) => {
         cleanBlockHeightOrHashParam(req.params);
         done();
@@ -129,7 +129,7 @@ export const BlockRoutesV2: FastifyPluginAsync<
   fastify.get(
     '/:height_or_hash/transactions',
     {
-      preHandler: handleChainTipCache,
+      preHandler: handleBlockCache,
       preValidation: (req, _reply, done) => {
         cleanBlockHeightOrHashParam(req.params);
         done();

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -97,6 +97,7 @@ import {
 import * as path from 'path';
 import { PgStoreV2 } from './pg-store-v2';
 import { Fragment } from 'postgres';
+import { parseBlockParam } from '../api/routes/v2/schemas';
 
 export const MIGRATIONS_DIR = path.join(REPO_DIR, 'migrations');
 
@@ -4458,5 +4459,26 @@ export class PgStore extends BasePgStore {
       SELECT DISTINCT tx_id FROM activity WHERE tx_id IS NOT NULL
     `;
     return result.map(r => r.tx_id);
+  }
+
+  /** Returns the `index_block_hash` and canonical status of a single block */
+  async getBlockCanonicalStatus(
+    height_or_hash: string | number
+  ): Promise<{ index_block_hash: string; canonical: boolean } | undefined> {
+    const param = parseBlockParam(height_or_hash);
+    const result = await this.sql<{ index_block_hash: string; canonical: boolean }[]>`
+      SELECT index_block_hash, canonical
+      FROM blocks
+      WHERE
+        ${
+          param.type == 'latest'
+            ? this.sql`index_block_hash = (SELECT index_block_hash FROM chain_tip)`
+            : param.type == 'hash'
+            ? this.sql`index_block_hash = ${param.hash}`
+            : this.sql`block_height = ${param.height} AND canonical = true`
+        }
+      LIMIT 1
+    `;
+    if (result.count) return result[0];
   }
 }


### PR DESCRIPTION
Adds a cache handler for endpoints that show data for individual blocks:
```ts
`${index_block_hash}:${canonical}`
```

Fixes #1230 