### PR TITLE
feat: add prom metrics for stacks block count at previous burn block

### DIFF
--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -4531,6 +4531,6 @@ export class PgStore extends BasePgStore {
       FROM blocks
       WHERE burn_block_height = ${burnBlockHeight} AND canonical = TRUE
     `;
-    return parseInt(result[0].count ?? '0');
+    return parseInt(result[0]?.count ?? '0');
   }
 }

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -4525,11 +4525,11 @@ export class PgStore extends BasePgStore {
     if (result.count) return result[0];
   }
 
-  async getStacksBlockCountAtBurnBlock(burnBlockHeight: number): Promise<number> {
+  async getStacksBlockCountAtPreviousBurnBlock(): Promise<number> {
     const result = await this.sql<{ count: string }[]>`
       SELECT COUNT(*) AS count
       FROM blocks
-      WHERE burn_block_height = ${burnBlockHeight} AND canonical = TRUE
+      WHERE burn_block_height = (SELECT burn_block_height - 1 FROM chain_tip) AND canonical = TRUE
     `;
     return parseInt(result[0]?.count ?? '0');
   }

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -4526,11 +4526,11 @@ export class PgStore extends BasePgStore {
   }
 
   async getStacksBlockCountAtBurnBlock(burnBlockHeight: number): Promise<number> {
-    const result = await this.sql<{ count: number }[]>`
+    const result = await this.sql<{ count: string }[]>`
       SELECT COUNT(*) AS count
       FROM blocks
       WHERE burn_block_height = ${burnBlockHeight} AND canonical = TRUE
     `;
-    return result[0].count ?? 0;
+    return parseInt(result[0].count ?? '0');
   }
 }

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -4540,7 +4540,9 @@ export class PgStore extends BasePgStore {
       }[]
     >`
       WITH current AS (
-        SELECT MAX(burn_block_height) AS height FROM blocks
+        SELECT MAX(burn_block_height) AS height
+        FROM blocks
+        WHERE canonical = TRUE
       ),
       current_count AS (
         SELECT COUNT(*) AS count
@@ -4550,6 +4552,7 @@ export class PgStore extends BasePgStore {
       previous AS (
         SELECT DISTINCT burn_block_height AS height
         FROM blocks
+        WHERE canonical = TRUE
         ORDER BY burn_block_height DESC
         LIMIT 1 OFFSET 1
       ),

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -4524,4 +4524,46 @@ export class PgStore extends BasePgStore {
     `;
     if (result.count) return result[0];
   }
+
+  async getCurrentAndPreviousTenureBlockCounts(): Promise<{
+    current_burn_block_height: number | null;
+    current_block_count: number;
+    previous_burn_block_height: number | null;
+    previous_block_count: number;
+  }> {
+    const result = await this.sql<
+      {
+        current_burn_block_height: number | null;
+        current_block_count: number;
+        previous_burn_block_height: number | null;
+        previous_block_count: number;
+      }[]
+    >`
+      WITH current AS (
+        SELECT MAX(burn_block_height) AS height FROM blocks
+      ),
+      current_count AS (
+        SELECT COUNT(*) AS count
+        FROM blocks
+        WHERE burn_block_height = (SELECT height FROM current) AND canonical = TRUE
+      ),
+      previous AS (
+        SELECT DISTINCT burn_block_height AS height
+        FROM blocks
+        ORDER BY burn_block_height DESC
+        LIMIT 1 OFFSET 1
+      ),
+      previous_count AS (
+        SELECT COUNT(*) AS count
+        FROM blocks
+        WHERE burn_block_height = (SELECT height FROM previous) AND canonical = TRUE
+      )
+      SELECT
+        (SELECT height FROM current) AS current_burn_block_height,
+        (SELECT count FROM current_count) AS current_block_count,
+        (SELECT height FROM previous) AS previous_burn_block_height,
+        (SELECT count FROM previous_count) AS previous_block_count
+    `;
+    return result[0];
+  }
 }

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -1780,6 +1780,12 @@ export class PgWriteStore extends PgStore {
     });
   }
 
+  async updateBurnChainBlockHeight(args: { blockHeight: number }): Promise<void> {
+    await this.sql`
+      UPDATE chain_tip SET burn_block_height = GREATEST(${args.blockHeight}, burn_block_height)
+    `;
+  }
+
   async insertSlotHoldersBatch(sql: PgSqlClient, slotHolders: DbRewardSlotHolder[]): Promise<void> {
     const slotValues: RewardSlotHolderInsertValues[] = slotHolders.map(slot => ({
       canonical: true,

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -655,6 +655,7 @@ function createMessageProcessorQueue(): EventMessageHandler {
         help: 'Number of Stacks blocks produced in the previous burn block',
       }),
     };
+    metrics.blocksInPreviousBurnBlock.remove();
   }
 
   const observeEvent = async (event: string, fn: () => Promise<void>) => {

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -653,8 +653,8 @@ function createMessageProcessorQueue(db: PgWriteStore): EventMessageHandler {
       blocksInPreviousBurnBlock: new prom.Gauge({
         name: 'stacks_blocks_in_previous_burn_block',
         help: 'Number of Stacks blocks produced in the previous burn block',
-        collect: async () => {
-          metrics?.blocksInPreviousBurnBlock.set(await db.getStacksBlockCountAtPreviousBurnBlock());
+        async collect() {
+          this.set(await db.getStacksBlockCountAtPreviousBurnBlock());
         },
       }),
     };


### PR DESCRIPTION
Observe the following metric:

- `stacks_blocks_in_previous_burn_block`: Number of Stacks blocks produced in previous Bitcoin block

This will help us create alerts for when a Bitcoin block gap happens or blocks stop being produced. We also update the chain tip `burn_block_height` with each new burn block event.