### PR TITLE
fix: make tx_total_size column nullable

### DIFF
--- a/migrations/1737567411419_block-tx-total-size.js
+++ b/migrations/1737567411419_block-tx-total-size.js
@@ -6,18 +6,8 @@ exports.up = pgm => {
   pgm.addColumn('blocks', {
     tx_total_size: {
       type: 'int',
-      notNull: true,
-      default: 0,
     },
   });
-  pgm.sql(`
-    UPDATE blocks
-    SET tx_total_size = (
-      SELECT SUM(OCTET_LENGTH(raw_tx))
-      FROM txs
-      WHERE index_block_hash = blocks.index_block_hash
-    )  
-  `);
 };
 
 exports.down = pgm => {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -22,7 +22,7 @@ export interface DbBlock {
   execution_cost_runtime: number;
   execution_cost_write_count: number;
   execution_cost_write_length: number;
-  tx_total_size: number;
+  tx_total_size: number | null;
   tx_count: number;
   block_time: number;
   signer_bitvec: string | null;
@@ -863,7 +863,7 @@ export interface BlockQueryResult {
   execution_cost_runtime: string;
   execution_cost_write_count: string;
   execution_cost_write_length: string;
-  tx_total_size: number;
+  tx_total_size: number | null;
   tx_count: number;
   signer_bitvec: string | null;
   tenure_height: number | null;
@@ -1289,7 +1289,7 @@ export interface BlockInsertValues {
   execution_cost_runtime: number;
   execution_cost_write_count: number;
   execution_cost_write_length: number;
-  tx_total_size: number;
+  tx_total_size: number | null;
   tx_count: number;
   signer_bitvec: string | null;
   signer_signatures: PgBytea[] | null;


### PR DESCRIPTION
Since we just need it for fee estimations, it's ok if this column remains null for past blocks