### PR TITLE
fix: only ingest snp chain events to avoid db bloat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@fastify/swagger": "8.15.0",
         "@fastify/type-provider-typebox": "4.0.0",
         "@hirosystems/api-toolkit": "1.9.0",
-        "@hirosystems/salt-n-pepper-client": "1.1.1",
+        "@hirosystems/salt-n-pepper-client": "1.1.2",
         "@scure/base": "1.1.1",
         "@sinclair/typebox": "0.32.35",
         "@stacks/common": "6.10.0",
@@ -1548,9 +1548,9 @@
       }
     },
     "node_modules/@hirosystems/salt-n-pepper-client": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@hirosystems/salt-n-pepper-client/-/salt-n-pepper-client-1.1.1.tgz",
-      "integrity": "sha512-xQqHAX0xIrpGFD9Hc4sqbSZ862vE1yDUT67RFv6ok7hd+OFJUNfCrfr+nMQJZK8qSt3jlmZJt/5R38+D6pQvvw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@hirosystems/salt-n-pepper-client/-/salt-n-pepper-client-1.1.2.tgz",
+      "integrity": "sha512-sExJxLdnkWmBcN08SyfKEmvRbrmlJDUvVsihHW5PbpfirPUBE9e66NaJAAp+GT86WGH+WbmDek5P+Ce6PWDULA==",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@hirosystems/api-toolkit": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@fastify/swagger": "8.15.0",
     "@fastify/type-provider-typebox": "4.0.0",
     "@hirosystems/api-toolkit": "1.9.0",
-    "@hirosystems/salt-n-pepper-client": "1.1.1",
+    "@hirosystems/salt-n-pepper-client": "1.1.2",
     "@scure/base": "1.1.1",
     "@sinclair/typebox": "0.32.35",
     "@stacks/common": "6.10.0",

--- a/src/event-stream/snp-event-stream.ts
+++ b/src/event-stream/snp-event-stream.ts
@@ -35,7 +35,7 @@ export class SnpEventStreamHandler {
     this.snpClientStream = new StacksEventStream({
       redisUrl: this.redisUrl,
       redisStreamPrefix: this.redisStreamPrefix,
-      eventStreamType: StacksEventStreamType.all,
+      eventStreamType: StacksEventStreamType.chainEvents,
       lastMessageId: opts.lastMessageId,
       appName,
     });

--- a/tests/snp/jest-global-setup.ts
+++ b/tests/snp/jest-global-setup.ts
@@ -223,7 +223,7 @@ export default async function setup(): Promise<void> {
     console.log(`Using REDIS_STREAM_KEY_PREFIX: ${process.env.SNP_REDIS_STREAM_KEY_PREFIX}`);
     const snpContainer = await startContainer({
       docker,
-      image: 'hirosystems/salt-n-pepper:1.1.1',
+      image: 'hirosystems/salt-n-pepper:1.1.2',
       ports: [{ container: snpObserverPort, host: snpHostPort }],
       env: [
         `OBSERVER_HOST=0.0.0.0`,


### PR DESCRIPTION
Ensures only relevant chain events are ingested when using SNP, as opposed to ingesting all events.
Tested and verified against the latest release of SNP as a part of https://github.com/hirosystems/salt-n-pepper/pull/28