### PR TITLE
feat: option to modify estimated fees in /v2/fees/transaction proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,11 +41,11 @@
         "elliptic": "6.5.7",
         "escape-goat": "3.0.0",
         "evt": "1.10.1",
-        "express": "^4.21.1",
+        "express": "4.21.1",
         "fastify": "4.28.1",
         "fastify-metrics": "11.0.0",
         "getopts": "2.3.0",
-        "http-proxy-middleware": "^2.0.7",
+        "http-proxy-middleware": "2.0.7",
         "jsonc-parser": "3.0.0",
         "jsonrpc-lite": "2.2.0",
         "lru-cache": "6.0.0",
@@ -69,6 +69,7 @@
         "strict-event-emitter-types": "2.0.0",
         "tiny-secp256k1": "2.2.1",
         "ts-unused-exports": "7.0.3",
+        "undici": "6.21.0",
         "uuid": "8.3.2",
         "ws": "7.5.10",
         "zone-file": "2.0.0-beta.3"
@@ -169,6 +170,19 @@
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^5.25.4"
+      }
+    },
+    "node_modules/@actions/http-client/node_modules/undici": {
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@actions/io": {
@@ -1253,6 +1267,18 @@
         "fastify-plugin": "^4.0.0",
         "toad-cache": "^3.7.0",
         "undici": "^5.19.1"
+      }
+    },
+    "node_modules/@fastify/reply-from/node_modules/undici": {
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@fastify/swagger": {
@@ -16928,14 +16954,12 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
+      "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "strict-event-emitter-types": "2.0.0",
     "tiny-secp256k1": "2.2.1",
     "ts-unused-exports": "7.0.3",
+    "undici": "6.21.0",
     "uuid": "8.3.2",
     "ws": "7.5.10",
     "zone-file": "2.0.0-beta.3"

--- a/src/api/routes/core-node-rpc-proxy.ts
+++ b/src/api/routes/core-node-rpc-proxy.ts
@@ -152,9 +152,7 @@ export const CoreNodeRpcProxyRouter: FastifyPluginAsync<
     upstream: `http://${stacksNodeRpcEndpoint}`,
     rewritePrefix: '/v2',
     http2: false,
-    // Use the `node:http` agent for requests https://github.com/fastify/fastify-reply-from?tab=readme-ov-file#globalagent
     globalAgent: true,
-    http: {},
     preValidation: async (req, reply) => {
       if (getReqUrl(req).pathname !== '/v2/transactions') {
         return;

--- a/src/api/routes/core-node-rpc-proxy.ts
+++ b/src/api/routes/core-node-rpc-proxy.ts
@@ -24,18 +24,6 @@ function getReqUrl(req: { url: string; hostname: string }): URL {
 // https://github.com/stacks-network/stacks-core/blob/20d5137438c7d169ea97dd2b6a4d51b8374a4751/stackslib/src/chainstate/stacks/db/blocks.rs#L338
 const MINIMUM_TX_FEE_RATE_PER_BYTE = 1;
 
-function getFeeEstimationModifier(): number | null {
-  const feeEstimationModifier = process.env['STACKS_CORE_FEE_ESTIMATION_MODIFIER'];
-  if (!feeEstimationModifier) {
-    return null;
-  }
-  const parsed = parseFloat(feeEstimationModifier);
-  if (isNaN(parsed) || parsed <= 0) {
-    return null;
-  }
-  return parsed;
-}
-
 interface FeeEstimation {
   fee: number;
   fee_rate: number;
@@ -149,6 +137,17 @@ export const CoreNodeRpcProxyRouter: FastifyPluginAsync<
     }
   );
 
+  let feeEstimationModifier: number | null = null;
+  fastify.addHook('onReady', () => {
+    const feeEstEnvVar = process.env['STACKS_CORE_FEE_ESTIMATION_MODIFIER'];
+    if (feeEstEnvVar) {
+      const parsed = parseFloat(feeEstEnvVar);
+      if (!isNaN(parsed) && parsed > 0) {
+        feeEstimationModifier = parsed;
+      }
+    }
+  });
+
   await fastify.register(fastifyHttpProxy, {
     upstream: `http://${stacksNodeRpcEndpoint}`,
     rewritePrefix: '/v2',
@@ -236,29 +235,29 @@ export const CoreNodeRpcProxyRouter: FastifyPluginAsync<
           const txId = responseBuffer.toString();
           await logTxBroadcast(txId);
           await reply.send(responseBuffer);
-        } else if (getReqUrl(req).pathname === '/v2/fees/transaction' && reply.statusCode === 200) {
-          const feeEstimationModifier = getFeeEstimationModifier();
-          if (feeEstimationModifier !== null) {
-            const reqBody = req.body as {
-              estimated_len?: number;
-              transaction_payload: string;
-            };
-            // https://github.com/stacks-network/stacks-core/blob/20d5137438c7d169ea97dd2b6a4d51b8374a4751/stackslib/src/net/api/postfeerate.rs#L200-L201
-            const txSize = Math.max(
-              reqBody.estimated_len ?? 0,
-              reqBody.transaction_payload.length / 2
-            );
-            const minFee = txSize * MINIMUM_TX_FEE_RATE_PER_BYTE;
-            const responseBuffer = await readRequestBody(response as ServerResponse);
-            const responseJson = JSON.parse(responseBuffer.toString()) as FeeEstimateResponse;
-            responseJson.estimations.forEach(estimation => {
-              // max(min fee, estimate returned by node * configurable modifier)
-              estimation.fee = Math.max(minFee, Math.round(estimation.fee * feeEstimationModifier));
-            });
-            await reply.removeHeader('content-length').send(JSON.stringify(responseJson));
-          } else {
-            await reply.send(response);
-          }
+        } else if (
+          getReqUrl(req).pathname === '/v2/fees/transaction' &&
+          reply.statusCode === 200 &&
+          feeEstimationModifier !== null
+        ) {
+          const reqBody = req.body as {
+            estimated_len?: number;
+            transaction_payload: string;
+          };
+          // https://github.com/stacks-network/stacks-core/blob/20d5137438c7d169ea97dd2b6a4d51b8374a4751/stackslib/src/net/api/postfeerate.rs#L200-L201
+          const txSize = Math.max(
+            reqBody.estimated_len ?? 0,
+            reqBody.transaction_payload.length / 2
+          );
+          const minFee = txSize * MINIMUM_TX_FEE_RATE_PER_BYTE;
+          const modifier = feeEstimationModifier;
+          const responseBuffer = await readRequestBody(response as ServerResponse);
+          const responseJson = JSON.parse(responseBuffer.toString()) as FeeEstimateResponse;
+          responseJson.estimations.forEach(estimation => {
+            // max(min fee, estimate returned by node * configurable modifier)
+            estimation.fee = Math.max(minFee, Math.round(estimation.fee * modifier));
+          });
+          await reply.removeHeader('content-length').send(JSON.stringify(responseJson));
         } else {
           await reply.send(response);
         }

--- a/tests/api/v2-proxy.test.ts
+++ b/tests/api/v2-proxy.test.ts
@@ -27,6 +27,84 @@ describe('v2-proxy tests', () => {
     await migrate('down');
   });
 
+  test('tx fee estimation', async () => {
+    const primaryProxyEndpoint = 'proxy-stacks-node:12345';
+    const feeEstimationModifier = 0.5;
+    await useWithCleanup(
+      () => {
+        const restoreEnvVars = withEnvVars(
+          ['STACKS_CORE_FEE_ESTIMATION_MODIFIER', feeEstimationModifier.toString()],
+          ['STACKS_CORE_PROXY_HOST', primaryProxyEndpoint.split(':')[0]],
+          ['STACKS_CORE_PROXY_PORT', primaryProxyEndpoint.split(':')[1]]
+        );
+        return [, () => restoreEnvVars()] as const;
+      },
+      async () => {
+        const apiServer = await startApiServer({
+          datastore: db,
+          chainId: ChainID.Mainnet,
+        });
+        return [apiServer, apiServer.terminate] as const;
+      },
+      async (_, api) => {
+        const primaryStubbedResponse = {
+          cost_scalar_change_by_byte: 0.00476837158203125,
+          estimated_cost: {
+            read_count: 19,
+            read_length: 4814,
+            runtime: 7175000,
+            write_count: 2,
+            write_length: 1020,
+          },
+          estimated_cost_scalar: 14,
+          estimations: [
+            {
+              fee: 400,
+              fee_rate: 1.2410714285714286,
+            },
+            {
+              fee: 800,
+              fee_rate: 8.958333333333332,
+            },
+            {
+              fee: 1000,
+              fee_rate: 10,
+            },
+          ],
+        };
+        const testRequest = {
+          estimated_len: 350,
+          transaction_payload:
+            '021af942874ce525e87f21bbe8c121b12fac831d02f4086765742d696e666f0b7570646174652d696e666f00000000',
+        };
+        nock(`http://${primaryProxyEndpoint}`)
+          .post('/v2/fees/transaction')
+          .once()
+          .reply(200, JSON.stringify(primaryStubbedResponse), {
+            'Content-Type': 'application/json',
+          });
+        const postTxReq = await supertest(api.server)
+          .post(`/v2/fees/transaction`)
+          .set('Content-Type', 'application/json')
+          .send(JSON.stringify(testRequest));
+        expect(postTxReq.status).toBe(200);
+        // Expected min fee is the byte size because MINIMUM_TX_FEE_RATE_PER_BYTE=1
+        const expectedMinFee = Math.max(
+          testRequest.estimated_len ?? 0,
+          testRequest.transaction_payload.length / 2
+        );
+        const expectedResponse = {
+          ...primaryStubbedResponse,
+        };
+        expectedResponse.estimations = expectedResponse.estimations.map(est => ({
+          ...est,
+          fee: Math.max(expectedMinFee, Math.round(est.fee * feeEstimationModifier)),
+        }));
+        expect(postTxReq.body).toEqual(expectedResponse);
+      }
+    );
+  });
+
   test('tx post multicast', async () => {
     const primaryProxyEndpoint = 'proxy-stacks-node:12345';
     const extraTxEndpoint = 'http://extra-tx-endpoint-a/test';


### PR DESCRIPTION
Adds a hook to the `/v2/fees/transaction` endpoint in the RPC proxy. 

Configure using the env var `STACKS_CORE_FEE_ESTIMATION_MODIFIER`. The fee estimations returned by the stacks-node will be multiplied by this value.

For example with `STACKS_CORE_FEE_ESTIMATION_MODIFIER=0.5`, if the response from stacks-core is:
```
estimations: [
  { fee: 400 },
  { fee: 800 },
  { fee: 1000 }
]
```
Then the modified response will be:
```
estimations: [
  { fee: 200 },
  { fee: 400 },
  { fee: 500 }
]
```