### PR TITLE
fix: keep a table of latest stacks node event timestamps

### DIFF
--- a/migrations/1745877592337_event-observer-timestamps.js
+++ b/migrations/1745877592337_event-observer-timestamps.js
@@ -1,0 +1,20 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = pgm => {
+  pgm.createTable('event_observer_timestamps', {
+    event_path: {
+      type: 'string',
+      primaryKey: true,
+    },
+    id: {
+      type: 'bigint',
+      notNull: true,
+    },
+    receive_timestamp: {
+      type: 'timestamptz',
+      notNull: true,
+    },
+  });
+};

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -4684,9 +4684,7 @@ export class PgStore extends BasePgStore {
   /// by event type.
   async getLastStacksNodeEventTimestamps() {
     return await this.sql<{ event_path: string; receive_timestamp: Date }[]>`
-      SELECT DISTINCT ON (event_path) event_path, receive_timestamp
-      FROM event_observer_requests
-      ORDER BY event_path, receive_timestamp DESC
+      SELECT event_path, receive_timestamp FROM event_observer_timestamps
     `;
   }
 }


### PR DESCRIPTION
Optimizes the query which retrieves the latest Stacks node event timestamps for Prometheus metrics (currently taking ~3,000ms to complete) by creating a new table that pre-computes the required values.