### PR TITLE
fix: validate block cursor pagination parameter format

### DIFF
--- a/src/api/routes/v2/block-tenures.ts
+++ b/src/api/routes/v2/block-tenures.ts
@@ -5,7 +5,7 @@ import { handleBlockCache } from '../../../api/controllers/cache-controller';
 import { getPagingQueryLimit, ResourceType } from '../../../api/pagination';
 import { CursorOffsetParam, LimitParam } from '../../../api/schemas/params';
 import { BlockListV2ResponseSchema } from '../../../api/schemas/responses/responses';
-import { BlockTenureParamsSchema } from './schemas';
+import { BlockTenureParamsSchema, BlockCursorParamSchema } from './schemas';
 import { NotFoundError } from '../../../errors';
 import { NakamotoBlock } from '../../../api/schemas/entities/block';
 import { parseDbNakamotoBlock } from './helpers';
@@ -28,7 +28,7 @@ export const BlockTenureRoutes: FastifyPluginAsync<
         querystring: Type.Object({
           limit: LimitParam(ResourceType.Block),
           offset: CursorOffsetParam({ resource: ResourceType.Block }),
-          cursor: Type.Optional(Type.String({ description: 'Cursor for pagination' })),
+          cursor: Type.Optional(BlockCursorParamSchema),
         }),
         response: {
           200: BlockListV2ResponseSchema,

--- a/src/api/routes/v2/blocks.ts
+++ b/src/api/routes/v2/blocks.ts
@@ -1,5 +1,10 @@
 import { handleBlockCache, handleChainTipCache } from '../../../api/controllers/cache-controller';
-import { BlockParamsSchema, cleanBlockHeightOrHashParam, parseBlockParam } from './schemas';
+import {
+  BlockParamsSchema,
+  cleanBlockHeightOrHashParam,
+  BlockCursorParamSchema,
+  parseBlockParam,
+} from './schemas';
 import { parseDbNakamotoBlock } from './helpers';
 import { InvalidRequestError, NotFoundError } from '../../../errors';
 import { parseDbTx } from '../../../api/controllers/db-controller';
@@ -7,13 +12,9 @@ import { FastifyPluginAsync } from 'fastify';
 import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Server } from 'node:http';
 import { CursorOffsetParam, LimitParam, OffsetParam } from '../../schemas/params';
-import { getPagingQueryLimit, pagingQueryLimits, ResourceType } from '../../pagination';
+import { getPagingQueryLimit, ResourceType } from '../../pagination';
 import { PaginatedResponse } from '../../schemas/util';
-import {
-  NakamotoBlock,
-  NakamotoBlockSchema,
-  SignerSignatureSchema,
-} from '../../schemas/entities/block';
+import { NakamotoBlock, NakamotoBlockSchema } from '../../schemas/entities/block';
 import { TransactionSchema } from '../../schemas/entities/transactions';
 import {
   BlockListV2ResponseSchema,
@@ -37,7 +38,7 @@ export const BlockRoutesV2: FastifyPluginAsync<
         querystring: Type.Object({
           limit: LimitParam(ResourceType.Block),
           offset: CursorOffsetParam({ resource: ResourceType.Block }),
-          cursor: Type.Optional(Type.String({ description: 'Cursor for pagination' })),
+          cursor: Type.Optional(BlockCursorParamSchema),
         }),
         response: {
           200: BlockListV2ResponseSchema,

--- a/src/api/routes/v2/schemas.ts
+++ b/src/api/routes/v2/schemas.ts
@@ -71,6 +71,11 @@ export const PoxSignerLimitParamSchema = Type.Integer({
   description: 'PoX signers per page',
 });
 
+export const BlockCursorParamSchema = Type.String({
+  pattern: '^0x[a-fA-F0-9]{64}$',
+  description: 'Cursor for block pagination',
+});
+
 export type BlockIdParam =
   | { type: 'height'; height: number }
   | { type: 'hash'; hash: string }

--- a/tests/api/block.test.ts
+++ b/tests/api/block.test.ts
@@ -834,6 +834,10 @@ describe('block tests', () => {
     const latestPageCursor = body.cursor;
     const latestBlock = body.results[0];
 
+    // Cursor fetch is rejected if it's not a valid block hash
+    const req2 = await supertest(api.server).get(`/extended/v2/blocks?limit=3&cursor=testvalue`);
+    expect(req2.statusCode).toBe(400);
+
     // Can fetch same page using cursor
     ({ body } = await supertest(api.server).get(
       `/extended/v2/blocks?limit=3&cursor=${body.cursor}`


### PR DESCRIPTION
Enforce `cursor` parameter format so it is always a block hash string.

Fixes #2316 