### PR TITLE
Feat/tbtc faucet amounts

### DIFF
--- a/src/api/routes/faucets.ts
+++ b/src/api/routes/faucets.ts
@@ -74,25 +74,25 @@ export const FaucetRoutes: FastifyPluginAsync<
       preHandler: missingBtcConfigMiddleware,
       schema: {
         operationId: 'run_faucet_btc',
-        summary: 'Add testnet BTC tokens to address',
-        description: `Add 0.01 BTC token to the specified testnet BTC address.
+        summary: 'Add regtest BTC tokens to address',
+        description: `Add 0.01 BTC token to the specified regtest BTC address.
 
-        The endpoint returns the transaction ID, which you can use to view the transaction in a testnet Bitcoin block
+        The endpoint returns the transaction ID, which you can use to view the transaction in a regtest Bitcoin block
         explorer. The tokens are delivered once the transaction has been included in a block.
 
-        **Note:** This is a testnet only endpoint. This endpoint will not work on the mainnet.`,
+        **Note:** This is a Bitcoin regtest-only endpoint. This endpoint will not work on the Bitcoin mainnet.`,
         tags: ['Faucets'],
         querystring: Type.Object({
           address: Type.Optional(
             Type.String({
-              description: 'A valid testnet BTC address',
+              description: 'A valid regtest BTC address',
               examples: ['2N4M94S1ZPt8HfxydXzL2P7qyzgVq7MHWts'],
             })
           ),
           large: Type.Optional(
             Type.Boolean({
               description:
-                'Request a larger amount of testnet BTC than the default',
+                'Request a larger amount of regtest BTC than the default',
               default: false,
             })
           ),
@@ -101,7 +101,7 @@ export const FaucetRoutes: FastifyPluginAsync<
           Type.Object({
             address: Type.Optional(
               Type.String({
-                description: 'A valid testnet BTC address',
+                description: 'A valid regtest BTC address',
                 examples: ['2N4M94S1ZPt8HfxydXzL2P7qyzgVq7MHWts'],
               })
             ),
@@ -119,7 +119,7 @@ export const FaucetRoutes: FastifyPluginAsync<
             {
               title: 'RunFaucetResponse',
               description:
-                'POST request that initiates a transfer of tokens to a specified testnet address',
+                'POST request that initiates a transfer of tokens to a specified Bitcoin regtest address',
             }
           ),
           '4xx': Type.Object({
@@ -132,7 +132,7 @@ export const FaucetRoutes: FastifyPluginAsync<
     async (req, reply) => {
       await btcFaucetRequestQueue.add(async () => {
         const address = req.query.address || req.body?.address;
-        const tbtcAmount = req.query.large ? 0.5 : 0.01;
+        const btcAmount = req.query.large ? 0.5 : 0.01;
         if (!address) {
           return await reply.status(400).send({
             error: 'address required',
@@ -164,7 +164,7 @@ export const FaucetRoutes: FastifyPluginAsync<
           });
         }
 
-        const tx = await makeBtcFaucetPayment(btc.networks.regtest, address, tbtcAmount);
+        const tx = await makeBtcFaucetPayment(btc.networks.regtest, address, btcAmount);
         await fastify.writeDb?.insertFaucetRequest({
           ip: `${ip}`,
           address: address,
@@ -191,7 +191,7 @@ export const FaucetRoutes: FastifyPluginAsync<
         tags: ['Faucets'],
         params: Type.Object({
           address: Type.String({
-            description: 'A valid testnet BTC address',
+            description: 'A valid regtest BTC address',
             examples: ['2N4M94S1ZPt8HfxydXzL2P7qyzgVq7MHWts'],
           }),
         }),


### PR DESCRIPTION
Closes https://github.com/hirosystems/stacks-blockchain-api/issues/2187

* Changes the default tBTC faucet amount from 0.5 -> 0.01 tBTC
* Adds a URL query option to the tBTC faucet to allow the user the request a larger amount of tBTC (the original amount of 0.5)
* Updates some Bitcoin-related text from `testnet` to `regtest` since we've replaced Bitcoin testnet with regtest on Stacks testnet