### PR TITLE
feat: mark /mempool/dropped endpoint as legacy deprecated

### DIFF
--- a/.env
+++ b/.env
@@ -158,6 +158,9 @@ STACKS_NODE_TYPE=L1
 # Enable FT metadata processing for Rosetta operations display. Disabled by default.
 # STACKS_API_ENABLE_FT_METADATA=1
 
+# Enable legacy API endpoints. Disabled by default.
+# STACKS_API_ENABLE_LEGACY_ENDPOINTS=1
+
 # The Rosetta API endpoints require FT metadata to display operations with the proper `symbol` and
 # `decimals` values. If FT metadata is enabled, this variable controls the token metadata error
 # handling mode when metadata is not found.

--- a/tests/api/setup.ts
+++ b/tests/api/setup.ts
@@ -8,5 +8,6 @@ export default (): void => {
   }
   loadDotEnv();
   process.env.PG_DATABASE = 'postgres';
+  process.env.STACKS_API_ENABLE_LEGACY_ENDPOINTS = '1';
   console.log('Jest - setup done');
 };


### PR DESCRIPTION
Users with their own deployments can still enable this by setting `STACKS_API_ENABLE_LEGACY_ENDPOINTS` as true in their ENV.