### PR TITLE
fix: indexes to optimize principal-based etag db lookups

### DIFF
--- a/migrations/1730724278636_principal_activity_txs_idx.js
+++ b/migrations/1730724278636_principal_activity_txs_idx.js
@@ -1,0 +1,61 @@
+/** @param { import("node-pg-migrate").MigrationBuilder } pgm */
+exports.up = pgm => {
+  // Indexes used to speed up queries in the `getPrincipalLastActivityTxIds` function:
+  // https://github.com/hirosystems/stacks-blockchain-api/blob/e3c30c6e0cb14843d5f089b64010d738b0b27763/src/datastore/pg-store.ts#L4440-L4492
+  // See issue https://github.com/hirosystems/stacks-blockchain-api/issues/2147
+
+  pgm.createIndex(
+    'ft_events', 
+    [
+      'sender',
+      'recipient',
+      { name: 'block_height', order: 'DESC' },
+      { name: 'microblock_sequence', order: 'DESC' },
+      { name: 'tx_index', order: 'DESC' },
+      { name: 'event_index', order: 'DESC' }
+    ],
+    {
+      name: 'idx_ft_events_optimized',
+      where: 'canonical = TRUE AND microblock_canonical = TRUE',
+    }
+  );
+
+  pgm.createIndex(
+    'nft_events', 
+    [
+      'sender',
+      'recipient',
+      { name: 'block_height', order: 'DESC' },
+      { name: 'microblock_sequence', order: 'DESC' },
+      { name: 'tx_index', order: 'DESC' },
+      { name: 'event_index', order: 'DESC' }
+    ],
+    {
+      name: 'idx_nft_events_optimized',
+      where: 'canonical = TRUE AND microblock_canonical = TRUE',
+    }
+  );
+
+  pgm.createIndex(
+    'mempool_txs', 
+    [
+      'sender_address',
+      'sponsor_address',
+      'token_transfer_recipient_address',
+      { name: 'receipt_time', order: 'DESC' },
+      { name: 'sender_address', order: 'DESC' },
+      { name: 'nonce', order: 'DESC' }
+    ],
+    {
+      name: 'idx_mempool_txs_optimized',
+      where: 'pruned = FALSE',
+    }
+  );
+};
+
+/** @param { import("node-pg-migrate").MigrationBuilder } pgm */
+exports.down = pgm => {
+  pgm.dropIndex('ft_events', 'idx_ft_events_optimized');
+  pgm.dropIndex('nft_events', 'idx_nft_events_optimized');
+  pgm.dropIndex('mempool_txs', 'idx_mempool_txs_optimized');
+};

--- a/migrations/1730724278636_principal_activity_txs_idx.js
+++ b/migrations/1730724278636_principal_activity_txs_idx.js
@@ -42,9 +42,7 @@ exports.up = pgm => {
       'sender_address',
       'sponsor_address',
       'token_transfer_recipient_address',
-      { name: 'receipt_time', order: 'DESC' },
-      { name: 'sender_address', order: 'DESC' },
-      { name: 'nonce', order: 'DESC' }
+      { name: 'receipt_time', order: 'DESC' }
     ],
     {
       name: 'idx_mempool_txs_optimized',
@@ -55,7 +53,7 @@ exports.up = pgm => {
 
 /** @param { import("node-pg-migrate").MigrationBuilder } pgm */
 exports.down = pgm => {
-  pgm.dropIndex('ft_events', 'idx_ft_events_optimized');
-  pgm.dropIndex('nft_events', 'idx_nft_events_optimized');
-  pgm.dropIndex('mempool_txs', 'idx_mempool_txs_optimized');
+  pgm.dropIndex('ft_events', ['sender', 'recipient', 'block_height', 'microblock_sequence', 'tx_index', 'event_index'], { name: 'idx_ft_events_optimized' });
+  pgm.dropIndex('nft_events', ['sender', 'recipient', 'block_height', 'microblock_sequence', 'tx_index', 'event_index'], { name: 'idx_nft_events_optimized' });
+  pgm.dropIndex('mempool_txs', ['sender_address', 'sponsor_address', 'token_transfer_recipient_address', 'receipt_time'], { name: 'idx_mempool_txs_optimized' });
 };

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -4453,10 +4453,27 @@ export class PgStore extends BasePgStore {
         UNION
         (
           SELECT '0x' || encode(tx_id, 'hex') AS tx_id
-          FROM ft_events
-          WHERE (sender = ${principal} OR recipient = ${principal})
-            AND canonical = true
-            AND microblock_canonical = true
+          FROM (
+            (
+              SELECT tx_id, block_height, microblock_sequence, tx_index, event_index
+              FROM ft_events
+              WHERE sender = ${principal}
+                AND canonical = true
+                AND microblock_canonical = true
+              ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+              LIMIT 1
+            )
+            UNION ALL
+            (
+              SELECT tx_id, block_height, microblock_sequence, tx_index, event_index
+              FROM ft_events
+              WHERE recipient = ${principal}
+                AND canonical = true
+                AND microblock_canonical = true
+              ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+              LIMIT 1
+            )
+          ) AS combined
           ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
           LIMIT 1
         )

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -4480,7 +4480,7 @@ export class PgStore extends BasePgStore {
                 (sender_address = ${principal}
                 OR sponsor_address = ${principal}
                 OR token_transfer_recipient_address = ${principal})
-              ORDER BY receipt_time DESC, sender_address DESC, nonce DESC
+              ORDER BY receipt_time DESC
               LIMIT 1
             )`
             : this.sql``


### PR DESCRIPTION
Possible fix for https://github.com/hirosystems/stacks-blockchain-api/issues/2147

In version v8.1.0, several endpoints (in particular the balance endpoints) were updated to use new [etag caching handling](https://github.com/hirosystems/stacks-blockchain-api/pull/2097). This change was actually an optimization to reduce db load, however, it performs a sql query that is very CPU intensive for postgres deployments without very large memory cache configurations. 

This PR adds composite indexes which _should_ be less CPU intensive than the bitmap scans required by the previously used indexes.

I was able to reproduce the slow query perf on a small-ish vm, and verify that this PR significantly improves the query:
```
// before PR
Planning Time: 4.330 ms
Execution Time: 774.455 ms

// after PR
Planning Time: 0.851 ms
Execution Time: 0.399 ms
```

Using this sample query:
```sql
    WITH activity AS (
      (
        SELECT '0x' || encode(tx_id, 'hex') AS tx_id
        FROM principal_stx_txs
        WHERE principal = 'SP2ADT4TAV92SPBNP3WE9GPJ12F6CKGWMEJ1H1BB9' AND canonical = true AND microblock_canonical = true
        ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC
        LIMIT 1
      )
      UNION
      (
        SELECT '0x' || encode(tx_id, 'hex') AS tx_id
        FROM (
          (
            SELECT tx_id, block_height, microblock_sequence, tx_index, event_index
            FROM ft_events
            WHERE sender = 'SP2ADT4TAV92SPBNP3WE9GPJ12F6CKGWMEJ1H1BB9'
              AND canonical = true
              AND microblock_canonical = true
            ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
            LIMIT 1
          )
          UNION ALL
          (
            SELECT tx_id, block_height, microblock_sequence, tx_index, event_index
            FROM ft_events
            WHERE recipient = 'SP2ADT4TAV92SPBNP3WE9GPJ12F6CKGWMEJ1H1BB9'
              AND canonical = true
              AND microblock_canonical = true
            ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
            LIMIT 1
          )
        ) AS combined
        ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
        LIMIT 1
      )
      UNION
      (
        SELECT '0x' || encode(tx_id, 'hex') AS tx_id
        FROM nft_events
        WHERE (sender = 'SP2ADT4TAV92SPBNP3WE9GPJ12F6CKGWMEJ1H1BB9' OR recipient = 'SP2ADT4TAV92SPBNP3WE9GPJ12F6CKGWMEJ1H1BB9')
          AND canonical = true
          AND microblock_canonical = true
        ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
        LIMIT 1
      )
     UNION
      (
        SELECT 'mempool-' || '0x' || encode(tx_id, 'hex') AS tx_id
        FROM mempool_txs
        WHERE pruned = false AND
          (sender_address = 'SP2ADT4TAV92SPBNP3WE9GPJ12F6CKGWMEJ1H1BB9'
          OR sponsor_address = 'SP2ADT4TAV92SPBNP3WE9GPJ12F6CKGWMEJ1H1BB9'
          OR token_transfer_recipient_address = 'SP2ADT4TAV92SPBNP3WE9GPJ12F6CKGWMEJ1H1BB9')
        ORDER BY receipt_time DESC, sender_address DESC, nonce DESC
        LIMIT 1
      )
    )
    SELECT tx_id FROM activity WHERE tx_id IS NOT NULL;
```