### PR TITLE
fix: adjust contract ABI writes to read from contract_interface key instead of contract_abi

### DIFF
--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -240,7 +240,7 @@ export interface CoreNodeTxMessage {
   raw_result: string;
   txid: string;
   tx_index: number;
-  contract_abi: ClarityAbi | null;
+  contract_interface: ClarityAbi | null;
   execution_cost: CoreNodeExecutionCostMessage;
   microblock_sequence: number | null;
   microblock_hash: string | null;

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -287,7 +287,7 @@ function parseDataStoreTxEventData(
           block_height: blockData.block_height,
           clarity_version: clarityVersion,
           source_code: tx.parsed_tx.payload.code_body,
-          abi: JSON.stringify(tx.core_tx.contract_abi),
+          abi: JSON.stringify(tx.core_tx.contract_interface),
           canonical: true,
         });
         break;

--- a/tests/api/address.test.ts
+++ b/tests/api/address.test.ts
@@ -2514,7 +2514,7 @@ describe('address tests', () => {
         raw_result: '0x0100000000000000000000000000000001', // u1
         txid: '0x' + txBuilder.txid(),
         tx_index: 2,
-        contract_abi: null,
+        contract_interface: null,
         microblock_hash: null,
         microblock_parent_hash: null,
         microblock_sequence: null,

--- a/tests/api/tx.test.ts
+++ b/tests/api/tx.test.ts
@@ -384,7 +384,7 @@ describe('tx tests', () => {
         raw_result: '0x0100000000000000000000000000000001', // u1
         txid: tx.tx_id,
         tx_index: 2,
-        contract_abi: abiSample,
+        contract_interface: abiSample,
         microblock_hash: null,
         microblock_parent_hash: null,
         microblock_sequence: null,
@@ -543,7 +543,7 @@ describe('tx tests', () => {
         raw_result: '0x0100000000000000000000000000000001', // u1
         txid: tx.tx_id,
         tx_index: 2,
-        contract_abi: null,
+        contract_interface: null,
         microblock_hash: null,
         microblock_parent_hash: null,
         microblock_sequence: null,
@@ -692,7 +692,7 @@ describe('tx tests', () => {
         raw_result: '0x0100000000000000000000000000000001', // u1
         txid: tx.tx_id,
         tx_index: 2,
-        contract_abi: null,
+        contract_interface: null,
         microblock_hash: null,
         microblock_parent_hash: null,
         microblock_sequence: null,
@@ -852,7 +852,7 @@ describe('tx tests', () => {
         raw_result: '0x0100000000000000000000000000000001', // u1
         txid: '0x' + txBuilder.txid(),
         tx_index: 2,
-        contract_abi: null,
+        contract_interface: null,
         microblock_hash: null,
         microblock_parent_hash: null,
         microblock_sequence: null,
@@ -1076,7 +1076,7 @@ describe('tx tests', () => {
         raw_result: '0x0100000000000000000000000000000001', // u1
         txid: '0x' + txBuilder.txid(),
         tx_index: 2,
-        contract_abi: null,
+        contract_interface: null,
         microblock_hash: null,
         microblock_parent_hash: null,
         microblock_sequence: null,
@@ -1480,7 +1480,7 @@ describe('tx tests', () => {
         raw_result: '0x0100000000000000000000000000000001', // u1
         txid: '0x' + txBuilder.txid(),
         tx_index: 2,
-        contract_abi: null,
+        contract_interface: null,
         microblock_hash: null,
         microblock_parent_hash: null,
         microblock_sequence: null,
@@ -1713,7 +1713,7 @@ describe('tx tests', () => {
         status: 'abort_by_response',
         txid: '0x' + txBuilder.txid(),
         tx_index: 2,
-        contract_abi: null,
+        contract_interface: null,
         microblock_hash: null,
         microblock_parent_hash: null,
         microblock_sequence: null,
@@ -1869,7 +1869,7 @@ describe('tx tests', () => {
         status: 'abort_by_post_condition',
         txid: '0x' + txBuilder.txid(),
         tx_index: 2,
-        contract_abi: null,
+        contract_interface: null,
         microblock_hash: null,
         microblock_parent_hash: null,
         microblock_sequence: null,


### PR DESCRIPTION
Stacks core changed the name of the key for this data from `contract_abi` to `contract_interface` in `/new_block` events. This PR reads from the new field.

A replay or a manual backfill will be necessary to get all the missing ABIs from recently deployed contracts.