### PR TITLE
fix: /extended/v2/pox/cycles/{n}/signers/{key}/stackers returning 500

### DIFF
--- a/src/datastore/pg-store-v2.ts
+++ b/src/datastore/pg-store-v2.ts
@@ -908,7 +908,7 @@ export class PgStoreV2 extends BasePgStoreModule {
             cs.stacker_type,
             COUNT(*) OVER()::int AS total
         FROM pox_sets ps
-        LEFT JOIN combined_stackers cs ON ps.signing_key = cs.signer_key
+        INNER JOIN combined_stackers cs ON ps.signing_key = cs.signer_key
         WHERE ps.canonical = TRUE 
           AND ps.cycle_number = ${cycleNumber} 
           AND ps.signing_key = ${signerKey}


### PR DESCRIPTION
Fixes https://github.com/hirosystems/stacks-blockchain-api/issues/2114

The final `LEFT JOIN` in this query resulted in a single empty row being returned even for results where no stackers were found (in the `combined_stackers` CTE).