### PR TITLE
Fix/allow stackerdb chunks

### DIFF
--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -1064,6 +1064,17 @@ export async function startEventServer(opts: {
     }
   });
 
+  app.post('/proposal_response', async (req, res) => {
+    try {
+      await handleRawEventRequest(req);
+      logger.info('Received proposal_response message (stored in db but otherwise not processed)');
+      await res.status(200).send({ result: 'ok' });
+    } catch (error) {
+      logger.error(error, 'error processing core-node /proposal_response');
+      await res.status(500).send({ error: error });
+    }
+  });
+
   app.post('*', async (req, res) => {
     await res.status(404).send({ error: `no route handler for ${req.url}` });
     logger.error(`Unexpected event on path ${req.url}`);

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -1056,7 +1056,11 @@ export async function startEventServer(opts: {
   app.post('/stackerdb_chunks', async (req, res) => {
     try {
       await handleRawEventRequest(req);
-      logger.info('Received stackerdb_chunks message (stored in db but otherwise not processed)');
+      if (isProdEnv) {
+        logger.warn(
+          'Received stackerdb_chunks message -- event not required for API operations and can cause db bloat and performance degradation in production'
+        );
+      }
       await res.status(200).send({ result: 'ok' });
     } catch (error) {
       logger.error(error, 'error processing core-node /stackerdb_chunks');
@@ -1067,7 +1071,11 @@ export async function startEventServer(opts: {
   app.post('/proposal_response', async (req, res) => {
     try {
       await handleRawEventRequest(req);
-      logger.info('Received proposal_response message (stored in db but otherwise not processed)');
+      if (isProdEnv) {
+        logger.warn(
+          'Received proposal_response message -- event not required for API operations and can cause db bloat and performance degradation in production'
+        );
+      }
       await res.status(200).send({ result: 'ok' });
     } catch (error) {
       logger.error(error, 'error processing core-node /proposal_response');

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -1053,6 +1053,17 @@ export async function startEventServer(opts: {
     }
   });
 
+  app.post('/stackerdb_chunks', async (req, res) => {
+    try {
+      await handleRawEventRequest(req);
+      logger.info('Received stackerdb_chunks message (stored in db but otherwise not processed)');
+      await res.status(200).send({ result: 'ok' });
+    } catch (error) {
+      logger.error(error, 'error processing core-node /stackerdb_chunks');
+      await res.status(500).send({ error: error });
+    }
+  });
+
   app.post('*', async (req, res) => {
     await res.status(404).send({ error: `no route handler for ${req.url}` });
     logger.error(`Unexpected event on path ${req.url}`);


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/2031

Allow the API to store `stackerdb` and `block_proposal` raw event bodies in postgres. No other processing is done -- this is only intended for debugging and to prevent the API from stalling stacks-core when these events are configured. Example stacks-node config toml:

```toml
[[events_observer]]
endpoint = "stacks-api:3700"
retry_count = 255
include_data_events = false
events_keys = ["*", "stackerdb", "block_proposal"]
```