### PR TITLE
fix: update mempool garbage collection logic for 3.0

### DIFF
--- a/.env
+++ b/.env
@@ -60,11 +60,6 @@ PG_APPLICATION_NAME=stacks-blockchain-api
 # (with both Event Server and API endpoints).
 # STACKS_API_MODE=
 
-# Stacks nodes automatically perform garbage-collection by dropping transactions from the mempool if they
-# are pending for more than 256 blocks. This variable controls the block age threshold at which the API will do
-# the same.
-# STACKS_MEMPOOL_TX_GARBAGE_COLLECTION_THRESHOLD=256
-
 # To avoid running unnecessary mempool stats during transaction influx, we use a debounce mechanism for the process.
 # This variable controls the duration it waits until there are no further mempool updates
 # MEMPOOL_STATS_DEBOUNCE_INTERVAL=1000

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -236,9 +236,7 @@
         "--runInBand",
         "--no-cache",
         "--config",
-        "${workspaceRoot}/tests/jest.config.api.js",
-        "-t",
-        "socket-io"
+        "${workspaceRoot}/tests/jest.config.api.js"
       ],
       "outputCapture": "std",
       "console": "integratedTerminal",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -236,7 +236,9 @@
         "--runInBand",
         "--no-cache",
         "--config",
-        "${workspaceRoot}/tests/jest.config.api.js"
+        "${workspaceRoot}/tests/jest.config.api.js",
+        "-t",
+        "socket-io"
       ],
       "outputCapture": "std",
       "console": "integratedTerminal",

--- a/tests/utils/test-builders.ts
+++ b/tests/utils/test-builders.ts
@@ -98,6 +98,7 @@ export interface TestBlockArgs {
   parent_microblock_hash?: string;
   parent_microblock_sequence?: number;
   canonical?: boolean;
+  signer_bitvec?: string;
 }
 
 /**
@@ -126,7 +127,7 @@ function testBlock(args?: TestBlockArgs): DbBlock {
     execution_cost_write_count: 0,
     execution_cost_write_length: 0,
     tx_count: 1,
-    signer_bitvec: null,
+    signer_bitvec: args?.signer_bitvec ?? null,
   };
 }
 


### PR DESCRIPTION
Changes the logic for mempool transaction garbage collection depending on which Stacks epoch is active so it adapts to the corresponding implementation on stacks-core:
* If epoch is 2.5 or lower, prune after 256 blocks
* If epoch is 3.0 or higher, prune after 2560 minutes