### PR TITLE
fix: drop redundant db indexes

### DIFF
--- a/migrations/1753205522199_drop-duplicate-indexes.js
+++ b/migrations/1753205522199_drop-duplicate-indexes.js
@@ -8,3 +8,10 @@ exports.up = pgm => {
   pgm.dropIndex('mempool_txs', ['sponsor_address']);
   pgm.dropIndex('nft_events', ['asset_identifier']);
 };
+
+exports.down = pgm => {
+  pgm.createIndex('ft_balances', ['token']);
+  pgm.createIndex('mempool_txs', ['sender_address']);
+  pgm.createIndex('mempool_txs', ['sponsor_address']);
+  pgm.createIndex('nft_events', ['asset_identifier']);
+};

--- a/migrations/1753205522199_drop-duplicate-indexes.js
+++ b/migrations/1753205522199_drop-duplicate-indexes.js
@@ -1,0 +1,10 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = pgm => {
+  pgm.dropIndex('ft_balances', ['token']);
+  pgm.dropIndex('mempool_txs', ['sender_address']);
+  pgm.dropIndex('mempool_txs', ['sponsor_address']);
+  pgm.dropIndex('nft_events', ['asset_identifier']);
+};


### PR DESCRIPTION
Drops redundant indexes from several tables based on PgHero's recommendations:
```
On ft_balances ft_balances_token_index (token)
is covered by ft_balances_token_balance_index (token, balance DESC)

On mempool_txs mempool_txs_sender_address_index (sender_address)
is covered by mempool_txs_sender_address_nonce_index (sender_address, nonce)

On mempool_txs mempool_txs_sponsor_address_index (sponsor_address)
is covered by mempool_txs_sponsor_address_nonce_index (sponsor_address, nonce)

On nft_events nft_events_asset_identifier_index (asset_identifier)
is covered by nft_events_asset_identifier_value_index (asset_identifier, value)
```