### PR TITLE
fix: Information exposure through a stack trace

### DIFF
--- a/src/inspector-util.ts
+++ b/src/inspector-util.ts
@@ -415,8 +415,8 @@ export async function startProfilerServer(httpServerPort?: number | string): Pro
     try {
       profilerResults = stopProfiler();
     } catch (error: any) {
-      console.error(error);
-      res.status(500).end(error);
+      logger.error("Exception occurred", error);
+      res.status(500).end("An internal server error occurred");
       return;
     }
     const fileName = `profile-${Date.now()}.svg`;


### PR DESCRIPTION
## Ticket 🎟️ #2238
fix the problem, we need to ensure that the stack trace or any sensitive information contained in the error object is not sent to the client. Instead, we should log the error on the server and send a generic error message to the client. This can be achieved by modifying the catch blocks to log the error and send a generic message.

1. Modify the catch block on line 417 to log the error and send a generic error message.
2. Ensure that the error logging mechanism is in place (e.g., using the `logger` module).


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @rafaelcr or @zone117x for review
