### PR TITLE
fix: pox cycle signer stackers query pagination

### DIFF
--- a/src/datastore/pg-store-v2.ts
+++ b/src/datastore/pg-store-v2.ts
@@ -966,7 +966,7 @@ export class PgStoreV2 extends BasePgStoreModule {
         WHERE ps.canonical = TRUE 
           AND ps.cycle_number = ${cycleNumber} 
           AND ps.signing_key = ${signerKey}
-        ORDER BY locked DESC
+        ORDER BY locked DESC, stacker ASC
         LIMIT ${limit}
         OFFSET ${offset}
       `;


### PR DESCRIPTION
The `ORDER BY` statement was incomplete as it only sorted by stacked amount. If multiple stackers were stacking the exact same STX, pagination could cause some of them to be missing or appear duplicate in endpoint results.

Fixes #2054
Fixes #2022