### PR TITLE
feat: ingest `signer_signature` from `/new_block` event and expose in new endpoint

### DIFF
--- a/migrations/1729262745699_stacks_block_signer-signatures.js
+++ b/migrations/1729262745699_stacks_block_signer-signatures.js
@@ -1,0 +1,14 @@
+/* eslint-disable camelcase */
+
+/** @param { import("node-pg-migrate").MigrationBuilder } pgm */
+exports.up = pgm => {
+
+  pgm.addColumn('blocks', {
+    signer_signature: {
+      type: 'bytea[]',
+    }
+  });
+
+  pgm.createIndex('blocks', 'signer_signature', { method: 'gin' });
+
+};

--- a/src/api/pagination.ts
+++ b/src/api/pagination.ts
@@ -39,6 +39,7 @@ export enum ResourceType {
   Signer,
   PoxCycle,
   TokenHolders,
+  BlockSignerSignature,
 }
 
 export const pagingQueryLimits: Record<ResourceType, { defaultLimit: number; maxLimit: number }> = {
@@ -93,6 +94,10 @@ export const pagingQueryLimits: Record<ResourceType, { defaultLimit: number; max
   [ResourceType.TokenHolders]: {
     defaultLimit: 100,
     maxLimit: 200,
+  },
+  [ResourceType.BlockSignerSignature]: {
+    defaultLimit: 500,
+    maxLimit: 1000,
   },
 };
 

--- a/src/api/routes/v2/blocks.ts
+++ b/src/api/routes/v2/blocks.ts
@@ -9,9 +9,16 @@ import { Server } from 'node:http';
 import { CursorOffsetParam, LimitParam, OffsetParam } from '../../schemas/params';
 import { getPagingQueryLimit, pagingQueryLimits, ResourceType } from '../../pagination';
 import { PaginatedResponse } from '../../schemas/util';
-import { NakamotoBlock, NakamotoBlockSchema } from '../../schemas/entities/block';
+import {
+  NakamotoBlock,
+  NakamotoBlockSchema,
+  SignerSignatureSchema,
+} from '../../schemas/entities/block';
 import { TransactionSchema } from '../../schemas/entities/transactions';
-import { BlockListV2ResponseSchema } from '../../schemas/responses/responses';
+import {
+  BlockListV2ResponseSchema,
+  BlockSignerSignatureResponseSchema,
+} from '../../schemas/responses/responses';
 
 export const BlockRoutesV2: FastifyPluginAsync<
   Record<never, never>,
@@ -163,6 +170,54 @@ export const BlockRoutesV2: FastifyPluginAsync<
           offset,
           total,
           results: results.map(r => parseDbTx(r)),
+        };
+        await reply.send(response);
+      } catch (error) {
+        if (error instanceof InvalidRequestError) {
+          throw new NotFoundError('Block not found');
+        }
+        throw error;
+      }
+    }
+  );
+
+  fastify.get(
+    '/:height_or_hash/signer-signature',
+    {
+      preHandler: handleBlockCache,
+      preValidation: (req, _reply, done) => {
+        cleanBlockHeightOrHashParam(req.params);
+        done();
+      },
+      schema: {
+        operationId: 'get_signer_signature_for_block',
+        summary: 'Get signer signature for block',
+        description: `Retrieves the "signer signature" (typically an array of signature byte strings) in a single block`,
+        tags: ['Blocks'],
+        params: BlockParamsSchema,
+        querystring: Type.Object({
+          limit: LimitParam(ResourceType.BlockSignerSignature),
+          offset: OffsetParam(),
+        }),
+        response: {
+          200: BlockSignerSignatureResponseSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const params = parseBlockParam(req.params.height_or_hash);
+      const query = req.query;
+
+      try {
+        const { limit, offset, results, total } = await fastify.db.v2.getBlockSignerSignature({
+          blockId: params,
+          ...query,
+        });
+        const response = {
+          limit,
+          offset,
+          total,
+          results: results,
         };
         await reply.send(response);
       } catch (error) {

--- a/src/api/routes/v2/schemas.ts
+++ b/src/api/routes/v2/schemas.ts
@@ -47,6 +47,14 @@ export const TransactionLimitParamSchema = Type.Integer({
   description: 'Transactions per page',
 });
 
+export const BlockSignerSignatureLimitParamSchema = Type.Integer({
+  minimum: 1,
+  maximum: pagingQueryLimits[ResourceType.BlockSignerSignature].maxLimit,
+  default: pagingQueryLimits[ResourceType.BlockSignerSignature].defaultLimit,
+  title: 'Block signer signature limit',
+  description: 'Block signer signatures per page',
+});
+
 export const PoxCycleLimitParamSchema = Type.Integer({
   minimum: 1,
   maximum: pagingQueryLimits[ResourceType.PoxCycle].maxLimit,

--- a/src/api/schemas/entities/block.ts
+++ b/src/api/schemas/entities/block.ts
@@ -116,3 +116,8 @@ export const NakamotoBlockSchema = Type.Object({
   execution_cost_write_length: Type.Integer({ description: 'Execution cost write length.' }),
 });
 export type NakamotoBlock = Static<typeof NakamotoBlockSchema>;
+
+export const SignerSignatureSchema = Type.String({
+  description: "Array of hex strings representing the block's signer signature",
+});
+export type SignerSignature = Static<typeof SignerSignatureSchema>;

--- a/src/api/schemas/responses/responses.ts
+++ b/src/api/schemas/responses/responses.ts
@@ -12,7 +12,7 @@ import {
   BurnchainRewardSchema,
   BurnchainRewardSlotHolderSchema,
 } from '../entities/burnchain-rewards';
-import { NakamotoBlockSchema } from '../entities/block';
+import { NakamotoBlockSchema, SignerSignatureSchema } from '../entities/block';
 
 export const ErrorResponseSchema = Type.Object(
   {
@@ -182,3 +182,6 @@ export type RunFaucetResponse = Static<typeof RunFaucetResponseSchema>;
 
 export const BlockListV2ResponseSchema = PaginatedCursorResponse(NakamotoBlockSchema);
 export type BlockListV2Response = Static<typeof BlockListV2ResponseSchema>;
+
+export const BlockSignerSignatureResponseSchema = PaginatedResponse(SignerSignatureSchema);
+export type BlockSignerSignatureResponse = Static<typeof BlockSignerSignatureResponseSchema>;

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -25,6 +25,7 @@ export interface DbBlock {
   tx_count: number;
   block_time: number;
   signer_bitvec: string | null;
+  signer_signature: string[] | null;
 }
 
 /** An interface representing the microblock data that can be constructed _only_ from the /new_microblocks payload */
@@ -862,6 +863,7 @@ export interface BlockQueryResult {
   execution_cost_write_length: string;
   tx_count: number;
   signer_bitvec: string | null;
+  signer_signature: string[] | null;
 }
 
 export interface MicroblockQueryResult {
@@ -1286,6 +1288,7 @@ export interface BlockInsertValues {
   execution_cost_write_length: number;
   tx_count: number;
   signer_bitvec: string | null;
+  signer_signature: PgBytea[] | null;
 }
 
 export interface MicroblockInsertValues {

--- a/src/datastore/helpers.ts
+++ b/src/datastore/helpers.ts
@@ -487,6 +487,7 @@ export function parseBlockQueryResult(row: BlockQueryResult): DbBlock {
     execution_cost_write_length: Number.parseInt(row.execution_cost_write_length),
     tx_count: row.tx_count,
     signer_bitvec: row.signer_bitvec,
+    signer_signature: row.signer_signature,
   };
   return block;
 }

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -484,6 +484,7 @@ export class PgWriteStore extends PgStore {
       execution_cost_write_length: block.execution_cost_write_length,
       tx_count: block.tx_count,
       signer_bitvec: block.signer_bitvec,
+      signer_signature: block.signer_signature,
     };
     const result = await sql`
       INSERT INTO blocks ${sql(values)}
@@ -3384,6 +3385,7 @@ export class PgWriteStore extends PgStore {
       execution_cost_write_length: block.execution_cost_write_length,
       tx_count: block.tx_count,
       signer_bitvec: block.signer_bitvec,
+      signer_signature: block.signer_signature,
     }));
     await sql`
       INSERT INTO blocks ${sql(values)}

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -321,6 +321,7 @@ export interface CoreNodeBlockMessage {
   };
   block_time: number;
   signer_bitvec?: string | null;
+  signer_signature?: string[];
 }
 
 export interface CoreNodeParsedTxMessage {

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -298,6 +298,10 @@ async function handleBlockMessage(
     ? BitVec.consensusDeserializeToString(msg.signer_bitvec)
     : null;
 
+  // Stacks-core does not include the '0x' prefix in the signer signature hex strings
+  const signerSignature =
+    msg.signer_signature?.map(s => (s.startsWith('0x') ? s : '0x' + s)) ?? null;
+
   const dbBlock: DbBlock = {
     canonical: true,
     block_hash: msg.block_hash,
@@ -319,6 +323,7 @@ async function handleBlockMessage(
     tx_count: msg.transactions.length,
     block_time: blockData.block_time,
     signer_bitvec: signerBitvec,
+    signer_signature: signerSignature,
   };
 
   logger.debug(`Received block ${msg.block_hash} (${msg.block_height}) from node`, dbBlock);
@@ -1158,6 +1163,7 @@ export function parseNewBlockMessage(chainId: ChainID, msg: CoreNodeBlockMessage
     execution_cost_write_length: totalCost.execution_cost_write_length,
     tx_count: msg.transactions.length,
     signer_bitvec: msg.signer_bitvec ?? null,
+    signer_signature: msg.signer_signature ?? null,
   };
 
   const dbMinerRewards: DbMinerReward[] = [];

--- a/tests/api/address.test.ts
+++ b/tests/api/address.test.ts
@@ -93,6 +93,7 @@ describe('address tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     let indexIdIndex = 0;
     const createStxTx = (
@@ -1169,6 +1170,7 @@ describe('address tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     let indexIdIndex = 0;
@@ -2386,6 +2388,7 @@ describe('address tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const txBuilder = await makeContractCall({
       contractAddress: 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y',

--- a/tests/api/cache-control.test.ts
+++ b/tests/api/cache-control.test.ts
@@ -60,6 +60,7 @@ describe('cache-control tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx: DbTxRaw = {
       tx_id: '0x1234',

--- a/tests/api/datastore.test.ts
+++ b/tests/api/datastore.test.ts
@@ -279,6 +279,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx: DbTxRaw = {
       tx_id: '0x1234',
@@ -447,6 +448,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx: DbTxRaw = {
       tx_id: '0x1234',
@@ -621,6 +623,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     await db.updateBlock(client, block);
     const blockQuery = await db.getBlock({ hash: block.block_hash });
@@ -691,6 +694,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     let indexIdIndex = 0;
@@ -955,6 +959,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const txs1 = [
       createStxTx('addrA', 'addrB', 100, dbBlock1),
@@ -1030,6 +1035,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx1: DbTxRaw = {
       tx_id: '0x1234',
@@ -2004,6 +2010,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx: DbTx = {
       tx_id: '0x1234',
@@ -2088,6 +2095,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx: DbTx = {
       tx_id: '0x421234',
@@ -2177,6 +2185,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx: DbTx = {
       tx_id: '0x421234',
@@ -2274,6 +2283,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx: DbTxRaw = {
       tx_id: '0x421234',
@@ -2415,6 +2425,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx: DbTx = {
       tx_id: '0x421234',
@@ -2504,6 +2515,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx: DbTx = {
       tx_id: '0x421234',
@@ -2592,6 +2604,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx: DbTx = {
       tx_id: '0x421234',
@@ -2679,6 +2692,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     await db.updateBlock(client, dbBlock);
 
@@ -2753,6 +2767,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx1: DbTx = {
       tx_id: '0x421234',
@@ -3127,6 +3142,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const block2: DbBlock = {
       block_hash: '0x22',
@@ -3149,6 +3165,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const block3: DbBlock = {
       block_hash: '0x33',
@@ -3171,6 +3188,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const block3B: DbBlock = {
       ...block3,
@@ -3199,6 +3217,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const block4: DbBlock = {
       block_hash: '0x44',
@@ -3221,6 +3240,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const block5: DbBlock = {
       block_hash: '0x55',
@@ -3243,6 +3263,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const block6: DbBlock = {
       block_hash: '0x66',
@@ -3265,6 +3286,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     const tx1Mempool: DbMempoolTxRaw = {
@@ -3457,6 +3479,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const block2: DbBlock = {
       block_hash: '0x22',
@@ -3479,6 +3502,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const block3: DbBlock = {
       block_hash: '0x33',
@@ -3501,6 +3525,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const block3B: DbBlock = {
       ...block3,
@@ -3529,6 +3554,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     const minerReward1: DbMinerReward = {
@@ -3664,6 +3690,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     const reorgResult = await db.handleReorg(client, block5, 0);
@@ -3745,6 +3772,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const block2: DbBlock = {
       block_hash: '0x22',
@@ -3767,6 +3795,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     const minerReward1: DbMinerReward = {
@@ -4047,6 +4076,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     await db.update({ block: block3, microblocks: [], minerRewards: [], txs: [] });
 
@@ -4071,6 +4101,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx3: DbTxRaw = {
       tx_id: '0x03',
@@ -4282,6 +4313,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     await db.update({ block: block3b, microblocks: [], minerRewards: [], txs: [] });
     const blockQuery2 = await db.getBlock({ hash: block3b.block_hash });
@@ -4323,6 +4355,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     await db.update({ block: block4b, microblocks: [], minerRewards: [], txs: [] });
 
@@ -4433,6 +4466,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     const block2: DbBlock = {
@@ -4456,6 +4490,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     const block2b: DbBlock = {
@@ -4479,6 +4514,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     const block3: DbBlock = {
@@ -4502,6 +4538,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     const block3b: DbBlock = {
@@ -4525,6 +4562,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     const block4b: DbBlock = {
@@ -4548,6 +4586,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     const minerReward1: DbMinerReward = {
@@ -5046,6 +5085,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx1: DbTxRaw = {
       tx_id: '0x421234',
@@ -5133,6 +5173,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx1: DbTxRaw = {
       tx_id: '0x421234',
@@ -5219,6 +5260,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx1: DbTxRaw = {
       tx_id: '0x421234',
@@ -5376,6 +5418,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     await db.update({
       block: dbBlock,
@@ -5438,6 +5481,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     await db.update({
       block: dbBlock,
@@ -5501,6 +5545,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     await db.update({
       block: dbBlock,
@@ -5564,6 +5609,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     await db.updateBlock(client, block);
     const blockQuery = await db.getBlock({ hash: block.block_hash });
@@ -5674,6 +5720,7 @@ describe('postgres datastore', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     await db.updateBlock(client, block);
     const blockQuery = await db.getBlock({ hash: block.block_hash });

--- a/tests/api/mempool.test.ts
+++ b/tests/api/mempool.test.ts
@@ -573,6 +573,7 @@ describe('mempool tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const dbTx1: DbTxRaw = {
       ...mempoolTx1,
@@ -1353,6 +1354,7 @@ describe('mempool tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     await db.updateBlock(client, dbBlock);
     const senderAddress = 'SP25YGP221F01S9SSCGN114MKDAK9VRK8P3KXGEMB';
@@ -1428,6 +1430,7 @@ describe('mempool tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     await db.updateBlock(client, dbBlock);
     const senderAddress = 'SP25YGP221F01S9SSCGN114MKDAK9VRK8P3KXGEMB';
@@ -1655,6 +1658,7 @@ describe('mempool tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const dbBlock2: DbBlock = {
       block_hash: '0x2123',
@@ -1677,6 +1681,7 @@ describe('mempool tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const mempoolTx: DbMempoolTxRaw = {
       tx_id: txId,
@@ -1802,6 +1807,7 @@ describe('mempool tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const dbBlock1b: DbBlock = {
       block_hash: '0x0123bb',
@@ -1824,6 +1830,7 @@ describe('mempool tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const dbBlock2b: DbBlock = {
       block_hash: '0x2123',
@@ -1846,6 +1853,7 @@ describe('mempool tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const mempoolTx: DbMempoolTxRaw = {
       tx_id: txId,

--- a/tests/api/microblock.test.ts
+++ b/tests/api/microblock.test.ts
@@ -287,6 +287,7 @@ describe('microblock tests', () => {
           execution_cost_write_length: 0,
           tx_count: 1,
           signer_bitvec: null,
+          signer_signature: null,
         };
 
         const tx1: DbTxRaw = {

--- a/tests/api/other.test.ts
+++ b/tests/api/other.test.ts
@@ -62,6 +62,7 @@ describe('other tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx: DbTxRaw = {
       tx_id: '0x1234',

--- a/tests/api/search.test.ts
+++ b/tests/api/search.test.ts
@@ -64,6 +64,7 @@ describe('search tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     await db.updateBlock(client, block);
     const tx: DbTxRaw = {
@@ -276,6 +277,7 @@ describe('search tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     const tx: DbTxRaw = {
@@ -616,6 +618,7 @@ describe('search tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     await db.updateBlock(client, block);
 
@@ -1061,6 +1064,7 @@ describe('search tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     const stxTx1: DbTxRaw = {

--- a/tests/api/smart-contract.test.ts
+++ b/tests/api/smart-contract.test.ts
@@ -64,6 +64,7 @@ describe('smart contract tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx1: DbTxRaw = {
       tx_id: '0x421234',
@@ -217,6 +218,7 @@ describe('smart contract tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const txId1 = '0x421234';
     const smartContract1: DbSmartContract = {
@@ -329,6 +331,7 @@ describe('smart contract tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const txId1 = '0x421234';
     const smartContract1: DbSmartContract = {
@@ -439,6 +442,7 @@ describe('smart contract tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx1: DbTxRaw = {
       tx_id: '0x421235',

--- a/tests/api/tx.test.ts
+++ b/tests/api/tx.test.ts
@@ -158,6 +158,7 @@ describe('tx tests', () => {
       execution_cost_write_count: 138,
       execution_cost_write_length: 91116,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const dbTx2: DbTxRaw = {
       tx_id: '0x8915000000000000000000000000000000000000000000000000000000000000',
@@ -355,6 +356,7 @@ describe('tx tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     // stacks.js does not have a versioned-smart-contract tx builder as of writing, so use a known good serialized tx
@@ -518,6 +520,7 @@ describe('tx tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     // stacks.js does not support `coinbase-pay-to-alt-recipient` tx support as of writing, so use a known good serialized tx
@@ -664,6 +667,7 @@ describe('tx tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     // stacks.js does not support `coinbase-pay-to-alt-recipient` tx support as of writing, so use a known good serialized tx
@@ -810,6 +814,7 @@ describe('tx tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const txBuilder = await makeContractCall({
       contractAddress: 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y',
@@ -1002,6 +1007,7 @@ describe('tx tests', () => {
       execution_cost_write_length: 0,
       tx_count: 1,
       signer_bitvec: null,
+      signer_signature: null,
     };
     await db.update({
       block: dbBlock,
@@ -1203,6 +1209,7 @@ describe('tx tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const dbTx: DbTxRaw = {
       tx_id: '0x421234',
@@ -1406,6 +1413,7 @@ describe('tx tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
       signer_bitvec: null,
+      signer_signature: null,
     };
 
     const pc1 = createNonFungiblePostCondition(
@@ -1659,6 +1667,7 @@ describe('tx tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const txBuilder = await makeContractDeploy({
       contractName: 'hello-world',
@@ -1812,6 +1821,7 @@ describe('tx tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const txBuilder = await makeContractDeploy({
       contractName: 'hello-world',
@@ -2652,6 +2662,7 @@ describe('tx tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx: DbTxRaw = {
       tx_id: '0x421234',
@@ -2772,6 +2783,7 @@ describe('tx tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
       signer_bitvec: null,
+      signer_signature: null,
     };
     await db.updateBlock(client, block);
     const tx: DbTxRaw = {
@@ -3428,6 +3440,7 @@ describe('tx tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx: DbTxRaw = {
       tx_id: '0x1234',
@@ -3685,6 +3698,7 @@ describe('tx tests', () => {
       execution_cost_write_count: 138,
       execution_cost_write_length: 91116,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const expected = {
       tx_id: '0x8407751d1a8d11ee986aca32a6459d9cd798283a12e048ebafcd4cc7dadb29af',
@@ -4023,6 +4037,7 @@ describe('tx tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
       signer_bitvec: null,
+      signer_signature: null,
     };
     const tx: DbTxRaw = {
       tx_id: '0x1234',
@@ -4225,6 +4240,7 @@ describe('tx tests', () => {
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
       signer_bitvec: null,
+      signer_signature: null,
     };
     await db.updateBlock(client, block);
     const tx: DbTxRaw = {

--- a/tests/api/v2-proxy.test.ts
+++ b/tests/api/v2-proxy.test.ts
@@ -77,6 +77,7 @@ describe('v2-proxy tests', () => {
           execution_cost_write_length: 0,
           tx_count: 1,
           signer_bitvec: null,
+          signer_signature: null,
         };
 
         // Ensure db has a block so that current block height queries return a found result

--- a/tests/utils/test-builders.ts
+++ b/tests/utils/test-builders.ts
@@ -99,6 +99,7 @@ export interface TestBlockArgs {
   parent_microblock_sequence?: number;
   canonical?: boolean;
   signer_bitvec?: string;
+  signer_signature?: string[];
 }
 
 /**
@@ -128,6 +129,7 @@ function testBlock(args?: TestBlockArgs): DbBlock {
     execution_cost_write_length: 0,
     tx_count: 1,
     signer_bitvec: args?.signer_bitvec ?? null,
+    signer_signature: args?.signer_signature ?? null,
   };
 }
 


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/2089

Ingest the `signer_signature` data from the `/new_block` payload. These are stored as a `bytea[]` type in the `blocks` table.

In epoch3.0 the `signer_signature` can be up to 4000 entries in length, 65 bytes each. So a new paginated endpoint is added to expose these rather than including them in existing block responses.

### Example
`GET /extended/v2/blocks/{height_or_hash}/signer-signature`
```json
{
  "limit": 500,
  "offset": 0,
  "total": 2,
  "results": [
    "0x00389af3b37f7a0bdd521bb053bf31c95f62082ed30ac6c6ed1eab9ef2453fe62368827d0741adef4ead4b48b6b3af0108836c95e6ecef76fc563f1194628e8062",
    "0x0028c9d37a458df35f5a23d4799e97739facae07143642baedc101e7cf9d470d7a2de562bc5efaa914b15182035ce520cd7a3639f342776796da9c8c6001c84048"
  ]
}
```