### PR TITLE
fix: optimize contract event list db index

### DIFF
--- a/migrations/1744989709876_contract-logs-events-index.js
+++ b/migrations/1744989709876_contract-logs-events-index.js
@@ -1,0 +1,47 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = pgm => {
+  pgm.dropIndex('contract_logs', 'contract_identifier');
+  pgm.dropIndex('contract_logs', [
+    { name: 'block_height', sort: 'DESC' },
+    { name: 'microblock_sequence', sort: 'DESC' },
+    { name: 'tx_index', sort: 'DESC' },
+    { name: 'event_index', sort: 'DESC' },
+  ]);
+
+  pgm.createIndex(
+    'contract_logs',
+    [
+      'contract_identifier',
+      { name: 'block_height', sort: 'DESC' },
+      { name: 'microblock_sequence', sort: 'DESC' },
+      { name: 'tx_index', sort: 'DESC' },
+      { name: 'event_index', sort: 'DESC' },
+    ],
+    { where: 'canonical = TRUE AND microblock_canonical = TRUE' }
+  );
+};
+
+exports.down = pgm => {
+  pgm.dropIndex(
+    'contract_logs',
+    [
+      'contract_identifier',
+      { name: 'block_height', sort: 'DESC' },
+      { name: 'microblock_sequence', sort: 'DESC' },
+      { name: 'tx_index', sort: 'DESC' },
+      { name: 'event_index', sort: 'DESC' },
+    ],
+    { where: 'canonical = TRUE AND microblock_canonical = TRUE' }
+  );
+
+  pgm.createIndex('contract_logs', 'contract_identifier');
+  pgm.createIndex('contract_logs', [
+    { name: 'block_height', sort: 'DESC' },
+    { name: 'microblock_sequence', sort: 'DESC' },
+    { name: 'tx_index', sort: 'DESC' },
+    { name: 'event_index', sort: 'DESC' },
+  ]);
+};


### PR DESCRIPTION
Optimizes the `/extended/v1/contract/${contractId}/events` endpoint by combining two indexes into one, which prevents the query planner from picking a sub-optimal index and then doing a filter. The planner will use this new index instead, optimizing query response times by ~99%.