### PR TITLE
feat: endpoint to get the balance of a specific ft for a given account

### DIFF
--- a/src/datastore/pg-store-v2.ts
+++ b/src/datastore/pg-store-v2.ts
@@ -1054,6 +1054,26 @@ export class PgStoreV2 extends BasePgStoreModule {
     };
   }
 
+  async getFtHolderBalance(args: {
+    sql: PgSqlClient;
+    stxAddress: string;
+    token: string;
+  }): Promise<FoundOrNot<{ balance: bigint }>> {
+    const [result] = await args.sql<{ balance: string }[]>`
+      SELECT token, balance FROM ft_balances
+      WHERE address = ${args.stxAddress}
+        AND token = ${args.token}
+      LIMIT 1
+    `;
+    if (!result) {
+      return { found: false };
+    }
+    return {
+      found: true,
+      result: { balance: BigInt(result.balance) },
+    };
+  }
+
   async getStxPoxLockedAtBlock({
     sql,
     stxAddress,

--- a/tests/api/address.test.ts
+++ b/tests/api/address.test.ts
@@ -1686,6 +1686,27 @@ describe('address tests', () => {
       results: [{ token: 'gox', balance: '585' }],
     });
 
+    const fetchAddrV2BalanceFt1 = await supertest(api.server).get(
+      `/extended/v2/addresses/${testContractAddr}/balances/ft/bux`
+    );
+    expect(fetchAddrV2BalanceFt1.status).toBe(200);
+    expect(fetchAddrV2BalanceFt1.type).toBe('application/json');
+    expect(fetchAddrV2BalanceFt1.body).toEqual({ balance: '375' });
+
+    const fetchAddrV2BalanceFt2 = await supertest(api.server).get(
+      `/extended/v2/addresses/${testContractAddr}/balances/ft/gox`
+    );
+    expect(fetchAddrV2BalanceFt2.status).toBe(200);
+    expect(fetchAddrV2BalanceFt2.type).toBe('application/json');
+    expect(fetchAddrV2BalanceFt2.body).toEqual({ balance: '585' });
+
+    const fetchAddrV2BalanceFt3 = await supertest(api.server).get(
+      `/extended/v2/addresses/${testContractAddr}/balances/ft/none`
+    );
+    expect(fetchAddrV2BalanceFt3.status).toBe(200);
+    expect(fetchAddrV2BalanceFt3.type).toBe('application/json');
+    expect(fetchAddrV2BalanceFt3.body).toEqual({ balance: '0' });
+
     const tokenLocked: DbTokenOfferingLocked = {
       address: testContractAddr,
       value: BigInt(4139391122),


### PR DESCRIPTION
In https://github.com/hirosystems/stacks-blockchain-api/pull/2229 we made the new `:addr/balances/ft` endpoint paginated. In some use cases, the deprecated "get all FT balances" endpoint was being used to lookup a single FT balance, which could now require multiple paginated requests using the new endpoint. 

This PR adds a new endpoint to get the balance of a specific FT for a given address:
```
GET /extended/v2/addresses/:addr/balances/ft/:token
```

Example:
```
GET /extended/v2/addresses/SPQC38PW542EQJ5M11CR25P7BS1CA6QT4TBXGB3M/balances/ft/SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc-token
```
```json
{
  "balance": "481723"
}
```