### PR TITLE
fix: count stx mint data at block 0 towards account balances

### DIFF
--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -208,7 +208,10 @@ export class PgWriteStore extends PgStore {
     await this.sqlWriteTransaction(async sql => {
       const chainTip = await this.getChainTip(sql);
       await this.handleReorg(sql, data.block, chainTip.block_height);
-      const isCanonical = data.block.block_height > chainTip.block_height;
+      // Our `chain_tip` table starts at zero, so we need to add a special check to make sure the
+      // block 0 boot data received from the Stacks node is considered canonical.
+      const isCanonical =
+        data.block.block_height == 0 || data.block.block_height > chainTip.block_height;
       if (!isCanonical) {
         markBlockUpdateDataAsNonCanonical(data);
       } else {

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -208,10 +208,7 @@ export class PgWriteStore extends PgStore {
     await this.sqlWriteTransaction(async sql => {
       const chainTip = await this.getChainTip(sql);
       await this.handleReorg(sql, data.block, chainTip.block_height);
-      // Our `chain_tip` table starts at zero, so we need to add a special check to make sure the
-      // block 0 boot data received from the Stacks node is considered canonical.
-      const isCanonical =
-        data.block.block_height == 0 || data.block.block_height > chainTip.block_height;
+      const isCanonical = data.block.block_height > chainTip.block_height;
       if (!isCanonical) {
         markBlockUpdateDataAsNonCanonical(data);
       } else {
@@ -287,7 +284,9 @@ export class PgWriteStore extends PgStore {
       if ((await this.updateBlock(sql, data.block)) !== 0) {
         const q = new PgWriteQueue();
         q.enqueue(() => this.updateMinerRewards(sql, data.minerRewards));
-        if (isCanonical) {
+        // Block 0 is non-canonical, but we need to make sure its STX mint events get considered in
+        // balance calculations.
+        if (data.block.block_height == 0 || isCanonical) {
           // Use `data.txs` directly instead of `newTxData` for these STX/FT balance updates because
           // we don't want to skip balance changes in transactions that were previously confirmed
           // via microblocks.

--- a/tests/2.5/block-zero-handling.test.ts
+++ b/tests/2.5/block-zero-handling.test.ts
@@ -175,5 +175,18 @@ describe('Block-zero event handling', () => {
     const firstMintEvent = mintTxEvents.filter(r => r.event_index === 0)[0];
     expect(firstMintEvent).toBeDefined();
     expect(firstMintEvent).toEqual(stxMintEvent);
+
+    // Compare balance endpoints for receiver address
+    const address = firstMintEvent.asset.recipient;
+    let result = await supertest(testEnv.api.server).get(`/extended/v1/address/${address}/stx`);
+    expect(result.status).toBe(200);
+    expect(result.type).toBe('application/json');
+    const v1balance = JSON.parse(result.text).balance;
+    result = await supertest(testEnv.api.server).get(
+      `/extended/v2/addresses/${address}/balances/stx`
+    );
+    expect(result.status).toBe(200);
+    expect(result.type).toBe('application/json');
+    expect(JSON.parse(result.text).balance).toBe(v1balance);
   });
 });


### PR DESCRIPTION
Our `chain_tip` table starts with `block_height` at zero, so when the API received the block 0 boot data from the Stacks node it is always marked as non-canonical.

This affected FT balance calculations because STX mint events contained within were not being considered, especially in devnet or testnet deployments where devs were configuring `[[ustx_balance]]` settings in their Stacks nodes.

This PR makes it so block 0 STX mint data is always considered for balances.

Related to #2267