### PR TITLE
fix: differentiate mempool transactions when calculating principal etag

### DIFF
--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -4444,7 +4444,7 @@ export class PgStore extends BasePgStore {
     const result = await this.sql<{ tx_id: string }[]>`
       WITH activity AS (
         (
-          SELECT tx_id
+          SELECT '0x' || encode(tx_id, 'hex') AS tx_id
           FROM principal_stx_txs
           WHERE principal = ${principal} AND canonical = true AND microblock_canonical = true
           ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC
@@ -4452,7 +4452,7 @@ export class PgStore extends BasePgStore {
         )
         UNION
         (
-          SELECT tx_id
+          SELECT '0x' || encode(tx_id, 'hex') AS tx_id
           FROM ft_events
           WHERE (sender = ${principal} OR recipient = ${principal})
             AND canonical = true
@@ -4462,7 +4462,7 @@ export class PgStore extends BasePgStore {
         )
         UNION
         (
-          SELECT tx_id
+          SELECT '0x' || encode(tx_id, 'hex') AS tx_id
           FROM nft_events
           WHERE (sender = ${principal} OR recipient = ${principal})
             AND canonical = true
@@ -4474,7 +4474,7 @@ export class PgStore extends BasePgStore {
           includeMempool
             ? this.sql`UNION
             (
-              SELECT tx_id
+              SELECT 'mempool-' || '0x' || encode(tx_id, 'hex') AS tx_id
               FROM mempool_txs
               WHERE pruned = false AND
                 (sender_address = ${principal}
@@ -4486,7 +4486,7 @@ export class PgStore extends BasePgStore {
             : this.sql``
         }
       )
-      SELECT DISTINCT tx_id FROM activity WHERE tx_id IS NOT NULL
+      SELECT tx_id FROM activity WHERE tx_id IS NOT NULL
     `;
     return result.map(r => r.tx_id);
   }


### PR DESCRIPTION
Fixes a bug where a mempool balance did not convert to confirmed balance due to a duplicate Etag calculation. This was because we were taking all the latest `tx_id`s that affected an account (both confirmed and mempool) to calculate the Etag, but when a mempool tx becomes confirmed the Etag did not change because that transaction retains the same transaction ID.

The solution is to prepend a string such as `mempool-` to a mempool transaction ID so the Etag will change once that transaction confirms.