### PR TITLE
Fix: socket-io reconnect

### DIFF
--- a/client/src/socket-io/index.ts
+++ b/client/src/socket-io/index.ts
@@ -72,7 +72,7 @@ export class StacksApiSocketClient {
 
   handleSubscription(topic: Topic, subscribe = false, listener?: (...args: any[]) => void) {
     const subsQuery = this.socket.io.opts.query?.subscriptions as string | undefined;
-    const subscriptions = new Set(subsQuery?.split(',') ?? []);
+    const subscriptions = new Set(subsQuery ? subsQuery.split(',') : []);
     if (subscribe) {
       this.socket.emit('subscribe', topic, error => {
         if (error) console.error(`Error subscribing: ${error}`);

--- a/src/api/routes/ws/channels/socket-io-channel.ts
+++ b/src/api/routes/ws/channels/socket-io-channel.ts
@@ -90,7 +90,10 @@ export class SocketIOChannel extends WebSocketChannel {
     io.use((socket, next) => {
       const subscriptions = socket.handshake.query['subscriptions'];
       if (subscriptions) {
-        const topics = [...[subscriptions]].flat().flatMap(r => r.split(','));
+        const topics = [...[subscriptions]]
+          .flat()
+          .flatMap(r => r.split(','))
+          .filter(r => !!r);
         const invalidSubs = this.getInvalidSubscriptionTopics(topics as Topic[]);
         if (invalidSubs) {
           const error = new Error(`Invalid topic: ${invalidSubs.join(', ')}`);


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/2146

There's a bug in the socket-io client reconnection logic, where an invalid empty topic was being sent. 
```js
client.socket.on('connect_error', error => {
  console.error('Socket connection was denied by the server', error);
  // > Socket connection was denied by the server Error: Invalid topic: 
});
```

This PR fixes the bug in the client, and also updates the server code to ignore empty topics so that existing client versions will work.