### PR TITLE
fix: ignore unanchored param for BNS names endpoint

### DIFF
--- a/tests/bns/api.test.ts
+++ b/tests/bns/api.test.ts
@@ -513,7 +513,9 @@ describe('BNS API tests', () => {
       [dbName2]
     );
 
-    const query1 = await supertest(api.server).get(`/v1/addresses/${blockchain}/${address}`);
+    const query1 = await supertest(api.server).get(
+      `/v1/addresses/${blockchain}/${address}?unanchored=true`
+    );
     expect(query1.status).toBe(200);
     expect(query1.body.names).toStrictEqual(['imported.btc', 'test-name.btc']);
     expect(query1.type).toBe('application/json');


### PR DESCRIPTION
Fixes 500 status error:
```
relation "nft_custody_unanchored" does not exist -> /v1/addresses/stacks/SP2E4MERK02YV3J5MC6SHT1XRVANEJ5DRD80NB3FV?unanchored=true -> 500 -> GET
```
We dropped the `nft_custody_unanchored` table a while ago because we no longer support microblocks.