### PR TITLE
fix: include nakamoto coinbase txs on coinbase txs filter

### DIFF
--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -168,7 +168,7 @@ export function getTxTypeId(typeString: Transaction['tx_type']): DbTxTypeId[] {
     case 'poison_microblock':
       return [DbTxTypeId.PoisonMicroblock];
     case 'coinbase':
-      return [DbTxTypeId.Coinbase, DbTxTypeId.CoinbaseToAltRecipient];
+      return [DbTxTypeId.Coinbase, DbTxTypeId.CoinbaseToAltRecipient, DbTxTypeId.NakamotoCoinbase];
     case 'tenure_change':
       return [DbTxTypeId.TenureChange];
     default:

--- a/tests/api/tx.test.ts
+++ b/tests/api/tx.test.ts
@@ -2716,43 +2716,6 @@ describe('tx tests', () => {
       .build();
     await db.update(block4);
 
-    // Ensure chain_tip reflects latest height for maxHeight filtering
-    const txCountRes = await client<{ count: number }[]>`
-      SELECT COUNT(*)::integer AS count FROM txs
-    `;
-    const txCount = txCountRes[0]?.count ?? 0;
-    await client`
-      INSERT INTO chain_tip (
-        id,
-        block_height,
-        block_hash,
-        index_block_hash,
-        burn_block_height,
-        block_count,
-        microblock_count,
-        tx_count,
-        tx_count_unanchored
-      ) VALUES (
-        true,
-        ${block4.block.block_height},
-        ${block4.block.block_hash},
-        ${block4.block.index_block_hash},
-        ${block4.block.burn_block_height},
-        ${block4.block.block_height},
-        0,
-        ${txCount},
-        ${txCount}
-      )
-      ON CONFLICT (id) DO UPDATE SET
-        block_height = EXCLUDED.block_height,
-        block_hash = EXCLUDED.block_hash,
-        index_block_hash = EXCLUDED.index_block_hash,
-        burn_block_height = EXCLUDED.burn_block_height,
-        block_count = EXCLUDED.block_count,
-        tx_count = EXCLUDED.tx_count,
-        tx_count_unanchored = EXCLUDED.tx_count_unanchored
-    `;
-
     const filterTypes: TransactionType[] = ['coinbase', 'poison_microblock', 'token_transfer'];
     const txsReq1 = await supertest(api.server).get(
       `/extended/v1/tx?type=${filterTypes.join(',')}`

--- a/tests/api/tx.test.ts
+++ b/tests/api/tx.test.ts
@@ -2704,14 +2704,16 @@ describe('tx tests', () => {
       parent_block_hash: block3.block.block_hash,
       parent_index_block_hash: block3.block.index_block_hash,
       burn_block_time: 1740000000,
-    }).addTx({
+    })
+      .addTx({
         tx_id: '0x4234',
         fee_rate: 4n,
         sender_address: testSendertAddr,
         nonce: 4,
         type_id: DbTxTypeId.NakamotoCoinbase,
         coinbase_vrf_proof: '0x01',
-      }).build();
+      })
+      .build();
     await db.update(block4);
 
     // Ensure chain_tip reflects latest height for maxHeight filtering


### PR DESCRIPTION
For details refer to issue [#2323](https://github.com/hirosystems/stacks-blockchain-api/issues/2323)

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No.

## Are documentation updates required?
No.

## Testing information

Provide context on how tests should be performed.
Steps to reproduce the bug are on the issue referenced.
```
docker compose -f docker/docker-compose.dev.postgres.yml up -d
npm run test -- --config ./tests/jest.config.api.js tests/api/tx.test.ts -t "tx list - filter by tx-type" --runInBand
```