### PR TITLE
feat: v3 STX supply endpoint backed by a materialized `chain_tip` counter

### DIFF
--- a/migrations/1779800000009_chain-tip-stx-supply.ts
+++ b/migrations/1779800000009_chain-tip-stx-supply.ts
@@ -1,0 +1,49 @@
+import type { ColumnDefinitions, MigrationBuilder } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+/**
+ * Materialized total liquid STX supply (µSTX) as a single counter on `chain_tip`,
+ * so reading the supply is a single-row lookup instead of a full-table aggregate
+ * over `stx_events` and `miner_rewards` on every request (what the v1 endpoint
+ * does).
+ *
+ * supply = mints − burns + matured miner coinbase rewards
+ *
+ * Maintained incrementally on block ingestion and delta-corrected on reorg,
+ * mirroring the `ft_balances` 'stx' updates (which cover the same event set).
+ */
+export function up(pgm: MigrationBuilder): void {
+  pgm.addColumn('chain_tip', {
+    stx_supply: {
+      type: 'numeric',
+      notNull: true,
+      default: 0,
+    },
+  });
+  // One-time backfill from the event tables.
+  pgm.sql(`
+    UPDATE chain_tip SET stx_supply = (
+      SELECT SUM(amount)
+      FROM (
+          SELECT COALESCE(SUM(amount), 0) amount
+          FROM stx_events
+          WHERE canonical = true AND microblock_canonical = true
+          AND asset_event_type_id = 2 -- Mint
+        UNION ALL
+          SELECT COALESCE(SUM(amount), 0) * -1 amount
+          FROM stx_events
+          WHERE canonical = true AND microblock_canonical = true
+          AND asset_event_type_id = 3 -- Burn
+        UNION ALL
+          SELECT COALESCE(SUM(coinbase_amount), 0) amount
+          FROM miner_rewards
+          WHERE canonical = true
+      ) totals
+    )
+  `);
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropColumn('chain_tip', 'stx_supply');
+}

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -9,7 +9,7 @@ import { BlockRoutes } from './routes/v1/block.js';
 import { FaucetRoutes } from './routes/v1/faucets.js';
 import { AddressRoutes } from './routes/v1/address.js';
 import { SearchRoutes } from './routes/v1/search.js';
-import { StxSupplyRoutes } from './routes/v1/stx-supply.js';
+import { StxSupplyRoutes as StxSupplyRoutesV1 } from './routes/v1/stx-supply.js';
 import { ChainID } from '../helpers.js';
 import { BurnchainRoutes } from './routes/v1/burnchain.js';
 import { BnsNamespaceRoutes } from './routes/v1/bns/namespaces.js';
@@ -56,6 +56,7 @@ import { BlocksRoutes } from './routes/v3/blocks.js';
 import { StakingBondsRoutes } from './routes/v3/staking-bonds.js';
 import { StakingCyclesRoutes } from './routes/v3/staking-cycles.js';
 import { StakingSignersRoutes } from './routes/v3/staking-signers.js';
+import { StxSupplyRoutes } from './routes/v3/stx-supply.js';
 
 export interface ApiServer {
   fastifyApp: FastifyInstance;
@@ -76,7 +77,7 @@ export const StacksApiRoutes: FastifyPluginAsync<
   await fastify.register(
     async fastify => {
       await fastify.register(TxRoutes, { prefix: '/tx' });
-      await fastify.register(StxSupplyRoutes, { prefix: '/stx_supply' });
+      await fastify.register(StxSupplyRoutesV1, { prefix: '/stx_supply' });
       await fastify.register(InfoRoutes, { prefix: '/info' });
       await fastify.register(TokenRoutes, { prefix: '/tokens' });
       await fastify.register(ContractRoutes, { prefix: '/contract' });
@@ -114,6 +115,7 @@ export const StacksApiRoutes: FastifyPluginAsync<
       await fastify.register(StakingBondsRoutes);
       await fastify.register(StakingCyclesRoutes);
       await fastify.register(StakingSignersRoutes);
+      await fastify.register(StxSupplyRoutes);
       await fastify.register(TransactionsRoutes);
     },
     { prefix: '/extended/v3' }

--- a/src/api/routes/v1/stx-supply.ts
+++ b/src/api/routes/v1/stx-supply.ts
@@ -50,9 +50,10 @@ export const StxSupplyRoutes: FastifyPluginAsync<
     {
       preHandler: handleChainTipCache,
       schema: {
+        deprecated: true,
         operationId: 'get_stx_supply',
         summary: 'Get total and unlocked STX supply',
-        description: `Retrieves the total and unlocked STX supply. More information on Stacking can be found [here] (https://docs.stacks.co/block-production/stacking).`,
+        description: `Retrieves the total and unlocked STX supply. More information on Stacking can be found [here] (https://docs.stacks.co/block-production/stacking). **This endpoint is deprecated in favor of the v3 \`get_stx_total_supply\` endpoint (\`/extended/v3/stx/supply\`), which returns amounts in micro-STX (µSTX).**`,
         tags: ['Info'],
         querystring: Type.Object({
           height: Type.Optional(
@@ -123,7 +124,7 @@ export const StxSupplyRoutes: FastifyPluginAsync<
         operationId: 'get_stx_supply_total_supply_plain',
         summary: 'Get total STX supply in plain text format',
         description:
-          'Retrieves the total circulating STX token supply as plain text. **This endpoint is deprecated in favor of `get_stx_supply`.**',
+          'Retrieves the total circulating STX token supply as plain text. **This endpoint is deprecated in favor of the v3 `get_stx_total_supply` endpoint (`/extended/v3/stx/supply`), which returns amounts in micro-STX (µSTX).**',
         tags: ['Info'],
         response: {
           200: {
@@ -151,7 +152,7 @@ export const StxSupplyRoutes: FastifyPluginAsync<
         operationId: 'get_stx_supply_circulating_plain',
         summary: 'Get circulating STX supply in plain text format',
         description:
-          'Retrieves the STX tokens currently in circulation that have been unlocked as plain text. **This endpoint is deprecated in favor of `get_stx_supply`.**',
+          'Retrieves the STX tokens currently in circulation that have been unlocked as plain text. **This endpoint is deprecated in favor of the v3 `get_stx_total_supply` endpoint (`/extended/v3/stx/supply`), which returns amounts in micro-STX (µSTX).**',
         tags: ['Info'],
         response: {
           200: {
@@ -180,7 +181,7 @@ export const StxSupplyRoutes: FastifyPluginAsync<
         summary:
           'Get total and unlocked STX supply (results formatted the same as the legacy 1.0 API)',
         description:
-          'Retrieves total supply of STX tokens including those currently in circulation that have been unlocked. **This endpoint is deprecated in favor of `get_stx_supply`.**',
+          'Retrieves total supply of STX tokens including those currently in circulation that have been unlocked. **This endpoint is deprecated in favor of the v3 `get_stx_total_supply` endpoint (`/extended/v3/stx/supply`), which returns amounts in micro-STX (µSTX).**',
         tags: ['Info'],
         querystring: Type.Object({
           height: Type.Optional(

--- a/src/api/routes/v1/stx-supply.ts
+++ b/src/api/routes/v1/stx-supply.ts
@@ -53,7 +53,7 @@ export const StxSupplyRoutes: FastifyPluginAsync<
         deprecated: true,
         operationId: 'get_stx_supply',
         summary: 'Get total and unlocked STX supply',
-        description: `Retrieves the total and unlocked STX supply. More information on Stacking can be found [here] (https://docs.stacks.co/block-production/stacking). **This endpoint is deprecated in favor of the v3 \`get_stx_total_supply\` endpoint (\`/extended/v3/stx/supply\`), which returns amounts in micro-STX (µSTX).**`,
+        description: `Retrieves the total and unlocked STX supply. More information on Stacking can be found [here] (https://docs.stacks.co/block-production/stacking). **This endpoint is deprecated in favor of the v3 \`get_stx_total_supply\` endpoint (\`/extended/v3/tokens/stx/supply\`), which returns amounts in micro-STX (µSTX).**`,
         tags: ['Info'],
         querystring: Type.Object({
           height: Type.Optional(
@@ -124,7 +124,7 @@ export const StxSupplyRoutes: FastifyPluginAsync<
         operationId: 'get_stx_supply_total_supply_plain',
         summary: 'Get total STX supply in plain text format',
         description:
-          'Retrieves the total circulating STX token supply as plain text. **This endpoint is deprecated in favor of the v3 `get_stx_total_supply` endpoint (`/extended/v3/stx/supply`), which returns amounts in micro-STX (µSTX).**',
+          'Retrieves the total circulating STX token supply as plain text. **This endpoint is deprecated in favor of the v3 `get_stx_total_supply` endpoint (`/extended/v3/tokens/stx/supply`), which returns amounts in micro-STX (µSTX).**',
         tags: ['Info'],
         response: {
           200: {
@@ -152,7 +152,7 @@ export const StxSupplyRoutes: FastifyPluginAsync<
         operationId: 'get_stx_supply_circulating_plain',
         summary: 'Get circulating STX supply in plain text format',
         description:
-          'Retrieves the STX tokens currently in circulation that have been unlocked as plain text. **This endpoint is deprecated in favor of the v3 `get_stx_total_supply` endpoint (`/extended/v3/stx/supply`), which returns amounts in micro-STX (µSTX).**',
+          'Retrieves the STX tokens currently in circulation that have been unlocked as plain text. **This endpoint is deprecated in favor of the v3 `get_stx_total_supply` endpoint (`/extended/v3/tokens/stx/supply`), which returns amounts in micro-STX (µSTX).**',
         tags: ['Info'],
         response: {
           200: {
@@ -181,7 +181,7 @@ export const StxSupplyRoutes: FastifyPluginAsync<
         summary:
           'Get total and unlocked STX supply (results formatted the same as the legacy 1.0 API)',
         description:
-          'Retrieves total supply of STX tokens including those currently in circulation that have been unlocked. **This endpoint is deprecated in favor of the v3 `get_stx_total_supply` endpoint (`/extended/v3/stx/supply`), which returns amounts in micro-STX (µSTX).**',
+          'Retrieves total supply of STX tokens including those currently in circulation that have been unlocked. **This endpoint is deprecated in favor of the v3 `get_stx_total_supply` endpoint (`/extended/v3/tokens/stx/supply`), which returns amounts in micro-STX (µSTX).**',
         tags: ['Info'],
         querystring: Type.Object({
           height: Type.Optional(

--- a/src/api/routes/v3/stx-supply.ts
+++ b/src/api/routes/v3/stx-supply.ts
@@ -1,0 +1,43 @@
+import { FastifyPluginAsync } from 'fastify';
+import { Server } from 'node:http';
+import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
+import { handleChainTipCache } from '../../controllers/cache-controller.js';
+import { StxSupplySchema } from '../../schemas/v3/entities/stx-supply.js';
+import { STACKS_DECIMAL_PLACES, TOTAL_STACKS_YEAR_2050 } from '../../../helpers.js';
+
+const TOTAL_MICRO_STX_YEAR_2050 =
+  TOTAL_STACKS_YEAR_2050.shiftedBy(STACKS_DECIMAL_PLACES).toFixed(0);
+
+export const StxSupplyRoutes: FastifyPluginAsync<
+  Record<never, never>,
+  Server,
+  TypeBoxTypeProvider
+> = async fastify => {
+  fastify.get(
+    '/stx/supply',
+    {
+      preHandler: handleChainTipCache,
+      schema: {
+        operationId: 'get_stx_total_supply',
+        summary: 'Get total STX supply',
+        description:
+          'Retrieves the total liquid STX supply in micro-STX (µSTX) at the current chain tip: ' +
+          'all STX minted (including vesting schedule unlocks) plus matured miner coinbase ' +
+          'rewards, minus burned STX.',
+        tags: ['Info'],
+        response: {
+          200: StxSupplySchema,
+        },
+      },
+    },
+    async (_req, reply) => {
+      const supply = await fastify.db.v3.getStxSupply();
+      await reply.send({
+        total: supply.stx_supply,
+        projected_total_2050: TOTAL_MICRO_STX_YEAR_2050,
+      });
+    }
+  );
+
+  await Promise.resolve();
+};

--- a/src/api/routes/v3/stx-supply.ts
+++ b/src/api/routes/v3/stx-supply.ts
@@ -14,7 +14,7 @@ export const StxSupplyRoutes: FastifyPluginAsync<
   TypeBoxTypeProvider
 > = async fastify => {
   fastify.get(
-    '/stx/supply',
+    '/tokens/stx/supply',
     {
       preHandler: handleChainTipCache,
       schema: {

--- a/src/api/schemas/v3/entities/stx-supply.ts
+++ b/src/api/schemas/v3/entities/stx-supply.ts
@@ -1,8 +1,10 @@
 import { Static, Type } from '@sinclair/typebox';
+import { AmountSchema } from './common.js';
 
 export const StxSupplySchema = Type.Object(
   {
     total: Type.String({
+      ...AmountSchema,
       description:
         'Total liquid STX supply as a string-quoted integer of micro-STX (µSTX): all STX ' +
         'minted (including vesting schedule unlocks) plus matured miner coinbase rewards, ' +
@@ -10,9 +12,10 @@ export const StxSupplySchema = Type.Object(
       examples: ['1470469916700000'],
     }),
     projected_total_2050: Type.String({
+      ...AmountSchema,
       description:
         'Projected total STX supply in the year 2050, as a string-quoted integer of micro-STX ' +
-        '(µSTX). STX supply grows approx 0.3% annually thereafter in perpetuity.',
+        '(µSTX).',
       examples: ['2318000000000000'],
     }),
   },

--- a/src/api/schemas/v3/entities/stx-supply.ts
+++ b/src/api/schemas/v3/entities/stx-supply.ts
@@ -1,0 +1,21 @@
+import { Static, Type } from '@sinclair/typebox';
+
+export const StxSupplySchema = Type.Object(
+  {
+    total: Type.String({
+      description:
+        'Total liquid STX supply as a string-quoted integer of micro-STX (µSTX): all STX ' +
+        'minted (including vesting schedule unlocks) plus matured miner coinbase rewards, ' +
+        'minus burned STX',
+      examples: ['1470469916700000'],
+    }),
+    projected_total_2050: Type.String({
+      description:
+        'Projected total STX supply in the year 2050, as a string-quoted integer of micro-STX ' +
+        '(µSTX). STX supply grows approx 0.3% annually thereafter in perpetuity.',
+      examples: ['2318000000000000'],
+    }),
+  },
+  { title: 'StxSupply' }
+);
+export type StxSupply = Static<typeof StxSupplySchema>;

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -1647,6 +1647,7 @@ export interface DbChainTip {
   tx_count_unanchored: number;
   mempool_tx_count: number;
   bond_count: number;
+  stx_supply: string;
 }
 
 export interface DbSmartContractStatus {

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -221,6 +221,7 @@ export class PgStore extends BasePgStore {
       tx_count_unanchored: tip?.tx_count_unanchored ?? 0,
       mempool_tx_count: tip?.mempool_tx_count ?? 0,
       bond_count: tip?.bond_count ?? 0,
+      stx_supply: tip?.stx_supply ?? '0',
     };
   }
 

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -384,6 +384,7 @@ export class PgWriteStore extends PgStore {
           // we don't want to skip balance changes in transactions that were previously confirmed
           // via microblocks.
           q.enqueue(() => this.updateStxBalances(sql, data.txs, data.minerRewards));
+          q.enqueue(() => this.updateStxSupply(sql, data.txs, data.minerRewards));
           q.enqueue(() => this.updateFtBalances(sql, data.txs));
           // If this block re-orgs past microblocks, though, we must discount the balances generated
           // by their txs which are now also reorged. We must do this here because the block re-org
@@ -2123,6 +2124,34 @@ export class PgWriteStore extends PgStore {
     }
   }
 
+  /**
+   * Advance the materialized total liquid STX supply counter on `chain_tip` with this block's
+   * delta: mints − burns + matured miner coinbase rewards. Reorg corrections are applied in
+   * `markEntitiesCanonical` and `updateFtBalancesFromMicroblockReOrg`, mirroring the
+   * `ft_balances` 'stx' updates.
+   */
+  async updateStxSupply(
+    sql: PgSqlClient,
+    entries: { stxEvents: DbStxEvent[] }[],
+    minerRewards: DbMinerReward[]
+  ) {
+    let delta = 0n;
+    for (const { stxEvents } of entries) {
+      for (const event of stxEvents) {
+        if (event.asset_event_type_id === DbAssetEventTypeId.Mint) {
+          delta += BigInt(event.amount);
+        } else if (event.asset_event_type_id === DbAssetEventTypeId.Burn) {
+          delta -= BigInt(event.amount);
+        }
+      }
+    }
+    for (const reward of minerRewards) {
+      delta += BigInt(reward.coinbase_amount);
+    }
+    if (delta === 0n) return;
+    await sql`UPDATE chain_tip SET stx_supply = stx_supply + ${delta.toString()}`;
+  }
+
   async updateFtBalances(sql: PgSqlClient, entries: { ftEvents: DbFtEvent[] }[]) {
     const balanceMap = new Map<string, { address: string; token: string; balance: bigint }>();
 
@@ -2267,14 +2296,29 @@ export class PgWriteStore extends PgStore {
             GROUP BY recipient
         ) AS subquery
         GROUP BY address
+      ),
+      update_balances AS (
+        INSERT INTO ft_balances (address, token, balance)
+        SELECT ec.address, 'stx', ec.balance_change
+        FROM event_changes ec
+        ON CONFLICT (address, token)
+        DO UPDATE
+        SET balance = ft_balances.balance + EXCLUDED.balance
+        RETURNING ft_balances.address
+      ),
+      supply_change AS (
+        SELECT SUM(
+          CASE asset_event_type_id
+            WHEN 2 THEN (CASE WHEN canonical AND microblock_canonical THEN amount ELSE -amount END) -- Mint
+            WHEN 3 THEN (CASE WHEN canonical AND microblock_canonical THEN -amount ELSE amount END) -- Burn
+            ELSE 0
+          END
+        ) AS delta
+        FROM updated_events
       )
-      INSERT INTO ft_balances (address, token, balance)
-      SELECT ec.address, 'stx', ec.balance_change
-      FROM event_changes ec
-      ON CONFLICT (address, token)
-      DO UPDATE
-      SET balance = ft_balances.balance + EXCLUDED.balance
-      RETURNING ft_balances.address
+      UPDATE chain_tip
+      SET stx_supply = stx_supply + (SELECT delta FROM supply_change)
+      WHERE EXISTS (SELECT 1 FROM supply_change WHERE delta IS NOT NULL)
     `;
   }
 
@@ -4611,8 +4655,17 @@ export class PgWriteStore extends PgStore {
           DO UPDATE
           SET balance = ft_balances.balance + EXCLUDED.balance
           RETURNING ft_balances.address
+        ),
+        supply_change AS (
+          SELECT SUM(CASE WHEN canonical THEN coinbase_amount ELSE -coinbase_amount END) AS delta
+          FROM updated_rewards
+        ),
+        update_stx_supply AS (
+          UPDATE chain_tip
+          SET stx_supply = stx_supply + (SELECT delta FROM supply_change)
+          WHERE EXISTS (SELECT 1 FROM supply_change WHERE delta IS NOT NULL)
         )
-        SELECT 
+        SELECT
           (SELECT COUNT(*)::int FROM updated_rewards) AS updated_rewards_count
       `;
       const updateCount = minerRewardResults[0]?.updated_rewards_count ?? 0;
@@ -4671,8 +4724,23 @@ export class PgWriteStore extends PgStore {
           DO UPDATE
           SET balance = ft_balances.balance + EXCLUDED.balance
           RETURNING ft_balances.address
+        ),
+        supply_change AS (
+          SELECT SUM(
+            CASE asset_event_type_id
+              WHEN 2 THEN (CASE WHEN canonical THEN amount ELSE -amount END) -- Mint
+              WHEN 3 THEN (CASE WHEN canonical THEN -amount ELSE amount END) -- Burn
+              ELSE 0
+            END
+          ) AS delta
+          FROM updated_events
+        ),
+        update_stx_supply AS (
+          UPDATE chain_tip
+          SET stx_supply = stx_supply + (SELECT delta FROM supply_change)
+          WHERE EXISTS (SELECT 1 FROM supply_change WHERE delta IS NOT NULL)
         )
-        SELECT 
+        SELECT
           (SELECT COUNT(*)::int FROM updated_events) AS updated_events_count
       `;
       const updateCount = stxResults[0]?.updated_events_count ?? 0;

--- a/src/datastore/v3/pg-store-v3.ts
+++ b/src/datastore/v3/pg-store-v3.ts
@@ -2015,4 +2015,15 @@ export class PgStoreV3 extends BasePgStoreModule {
       };
     });
   }
+
+  /**
+   * Gets the total liquid STX supply in µSTX, materialized on `chain_tip` by the write path
+   * (mints − burns + matured miner coinbase rewards).
+   */
+  async getStxSupply(): Promise<{ stx_supply: string }> {
+    const result = await this.sql<{ stx_supply: string }[]>`
+      SELECT stx_supply::text FROM chain_tip
+    `;
+    return { stx_supply: result[0]?.stx_supply ?? '0' };
+  }
 }

--- a/tests/api/datastore/datastore.test.ts
+++ b/tests/api/datastore/datastore.test.ts
@@ -4502,6 +4502,7 @@ describe('postgres datastore', () => {
       microblock_sequence: undefined,
       tx_count: 2, // Tx from block 2b does not count
       tx_count_unanchored: 2,
+      stx_supply: '2000', // Coinbase rewards from blocks 1 and 2
     });
     const namespaces = await db.getNamespaceList({ includeUnanchored: false });
     assert.equal(namespaces.results.length, 1);
@@ -4576,6 +4577,7 @@ describe('postgres datastore', () => {
       tx_count: 2,
       tx_count_unanchored: 2,
       mempool_tx_count: 0,
+      stx_supply: '2000',
     });
 
     const block4b: DbBlock = {
@@ -4633,6 +4635,7 @@ describe('postgres datastore', () => {
       tx_count: 2, // Tx from block 2b now counts, but compensates with tx from block 2
       tx_count_unanchored: 2,
       mempool_tx_count: 0,
+      stx_supply: '1000', // Block 2's coinbase reward was orphaned along with the block
     });
 
     const b1 = await db.getBlock({ hash: block1.block_hash });

--- a/tests/api/test-builders.ts
+++ b/tests/api/test-builders.ts
@@ -360,6 +360,7 @@ export function testMempoolTx(args?: TestMempoolTxArgs): DbMempoolTxRaw {
 
 interface TestStxEventArgs {
   amount?: bigint;
+  asset_event_type_id?: DbAssetEventTypeId;
   block_height?: number;
   event_index?: number;
   recipient?: string;
@@ -375,17 +376,21 @@ interface TestStxEventArgs {
  * @returns `DbStxEvent`
  */
 function testStxEvent(args?: TestStxEventArgs): DbStxEvent {
+  const assetEventTypeId = args?.asset_event_type_id ?? DbAssetEventTypeId.Transfer;
   return {
     canonical: true,
     event_type: DbEventTypeId.StxAsset,
-    asset_event_type_id: DbAssetEventTypeId.Transfer,
+    asset_event_type_id: assetEventTypeId,
     event_index: args?.event_index ?? 0,
     tx_id: args?.tx_id ?? TX_ID,
     tx_index: args?.tx_index ?? 0,
     block_height: args?.block_height ?? BLOCK_HEIGHT,
     amount: args?.amount ?? TOKEN_TRANSFER_AMOUNT,
-    recipient: args?.recipient ?? RECIPIENT_ADDRESS,
-    sender: args?.sender ?? SENDER_ADDRESS,
+    // Mints have no sender and burns have no recipient.
+    recipient:
+      assetEventTypeId === DbAssetEventTypeId.Burn ? undefined : (args?.recipient ?? RECIPIENT_ADDRESS),
+    sender:
+      assetEventTypeId === DbAssetEventTypeId.Mint ? undefined : (args?.sender ?? SENDER_ADDRESS),
     memo: args?.memo,
   };
 }

--- a/tests/api/v3/stx-supply.test.ts
+++ b/tests/api/v3/stx-supply.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, beforeEach, afterEach } from 'node:test';
+import { PgWriteStore } from '../../../src/datastore/pg-write-store.ts';
+import { ApiServer, startApiServer } from '../../../src/api/init.ts';
+import { migrate } from '../../test-helpers.ts';
+import { STACKS_TESTNET } from '@stacks/network';
+import * as assert from 'node:assert/strict';
+import { TestBlockBuilder } from '../test-builders.ts';
+import { DbAssetEventTypeId } from '../../../src/datastore/common.ts';
+import { hex } from '../test-helpers.ts';
+
+describe('stx supply', () => {
+  let db: PgWriteStore;
+  let api: ApiServer;
+
+  beforeEach(async () => {
+    await migrate('up');
+    db = await PgWriteStore.connect({
+      usageName: 'tests',
+      withNotifier: false,
+      skipMigrations: true,
+    });
+    api = await startApiServer({ datastore: db, chainId: STACKS_TESTNET.chainId });
+  });
+
+  afterEach(async () => {
+    await api.terminate();
+    await db?.close();
+    await migrate('down');
+  });
+
+  async function getSupply(): Promise<{ total: string; projected_total_2050: string }> {
+    const res = await api.fastifyApp.inject({ method: 'GET', url: '/extended/v3/stx/supply' });
+    assert.equal(res.statusCode, 200);
+    return JSON.parse(res.body);
+  }
+
+  test('accumulates mints, burns, and matured coinbase rewards', async () => {
+    assert.equal((await getSupply()).total, '0');
+
+    // Mints and a matured coinbase reward increase the supply.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        index_block_hash: hex(1),
+        parent_index_block_hash: hex(0),
+      })
+        .addTx({ tx_id: hex(0x11) })
+        .addTxStxEvent({ asset_event_type_id: DbAssetEventTypeId.Mint, amount: 1000n })
+        .addMinerReward({ coinbase_amount: 100n, tx_fees_anchored: 7n })
+        .build()
+    );
+    // Miner tx fees are redistribution, not new supply — only the coinbase counts.
+    assert.equal((await getSupply()).total, '1100');
+
+    // Burns decrease it; transfers don't affect it.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        index_block_hash: hex(2),
+        parent_index_block_hash: hex(1),
+      })
+        .addTx({ tx_id: hex(0x22) })
+        .addTxStxEvent({ asset_event_type_id: DbAssetEventTypeId.Mint, amount: 500n })
+        .addTxStxEvent({ asset_event_type_id: DbAssetEventTypeId.Burn, amount: 200n })
+        .addTxStxEvent({ asset_event_type_id: DbAssetEventTypeId.Transfer, amount: 10_000n })
+        .build()
+    );
+    const supply = await getSupply();
+    assert.equal(supply.total, '1400');
+    assert.equal(supply.projected_total_2050, '2318000000000000');
+  });
+
+  test('adjusts for reorgs', async () => {
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        index_block_hash: hex(1),
+        parent_index_block_hash: hex(0),
+      })
+        .addTx({ tx_id: hex(0x11) })
+        .addTxStxEvent({ asset_event_type_id: DbAssetEventTypeId.Mint, amount: 1000n })
+        .addMinerReward({ coinbase_amount: 100n })
+        .build()
+    );
+
+    // Canonical block 2a: mint + burn + matured coinbase.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        index_block_hash: hex(0x2a),
+        parent_index_block_hash: hex(1),
+      })
+        .addTx({ tx_id: hex(0x22a) })
+        .addTxStxEvent({ asset_event_type_id: DbAssetEventTypeId.Mint, amount: 500n })
+        .addTxStxEvent({ asset_event_type_id: DbAssetEventTypeId.Burn, amount: 200n })
+        .addMinerReward({ coinbase_amount: 70n })
+        .build()
+    );
+    assert.equal((await getSupply()).total, '1470');
+
+    // Sibling block 2b arrives non-canonical: no supply change.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        index_block_hash: hex(0x2b),
+        parent_index_block_hash: hex(1),
+      })
+        .addTx({ tx_id: hex(0x22b) })
+        .addTxStxEvent({ asset_event_type_id: DbAssetEventTypeId.Mint, amount: 50n })
+        .build()
+    );
+    assert.equal((await getSupply()).total, '1470');
+
+    // Block 3b builds on 2b: 2a is orphaned (mint − burn + coinbase reverted) and 2b is
+    // restored, then 3b's own mint applies.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 3,
+        index_block_hash: hex(3),
+        parent_index_block_hash: hex(0x2b),
+      })
+        .addTx({ tx_id: hex(0x33) })
+        .addTxStxEvent({ asset_event_type_id: DbAssetEventTypeId.Mint, amount: 25n })
+        .build()
+    );
+    // 1000 + 100 (block 1) + 50 (block 2b) + 25 (block 3b)
+    assert.equal((await getSupply()).total, '1175');
+  });
+});

--- a/tests/api/v3/stx-supply.test.ts
+++ b/tests/api/v3/stx-supply.test.ts
@@ -29,7 +29,10 @@ describe('stx supply', () => {
   });
 
   async function getSupply(): Promise<{ total: string; projected_total_2050: string }> {
-    const res = await api.fastifyApp.inject({ method: 'GET', url: '/extended/v3/stx/supply' });
+    const res = await api.fastifyApp.inject({
+      method: 'GET',
+      url: '/extended/v3/tokens/stx/supply',
+    });
     assert.equal(res.statusCode, 200);
     return JSON.parse(res.body);
   }


### PR DESCRIPTION
Adds `GET /extended/v3/tokens/stx/supply`, which returns the total liquid STX supply from a single-row `chain_tip` lookup, replacing the v1 endpoint whose queries aggregate over the entire `stx_events` and `miner_rewards` tables on every request.

```json
{
  "total": "1470469916700000",
  "projected_total_2050": "2318000000000000"
}
```

Amounts are string-quoted micro-STX (µSTX) integers, following v3 conventions (v1 returned decimal STX). No query parameters; responses are served behind the chain-tip ETag cache.