### PR TITLE
fix: more details in event-observer http server logging

### DIFF
--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -757,15 +757,50 @@ export async function startEventServer(opts: {
   }
 
   const bodyLimit = 1_000_000 * 500; // 500MB body limit
+
+  const reqLogSerializer = (req: FastifyRequest) => ({
+    method: req.method,
+    url: req.url,
+    version: req.headers?.['accept-version'] as string,
+    hostname: req.hostname,
+    remoteAddress: req.ip,
+    remotePort: req.socket ? req.socket.remotePort : undefined,
+    bodySize: parseInt(req.headers?.['content-length'] as string) || 'unknown',
+  });
+
   const loggerOpts: FastifyServerOptions['logger'] = {
     ...PINO_LOGGER_CONFIG,
     name: 'stacks-node-event',
+    serializers: {
+      req: reqLogSerializer,
+      res: reply => ({
+        statusCode: reply.statusCode,
+        method: reply.request?.method,
+        url: reply.request?.url,
+        requestBodySize:
+          parseInt(reply.request?.headers?.['content-length'] as string) || 'unknown',
+        responseBodySize: parseInt(reply.getHeader?.('content-length') as string) || 'unknown',
+      }),
+    },
   };
+
   const app = Fastify({
     bodyLimit,
     trustProxy: true,
     logger: loggerOpts,
     ignoreTrailingSlash: true,
+  });
+
+  app.addHook('onRequest', (req, reply, done) => {
+    req.raw.on('close', () => {
+      if (req.raw.aborted) {
+        req.log.warn(
+          reqLogSerializer(req),
+          `Request was aborted by the client: ${req.method} ${req.url}`
+        );
+      }
+    });
+    done();
   });
 
   const handleRawEventRequest = async (req: FastifyRequest) => {

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -764,7 +764,7 @@ export async function startEventServer(opts: {
     version: req.headers?.['accept-version'] as string,
     hostname: req.hostname,
     remoteAddress: req.ip,
-    remotePort: req.socket ? req.socket.remotePort : undefined,
+    remotePort: req.socket?.remotePort,
     bodySize: parseInt(req.headers?.['content-length'] as string) || 'unknown',
   });
 
@@ -777,8 +777,7 @@ export async function startEventServer(opts: {
         statusCode: reply.statusCode,
         method: reply.request?.method,
         url: reply.request?.url,
-        requestBodySize:
-          parseInt(reply.request?.headers?.['content-length'] as string) || 'unknown',
+        requestBodySize: parseInt(reply.request?.headers['content-length'] as string) || 'unknown',
         responseBodySize: parseInt(reply.getHeader?.('content-length') as string) || 'unknown',
       }),
     },


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/2158

* Event http response logs now include details like the url, request body size, etc so they don't have to be matched with a previous log entry.
* Aborted http requests are logged as an error with details about the request (this will identify issues like stacks-core using a short timeout).