### PR TITLE
feat: deprecate v1 BNS endpoints and add an asset_identifier filter to v3 NFT balances

### DIFF
--- a/src/api/routes/v1/bns/addresses.ts
+++ b/src/api/routes/v1/bns/addresses.ts
@@ -4,6 +4,10 @@ import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Server } from 'node:http';
 import { UnanchoredParamSchema } from '../../../schemas/v1/params.js';
 import { InvalidRequestError, InvalidRequestErrorType } from '../../../../errors.js';
+import {
+  BNS_NAMES_OWNED_DEPRECATION_MESSAGE,
+  BNS_NAMES_OWNED_DEPRECATION_NOTE,
+} from './deprecation.js';
 
 const SUPPORTED_BLOCKCHAINS = ['stacks'];
 
@@ -18,8 +22,10 @@ export const BnsAddressRoutes: FastifyPluginAsync<
       preHandler: handleChainTipCache,
       schema: {
         operationId: 'get_names_owned_by_address',
+        deprecated: true,
+        deprecatedMessage: BNS_NAMES_OWNED_DEPRECATION_MESSAGE,
         summary: 'Get Names Owned by Address',
-        description: `Retrieves a list of names owned by the address provided.`,
+        description: `Retrieves a list of names owned by the address provided. ${BNS_NAMES_OWNED_DEPRECATION_NOTE}`,
         tags: ['Names'],
         params: Type.Object({
           blockchain: Type.String({

--- a/src/api/routes/v1/bns/deprecation.ts
+++ b/src/api/routes/v1/bns/deprecation.ts
@@ -1,0 +1,10 @@
+export const BNS_DEPRECATION_NOTE = '**Deprecated:** BNS endpoints are no longer maintained.';
+export const BNS_DEPRECATION_MESSAGE = 'BNS endpoints are no longer maintained.';
+
+export const BNS_NAMES_OWNED_DEPRECATION_NOTE =
+  '**Deprecated:** use `GET /extended/v3/principals/{principal}/balances/nft` instead, filtered ' +
+  'to the BNS asset identifier. Note that this returns only NFT-backed names, not subdomains or ' +
+  'names imported from Blockstack v1.';
+export const BNS_NAMES_OWNED_DEPRECATION_MESSAGE =
+  'Use /extended/v3/principals/{principal}/balances/nft filtered to the BNS asset identifier. ' +
+  'Subdomains and Blockstack v1 imported names are not included there.';

--- a/src/api/routes/v1/bns/names.ts
+++ b/src/api/routes/v1/bns/names.ts
@@ -5,6 +5,7 @@ import { FastifyPluginAsync } from 'fastify';
 import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Server } from 'node:http';
 import { UnanchoredParamSchema } from '../../../schemas/v1/params.js';
+import { BNS_DEPRECATION_MESSAGE, BNS_DEPRECATION_NOTE } from './deprecation.js';
 
 class NameRedirectError extends Error {
   constructor(message: string) {
@@ -25,8 +26,10 @@ export const BnsNameRoutes: FastifyPluginAsync<
       preHandler: handleChainTipCache,
       schema: {
         operationId: 'get_historical_zone_file',
+        deprecated: true,
+        deprecatedMessage: BNS_DEPRECATION_MESSAGE,
         summary: 'Get Historical Zone File',
-        description: `Retrieves the historical zonefile specified by the username and zone hash.`,
+        description: `Retrieves the historical zonefile specified by the username and zone hash. ${BNS_DEPRECATION_NOTE}`,
         tags: ['Names'],
         params: Type.Object({
           name: Type.String({ description: 'fully-qualified name', examples: ['muneeb.id'] }),
@@ -76,8 +79,10 @@ export const BnsNameRoutes: FastifyPluginAsync<
       preHandler: handleChainTipCache,
       schema: {
         operationId: 'fetch_subdomains_list_for_name',
+        deprecated: true,
+        deprecatedMessage: BNS_DEPRECATION_MESSAGE,
         summary: 'Get Name Subdomains',
-        description: `Retrieves the list of subdomains for a specific name`,
+        description: `Retrieves the list of subdomains for a specific name. ${BNS_DEPRECATION_NOTE}`,
         tags: ['Names'],
         params: Type.Object({
           name: Type.String({ description: 'fully-qualified name', examples: ['id.blockstack'] }),
@@ -120,8 +125,10 @@ export const BnsNameRoutes: FastifyPluginAsync<
       preHandler: handleChainTipCache,
       schema: {
         operationId: 'fetch_zone_file',
+        deprecated: true,
+        deprecatedMessage: BNS_DEPRECATION_MESSAGE,
         summary: 'Get Zone File',
-        description: `Retrieves a user's raw zone file. This only works for RFC-compliant zone files. This method returns an error for names that have non-standard zone files.`,
+        description: `Retrieves a user's raw zone file. This only works for RFC-compliant zone files. This method returns an error for names that have non-standard zone files. ${BNS_DEPRECATION_NOTE}`,
         tags: ['Names'],
         params: Type.Object({
           name: Type.String({ description: 'fully-qualified name', examples: ['bar.test'] }),
@@ -176,8 +183,10 @@ export const BnsNameRoutes: FastifyPluginAsync<
       preHandler: handleChainTipCache,
       schema: {
         operationId: 'get_all_names',
+        deprecated: true,
+        deprecatedMessage: BNS_DEPRECATION_MESSAGE,
         summary: 'Get All Names',
-        description: `Retrieves a list of all names known to the node.`,
+        description: `Retrieves a list of all names known to the node. ${BNS_DEPRECATION_NOTE}`,
         tags: ['Names'],
         querystring: Type.Object({
           unanchored: UnanchoredParamSchema,
@@ -225,8 +234,10 @@ export const BnsNameRoutes: FastifyPluginAsync<
       preHandler: handleChainTipCache,
       schema: {
         operationId: 'get_name_info',
+        deprecated: true,
+        deprecatedMessage: BNS_DEPRECATION_MESSAGE,
         summary: 'Get Name Details',
-        description: `Retrieves details of a given name including the \`address\`, \`status\` and last transaction id - \`last_txid\`.`,
+        description: `Retrieves details of a given name including the \`address\`, \`status\` and last transaction id - \`last_txid\`. ${BNS_DEPRECATION_NOTE}`,
         tags: ['Names'],
         params: Type.Object({
           name: Type.String({ description: 'fully-qualified name', examples: ['muneeb.id'] }),

--- a/src/api/routes/v1/bns/namespaces.ts
+++ b/src/api/routes/v1/bns/namespaces.ts
@@ -5,6 +5,7 @@ import { FastifyPluginAsync } from 'fastify';
 import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Server } from 'node:http';
 import { UnanchoredParamSchema } from '../../../schemas/v1/params.js';
+import { BNS_DEPRECATION_MESSAGE, BNS_DEPRECATION_NOTE } from './deprecation.js';
 
 export const BnsNamespaceRoutes: FastifyPluginAsync<
   Record<never, never>,
@@ -17,8 +18,10 @@ export const BnsNamespaceRoutes: FastifyPluginAsync<
       preHandler: handleChainTipCache,
       schema: {
         operationId: 'get_all_namespaces',
+        deprecated: true,
+        deprecatedMessage: BNS_DEPRECATION_MESSAGE,
         summary: 'Get All Namespaces',
-        description: `Retrieves a list of all namespaces known to the node.`,
+        description: `Retrieves a list of all namespaces known to the node. ${BNS_DEPRECATION_NOTE}`,
         tags: ['Names'],
         querystring: Type.Object({
           unanchored: UnanchoredParamSchema,
@@ -49,8 +52,10 @@ export const BnsNamespaceRoutes: FastifyPluginAsync<
       preHandler: handleChainTipCache,
       schema: {
         operationId: 'get_namespace_names',
+        deprecated: true,
+        deprecatedMessage: BNS_DEPRECATION_MESSAGE,
         summary: 'Get Namespace Names',
-        description: `Retrieves a list of names within a given namespace.`,
+        description: `Retrieves a list of names within a given namespace. ${BNS_DEPRECATION_NOTE}`,
         tags: ['Names'],
         params: Type.Object({
           tld: Type.String({ description: 'the namespace to fetch names from.', examples: ['id'] }),

--- a/src/api/routes/v1/bns/pricing.ts
+++ b/src/api/routes/v1/bns/pricing.ts
@@ -12,6 +12,7 @@ import { FastifyPluginAsync } from 'fastify';
 import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Server } from 'node:http';
 import { handleChainTipCache } from '../../../controllers/cache-controller.js';
+import { BNS_DEPRECATION_MESSAGE, BNS_DEPRECATION_NOTE } from './deprecation.js';
 
 export const BnsPriceRoutes: FastifyPluginAsync<
   Record<never, never>,
@@ -24,8 +25,10 @@ export const BnsPriceRoutes: FastifyPluginAsync<
       preHandler: handleChainTipCache,
       schema: {
         operationId: 'get_namespace_price',
+        deprecated: true,
+        deprecatedMessage: BNS_DEPRECATION_MESSAGE,
         summary: 'Get Namespace Price',
-        description: `Retrieves the price of a namespace. The \`amount\` given will be in the smallest possible units of the currency.`,
+        description: `Retrieves the price of a namespace. The \`amount\` given will be in the smallest possible units of the currency. ${BNS_DEPRECATION_NOTE}`,
         tags: ['Names'],
         params: Type.Object({
           tld: Type.String({ description: 'the namespace to fetch price for', examples: ['id'] }),
@@ -85,8 +88,10 @@ export const BnsPriceRoutes: FastifyPluginAsync<
       preHandler: handleChainTipCache,
       schema: {
         operationId: 'get_name_price',
+        deprecated: true,
+        deprecatedMessage: BNS_DEPRECATION_MESSAGE,
         summary: 'Get Name Price',
-        description: `Retrieves the price of a name. The \`amount\` given will be in the smallest possible units of the currency.`,
+        description: `Retrieves the price of a name. The \`amount\` given will be in the smallest possible units of the currency. ${BNS_DEPRECATION_NOTE}`,
         tags: ['Names'],
         params: Type.Object({
           name: Type.String({

--- a/src/api/routes/v3/principals.ts
+++ b/src/api/routes/v3/principals.ts
@@ -504,10 +504,23 @@ export const PrincipalsRoutes: FastifyPluginAsync<
         operationId: 'get_principal_balances_nft',
         summary: 'Get principal NFT balances',
         description:
-          'Get the non-fungible token instances currently owned by a principal, ordered by asset identifier and value.',
+          'Get the non-fungible token instances currently owned by a principal, ordered by asset identifier and value. Optionally filtered to a single asset class via `asset_identifier`.',
         tags: ['Accounts'],
         params: Type.Object({ principal: PrincipalSchema }),
-        querystring: CursorPaginationQuerystring(NftBalanceCursorSchema, ResourceType.NftBalance),
+        querystring: Type.Composite([
+          CursorPaginationQuerystring(NftBalanceCursorSchema, ResourceType.NftBalance),
+          Type.Object({
+            asset_identifier: Type.Optional(
+              Type.String({
+                ...AssetIdentifierSchema,
+                description:
+                  'Return only the instances of this non-fungible token asset class. For ' +
+                  'example, BNS names are held as ' +
+                  '`SP000000000000000000002Q6VF78.bns::names` on mainnet.',
+              })
+            ),
+          }),
+        ]),
         response: {
           200: CursorPaginatedResponse(
             PrincipalNftPositionSchema,
@@ -522,6 +535,7 @@ export const PrincipalsRoutes: FastifyPluginAsync<
         principal: req.params.principal,
         limit: req.query.limit ?? getPagingQueryLimit(ResourceType.NftBalance),
         cursor: req.query.cursor,
+        assetIdentifier: req.query.asset_identifier,
       });
       await reply.send({
         limit: results.limit,

--- a/src/datastore/v3/pg-store-v3.ts
+++ b/src/datastore/v3/pg-store-v3.ts
@@ -550,8 +550,12 @@ export class PgStoreV3 extends BasePgStoreModule {
     principal: Principal;
     limit: number;
     cursor?: NftBalanceCursor;
+    assetIdentifier?: string;
   }): Promise<DbCursorPaginatedResult<DbPrincipalNftBalance>> {
     return await this.sqlTransaction(async sql => {
+      const assetFilter = args.assetIdentifier
+        ? sql`AND asset_identifier = ${args.assetIdentifier}`
+        : sql``;
       // Position the page strictly after the cursor in `(asset_identifier, value)`
       // ascending order.
       let cursorFilter = sql``;
@@ -570,9 +574,12 @@ export class PgStoreV3 extends BasePgStoreModule {
         SELECT
           asset_identifier,
           value,
-          (SELECT COUNT(*)::int FROM nft_custody WHERE recipient = ${args.principal}) AS total
+          (
+            SELECT COUNT(*)::int FROM nft_custody
+            WHERE recipient = ${args.principal} ${assetFilter}
+          ) AS total
         FROM nft_custody
-        WHERE recipient = ${args.principal} ${cursorFilter}
+        WHERE recipient = ${args.principal} ${assetFilter} ${cursorFilter}
         ORDER BY asset_identifier ASC, value ASC
         LIMIT ${args.limit + 1}
       `;
@@ -593,7 +600,7 @@ export class PgStoreV3 extends BasePgStoreModule {
         const prevPageQuery = await sql<{ asset_identifier: string; value: string }[]>`
           SELECT asset_identifier, value
           FROM nft_custody
-          WHERE recipient = ${args.principal}
+          WHERE recipient = ${args.principal} ${assetFilter}
             AND (
               asset_identifier < ${firstResult.asset_identifier}
               OR (asset_identifier = ${firstResult.asset_identifier} AND value < ${firstResult.value})

--- a/tests/api/v3/principals.test.ts
+++ b/tests/api/v3/principals.test.ts
@@ -1353,6 +1353,89 @@ describe('principals', () => {
         current: `${vB1}:${collectionB}`,
       });
     });
+
+    test('filters to a single asset class and scopes `total` to the filter', async () => {
+      await db.update(buildNftBlock());
+      const body = await getNftBalances(nftAddr, { asset_identifier: collectionA });
+      // `total` must reflect the filter, not the principal's full NFT count (3).
+      assert.equal(body.total, 2);
+      assert.deepEqual(body.results, [
+        { asset_identifier: collectionA, value: { hex: vA1, repr: 'u1' } },
+        { asset_identifier: collectionA, value: { hex: vA2, repr: 'u2' } },
+      ]);
+    });
+
+    test('scopes the previous cursor to the filter', async () => {
+      await db.update(buildNftBlock());
+      // Collection B sorts after collection A. Unfiltered, the row before `vB1` is
+      // `vA2` of collection A; under the filter there is no previous row at all.
+      const body = await getNftBalances(nftAddr, { asset_identifier: collectionB });
+      assert.equal(body.total, 1);
+      assert.deepEqual(body.results, [
+        { asset_identifier: collectionB, value: { hex: vB1, repr: 'u1' } },
+      ]);
+      assert.deepEqual(body.cursor, {
+        next: null,
+        previous: null,
+        current: `${vB1}:${collectionB}`,
+      });
+    });
+
+    test('paginates with cursors while filtered', async () => {
+      await db.update(buildNftBlock());
+
+      const page1 = await getNftBalances(nftAddr, {
+        asset_identifier: collectionA,
+        limit: '1',
+      });
+      assert.equal(page1.total, 2);
+      assert.deepEqual(page1.results, [
+        { asset_identifier: collectionA, value: { hex: vA1, repr: 'u1' } },
+      ]);
+      assert.deepEqual(page1.cursor, {
+        next: `${vA2}:${collectionA}`,
+        previous: null,
+        current: `${vA1}:${collectionA}`,
+      });
+
+      // The last page must not spill into collection B.
+      const page2 = await getNftBalances(nftAddr, {
+        asset_identifier: collectionA,
+        limit: '1',
+        cursor: page1.cursor.next,
+      });
+      assert.equal(page2.total, 2);
+      assert.deepEqual(page2.results, [
+        { asset_identifier: collectionA, value: { hex: vA2, repr: 'u2' } },
+      ]);
+      assert.deepEqual(page2.cursor, {
+        next: null,
+        previous: `${vA1}:${collectionA}`,
+        current: `${vA2}:${collectionA}`,
+      });
+    });
+
+    test('returns an empty page for an asset class the principal does not hold', async () => {
+      await db.update(buildNftBlock());
+      const body = await getNftBalances(nftAddr, {
+        asset_identifier: 'SP000000000000000000002Q6VF78.collection-c::C',
+      });
+      assert.deepEqual(body, {
+        total: 0,
+        limit: 100,
+        cursor: { next: null, previous: null, current: null },
+        results: [],
+      });
+    });
+
+    test('rejects a malformed asset identifier', async () => {
+      const res = await api.fastifyApp.inject({
+        method: 'GET',
+        url: `/extended/v3/principals/${nftAddr}/balances/nft`,
+        query: { asset_identifier: 'not-an-asset-identifier' },
+      });
+      assert.equal(res.statusCode, 400, res.body);
+    });
   });
 
   describe('/v3/principals/:principal/nonces', () => {


### PR DESCRIPTION
Deprecates all ten BNS endpoints under `src/api/routes/v1/bns`, and adds the `asset_identifier` filter to `GET /extended/v3/principals/{principal}/balances/nft` that BNS callers need in order to migrate.

`/v1/addresses/{blockchain}/{address}` points at `GET /extended/v3/principals/{principal}/balances/nft` filtered to the BNS asset identifier.