### PR TITLE
feat: switch to the new canonical chain tip immediately during Nakamoto re-orgs

### DIFF
--- a/src/datastore/helpers.ts
+++ b/src/datastore/helpers.ts
@@ -1389,6 +1389,15 @@ export function convertTxQueryResultToDbMempoolTx(txs: TxQueryResult[]): DbMempo
   return dbMempoolTxs;
 }
 
+/**
+ * Determines if a block was produced under Nakamoto (epoch 3.0) rules. Nakamoto blocks are
+ * validated by signers before they are announced by stacks-nodes, which is signaled by the
+ * presence of a `signer_bitvec` value.
+ */
+export function isNakamotoBlock(block: Pick<DbBlock, 'signer_bitvec'>): boolean {
+  return block.signer_bitvec !== null;
+}
+
 export function markBlockUpdateDataAsNonCanonical(data: DataStoreBlockUpdateData): void {
   data.block = { ...data.block, canonical: false };
   data.microblocks = data.microblocks.map(mb => ({ ...mb, canonical: false }));

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -5248,11 +5248,19 @@ export class PgWriteStore extends PgStore {
         updatedEntities.markedNonCanonical.poxCycles += poxCycleResult.count;
       }
     });
+    // Entities scoped to the block's `burn_block_hash` are only marked non-canonical when no
+    // canonical block still anchors to that burn block. Multiple Nakamoto blocks in a tenure share
+    // the same burn block, so orphaning part of a tenure (e.g. its trailing blocks) must not
+    // invalidate the burn block's own rows. The `blocks.canonical` flip for this block runs before
+    // this method, so the check reflects the post-re-org state.
     q.enqueue(async () => {
       await sql`
         UPDATE burnchain_rewards
         SET canonical = ${canonical}
         WHERE burn_block_hash = ${burnBlockHash} AND canonical != ${canonical}
+          AND (${canonical} OR NOT EXISTS (
+            SELECT 1 FROM blocks WHERE burn_block_hash = ${burnBlockHash} AND canonical = true
+          ))
       `;
     });
     q.enqueue(async () => {
@@ -5261,6 +5269,9 @@ export class PgWriteStore extends PgStore {
           UPDATE burn_block_pox_txs
           SET canonical = ${canonical}
           WHERE burn_block_hash = ${burnBlockHash} AND canonical != ${canonical}
+            AND (${canonical} OR NOT EXISTS (
+              SELECT 1 FROM blocks WHERE burn_block_hash = ${burnBlockHash} AND canonical = true
+            ))
           RETURNING recipient
         ),
         count_deltas AS (

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -86,6 +86,7 @@ import {
 import {
   BLOCK_COLUMNS,
   convertTxQueryResultToDbMempoolTx,
+  isNakamotoBlock,
   markBlockUpdateDataAsNonCanonical,
   MICROBLOCK_COLUMNS,
   parseBlockQueryResult,
@@ -293,11 +294,32 @@ export class PgWriteStore extends PgStore {
     let newTxData: DataStoreTxEventData[] = [];
     let reorg: ReOrgUpdatedEntities = newReOrgUpdatedEntities();
     let isCanonical = true;
+    let skippedDuplicateBlock = false;
 
     await this.sqlWriteTransaction(async sql => {
       const chainTip = await this.getChainTip(sql);
-      reorg = await this.handleReorg(sql, data.block, chainTip.block_height);
-      isCanonical = data.block.block_height > chainTip.block_height;
+      if (isNakamotoBlock(data.block)) {
+        // Nakamoto blocks are validated by signers before they reach the event stream, so they are
+        // always immediately canonical even when they re-org the chain onto a shorter fork.
+        // Canonical flips of already-known blocks only ever happen via a new descendant block, so a
+        // re-delivered block event (e.g. from an SNP stream replay after the chain tip moved
+        // backwards) must be ignored entirely.
+        const existingBlock = await sql`
+          SELECT 1 FROM blocks WHERE index_block_hash = ${data.block.index_block_hash} LIMIT 1
+        `;
+        if (existingBlock.count > 0) {
+          logger.debug(
+            `Ignoring duplicate event for already ingested block ${data.block.block_height} ${data.block.index_block_hash}`
+          );
+          skippedDuplicateBlock = true;
+          return;
+        }
+        reorg = await this.handleReorgNakamoto(sql, data.block, chainTip);
+        isCanonical = true;
+      } else {
+        reorg = await this.handleReorg(sql, data.block, chainTip.block_height);
+        isCanonical = data.block.block_height > chainTip.block_height;
+      }
       if (!isCanonical) {
         markBlockUpdateDataAsNonCanonical(data);
       } else {
@@ -469,6 +491,7 @@ export class PgWriteStore extends PgStore {
         }
       }
     });
+    if (skippedDuplicateBlock) return;
     if (isCanonical) {
       await this.redisNotifier?.notify(
         {
@@ -5264,6 +5287,58 @@ export class PgWriteStore extends PgStore {
   }
 
   /**
+   * Marks a single currently-canonical block (and all its associated entities) as non-canonical,
+   * restoring its transactions to the mempool. Microblock canonical-status results are returned to
+   * the caller instead of being tallied into `updatedEntities` so callers can dedupe them against
+   * other canonical-flip operations happening as part of the same re-org (see
+   * `restoreOrphanedChain`).
+   */
+  private async markBlockNonCanonical(
+    sql: PgSqlClient,
+    block: DbBlock,
+    updatedEntities: ReOrgUpdatedEntities
+  ): Promise<{ orphanedMicroblocks: string[]; acceptedMicroblocks: string[] }> {
+    await sql`
+      UPDATE blocks
+      SET canonical = false
+      WHERE index_block_hash = ${block.index_block_hash} AND canonical = true
+    `;
+    const microCanonicalUpdateResult = await this.updateMicroCanonical(sql, {
+      isCanonical: false,
+      blockHeight: block.block_height,
+      blockHash: block.block_hash,
+      indexBlockHash: block.index_block_hash,
+      parentIndexBlockHash: block.parent_index_block_hash,
+      parentMicroblockHash: block.parent_microblock_hash,
+      parentMicroblockSequence: block.parent_microblock_sequence,
+      burnBlockTime: block.burn_block_time,
+      burnBlockHeight: block.burn_block_height,
+    });
+    updatedEntities.markedNonCanonical.blocks++;
+    updatedEntities.markedNonCanonical.blockHeaders.unshift({
+      index_block_hash: block.index_block_hash,
+      block_height: block.block_height,
+      block_time: block.block_time,
+    });
+    const markNonCanonicalResult = await this.markEntitiesCanonical(
+      sql,
+      block.index_block_hash,
+      block.burn_block_hash,
+      false,
+      updatedEntities
+    );
+    const restoredMempoolTxs = await this.restoreMempoolTxs(
+      sql,
+      markNonCanonicalResult.txsMarkedNonCanonical
+    );
+    updatedEntities.restoredMempoolTxs += restoredMempoolTxs.restoredTxs.length;
+    return {
+      orphanedMicroblocks: microCanonicalUpdateResult.orphanedMicroblocks,
+      acceptedMicroblocks: microCanonicalUpdateResult.acceptedMicroblocks,
+    };
+  }
+
+  /**
    * Recursively restore previously orphaned blocks to canonical.
    * @param sql - The SQL client
    * @param indexBlockHash - The index block hash that we will restore first
@@ -5300,11 +5375,10 @@ export class PgWriteStore extends PgStore {
 
     // Orphan the now conflicting block at the same height
     const orphanedBlockResult = await sql<BlockQueryResult[]>`
-      UPDATE blocks
-      SET canonical = false
+      SELECT ${sql(BLOCK_COLUMNS)}
+      FROM blocks
       WHERE block_height = ${restoredBlockResult[0].block_height}
         AND index_block_hash != ${indexBlockHash} AND canonical = true
-      RETURNING ${sql(BLOCK_COLUMNS)}
     `;
 
     const microblocksOrphaned = new Set<string>();
@@ -5313,17 +5387,11 @@ export class PgWriteStore extends PgStore {
     if (orphanedBlockResult.length > 0) {
       const orphanedBlocks = orphanedBlockResult.map(b => parseBlockQueryResult(b));
       for (const orphanedBlock of orphanedBlocks) {
-        const microCanonicalUpdateResult = await this.updateMicroCanonical(sql, {
-          isCanonical: false,
-          blockHeight: orphanedBlock.block_height,
-          blockHash: orphanedBlock.block_hash,
-          indexBlockHash: orphanedBlock.index_block_hash,
-          parentIndexBlockHash: orphanedBlock.parent_index_block_hash,
-          parentMicroblockHash: orphanedBlock.parent_microblock_hash,
-          parentMicroblockSequence: orphanedBlock.parent_microblock_sequence,
-          burnBlockTime: orphanedBlock.burn_block_time,
-          burnBlockHeight: orphanedBlock.burn_block_height,
-        });
+        const microCanonicalUpdateResult = await this.markBlockNonCanonical(
+          sql,
+          orphanedBlock,
+          updatedEntities
+        );
         microCanonicalUpdateResult.orphanedMicroblocks.forEach(mb => {
           microblocksOrphaned.add(mb);
           microblocksAccepted.delete(mb);
@@ -5333,25 +5401,6 @@ export class PgWriteStore extends PgStore {
           microblocksAccepted.add(mb);
         });
       }
-
-      updatedEntities.markedNonCanonical.blocks++;
-      updatedEntities.markedNonCanonical.blockHeaders.unshift({
-        index_block_hash: orphanedBlockResult[0].index_block_hash,
-        block_height: orphanedBlockResult[0].block_height,
-        block_time: orphanedBlockResult[0].block_time,
-      });
-      const markNonCanonicalResult = await this.markEntitiesCanonical(
-        sql,
-        orphanedBlockResult[0].index_block_hash,
-        orphanedBlockResult[0].burn_block_hash,
-        false,
-        updatedEntities
-      );
-      const restoredMempoolTxs = await this.restoreMempoolTxs(
-        sql,
-        markNonCanonicalResult.txsMarkedNonCanonical
-      );
-      updatedEntities.restoredMempoolTxs += restoredMempoolTxs.restoredTxs.length;
     }
 
     // The canonical microblock tables _must_ be restored _after_ orphaning all other blocks at a
@@ -5422,6 +5471,105 @@ export class PgWriteStore extends PgStore {
     return updatedEntities;
   }
 
+  /**
+   * Marks all canonical blocks above the given height (and their associated entities) as
+   * non-canonical, walking down from the current chain tip. Used when a Nakamoto block re-orgs the
+   * chain onto a fork that is shorter than (or equal in length to) the current canonical chain,
+   * which moves the chain tip backwards.
+   */
+  private async orphanCanonicalBlocksAboveHeight(
+    sql: PgSqlClient,
+    height: number,
+    updatedEntities: ReOrgUpdatedEntities
+  ): Promise<void> {
+    const blocksToOrphanResult = await sql<BlockQueryResult[]>`
+      SELECT ${sql(BLOCK_COLUMNS)}
+      FROM blocks
+      WHERE block_height > ${height} AND canonical = true
+      ORDER BY block_height DESC
+    `;
+    if (blocksToOrphanResult.length > 1) {
+      logger.debug(
+        `Orphaning ${blocksToOrphanResult.length} canonical blocks above height ${height}, chain tip is moving backwards`
+      );
+    }
+    for (const blockToOrphan of blocksToOrphanResult) {
+      const block = parseBlockQueryResult(blockToOrphan);
+      const { orphanedMicroblocks } = await this.markBlockNonCanonical(sql, block, updatedEntities);
+      updatedEntities.markedNonCanonical.microblocks += orphanedMicroblocks.length;
+      updatedEntities.markedNonCanonical.microblockHashes.push(...orphanedMicroblocks);
+    }
+  }
+
+  /**
+   * Handles a re-org for an incoming Nakamoto block. Nakamoto blocks are validated by signers
+   * before they reach the event stream, so an incoming block always becomes the new canonical chain
+   * tip immediately, even when it builds on a fork that is shorter than the current canonical chain
+   * (i.e. the chain tip can move backwards).
+   */
+  async handleReorgNakamoto(
+    sql: PgSqlClient,
+    block: DbBlock,
+    chainTip: DbChainTip
+  ): Promise<ReOrgUpdatedEntities> {
+    const updatedEntities = newReOrgUpdatedEntities();
+    // Common case: the new block builds off the current chain tip.
+    if (block.parent_index_block_hash === chainTip.index_block_hash) {
+      return updatedEntities;
+    }
+    if (block.block_height <= 1) {
+      return updatedEntities;
+    }
+    const parentResult = await sql<
+      {
+        canonical: boolean;
+        index_block_hash: string;
+        burn_block_hash: string;
+        parent_index_block_hash: string;
+      }[]
+    >`
+      SELECT canonical, index_block_hash, burn_block_hash, parent_index_block_hash
+      FROM blocks
+      WHERE block_height = ${block.block_height - 1}
+        AND index_block_hash = ${block.parent_index_block_hash}
+    `;
+    if (parentResult.length > 1)
+      throw new Error(
+        `DB contains multiple blocks at height ${block.block_height - 1} and index_hash ${
+          block.parent_index_block_hash
+        }`
+      );
+    if (parentResult.length === 0)
+      throw new Error(
+        `DB does not contain a parent block at height ${block.block_height - 1} with index_hash ${
+          block.parent_index_block_hash
+        }`
+      );
+    // The two operations below never flip the same block: the orphaned suffix covers heights >=
+    // this block's height, while the restored chain covers heights <= the parent's height.
+    if (block.block_height <= chainTip.block_height) {
+      // The new block re-orgs the chain onto a fork that doesn't extend past the current chain
+      // tip. Orphan all canonical blocks at or above the new block's height.
+      await this.orphanCanonicalBlocksAboveHeight(sql, block.block_height - 1, updatedEntities);
+    }
+    if (!parentResult[0].canonical) {
+      // The new block builds off a previously orphaned chain. Restore canonical status for this
+      // chain, orphaning any conflicting blocks along the way.
+      await this.restoreOrphanedChain(
+        sql,
+        parentResult[0].index_block_hash,
+        parentResult[0].burn_block_hash,
+        updatedEntities
+      );
+    }
+    await this.updateChainTipTxCountsAfterReorg(sql, updatedEntities);
+    logger.info(
+      updatedEntities,
+      `Re-org resolved. Nakamoto block ${block.block_height} ${block.index_block_hash} is the new canonical chain tip.`
+    );
+    return updatedEntities;
+  }
+
   async handleReorg(
     sql: PgSqlClient,
     block: DbBlock,
@@ -5468,22 +5616,32 @@ export class PgWriteStore extends PgStore {
           `Re-org resolved. Block ${block.block_height} builds off a previously orphaned chain.`
         );
       }
-      // Reflect updated transaction totals in `chain_tip` table.
-      const txCountDelta =
-        updatedEntities.markedCanonical.txs - updatedEntities.markedNonCanonical.txs;
-      await sql`
-        UPDATE chain_tip SET
-          tx_count = tx_count + ${txCountDelta},
-          tx_count_unanchored = tx_count_unanchored + ${txCountDelta},
-          bond_count = (
-            SELECT COUNT(*)::int
-            FROM bonds
-            WHERE canonical = true
-              AND microblock_canonical = true
-          )
-      `;
+      await this.updateChainTipTxCountsAfterReorg(sql, updatedEntities);
     }
     return updatedEntities;
+  }
+
+  /**
+   * Reflect updated transaction totals in the `chain_tip` table after a re-org has marked entities
+   * canonical/non-canonical.
+   */
+  private async updateChainTipTxCountsAfterReorg(
+    sql: PgSqlClient,
+    updatedEntities: ReOrgUpdatedEntities
+  ): Promise<void> {
+    const txCountDelta =
+      updatedEntities.markedCanonical.txs - updatedEntities.markedNonCanonical.txs;
+    await sql`
+      UPDATE chain_tip SET
+        tx_count = tx_count + ${txCountDelta},
+        tx_count_unanchored = tx_count_unanchored + ${txCountDelta},
+        bond_count = (
+          SELECT COUNT(*)::int
+          FROM bonds
+          WHERE canonical = true
+            AND microblock_canonical = true
+        )
+    `;
   }
 
   async close(args?: { timeout?: number }): Promise<void> {

--- a/tests/api/datastore/nakamoto-reorg.test.ts
+++ b/tests/api/datastore/nakamoto-reorg.test.ts
@@ -19,12 +19,14 @@ describe('nakamoto re-org handling', () => {
     hash: string;
     parent: string;
     txId?: string;
+    burnBlockHash?: string;
   }): TestBlockBuilder {
     const builder = new TestBlockBuilder({
       block_height: args.height,
       block_hash: args.hash,
       index_block_hash: args.hash,
       parent_index_block_hash: args.parent,
+      burn_block_hash: args.burnBlockHash,
       signer_bitvec: SIGNER_BITVEC,
     });
     if (args.txId) {
@@ -204,6 +206,75 @@ describe('nakamoto re-org handling', () => {
     assert.equal(txA.result?.canonical, true);
     const txB = await db.getTx({ txId: '0x0302', includeUnanchored: false });
     assert.equal(txB.result?.canonical, false);
+  });
+
+  test('keeps burnchain entities canonical during a same-tenure re-org', async () => {
+    // All blocks share the same burn block (one Nakamoto tenure).
+    const burnBlockHash = '0xbb01';
+    await db.updateBurnchainRewards({
+      rewards: [
+        {
+          canonical: true,
+          burn_block_hash: burnBlockHash,
+          burn_block_height: 200,
+          burn_amount: 2000n,
+          reward_recipient: '1G4ayBXJvxZMoZpaNdZG6VyWwWq2mHpMjQ',
+          reward_amount: 900n,
+          reward_index: 0,
+        },
+      ],
+    });
+    await db.update(nakamotoBlock({ height: 1, hash: '0xa1', parent: '0x00', burnBlockHash }).build());
+    await db.update(nakamotoBlock({ height: 2, hash: '0xa2', parent: '0xa1', burnBlockHash }).build());
+    await db.update(nakamotoBlock({ height: 3, hash: '0xa3', parent: '0xa2', burnBlockHash }).build());
+    // Sibling switch at height 3 within the same tenure.
+    await db.update(nakamotoBlock({ height: 3, hash: '0xb3', parent: '0xa2', burnBlockHash }).build());
+
+    // The stacks-level re-org must not orphan the burn block's rewards: the burn block itself is
+    // still canonical (blocks 1, 2 and 3' anchor to it).
+    const rewards = await db.getBurnchainRewards({ limit: 10, offset: 0 });
+    assert.equal(rewards.length, 1);
+    assert.equal(rewards[0].burn_block_hash, burnBlockHash);
+    assert.equal(rewards[0].canonical, true);
+  });
+
+  test('orphans burnchain entities when a full tenure is orphaned', async () => {
+    await db.updateBurnchainRewards({
+      rewards: [
+        {
+          canonical: true,
+          burn_block_hash: '0xbb02',
+          burn_block_height: 201,
+          burn_amount: 2000n,
+          reward_recipient: '1G4ayBXJvxZMoZpaNdZG6VyWwWq2mHpMjQ',
+          reward_amount: 900n,
+          reward_index: 0,
+        },
+      ],
+    });
+    // Tenure 1 (burn block 0xbb01) mines blocks 1-2, tenure 2 (burn block 0xbb02) mines 3-4.
+    await db.update(
+      nakamotoBlock({ height: 1, hash: '0xa1', parent: '0x00', burnBlockHash: '0xbb01' }).build()
+    );
+    await db.update(
+      nakamotoBlock({ height: 2, hash: '0xa2', parent: '0xa1', burnBlockHash: '0xbb01' }).build()
+    );
+    await db.update(
+      nakamotoBlock({ height: 3, hash: '0xa3', parent: '0xa2', burnBlockHash: '0xbb02' }).build()
+    );
+    await db.update(
+      nakamotoBlock({ height: 4, hash: '0xa4', parent: '0xa3', burnBlockHash: '0xbb02' }).build()
+    );
+
+    // A re-org (e.g. after a burnchain fork) replaces all of tenure 2 with a new tenure built on
+    // burn block 0xbb03. No canonical block anchors to 0xbb02 anymore, so its rewards must be
+    // orphaned along with the blocks.
+    await db.update(
+      nakamotoBlock({ height: 3, hash: '0xb3', parent: '0xa2', burnBlockHash: '0xbb03' }).build()
+    );
+
+    const rewards = await db.getBurnchainRewards({ limit: 10, offset: 0 });
+    assert.equal(rewards.length, 0);
   });
 
   test('ignores duplicate block events', async () => {

--- a/tests/api/datastore/nakamoto-reorg.test.ts
+++ b/tests/api/datastore/nakamoto-reorg.test.ts
@@ -1,0 +1,234 @@
+import assert from 'node:assert/strict';
+import { PgWriteStore } from '../../../src/datastore/pg-write-store.ts';
+import { DbTxStatus } from '../../../src/datastore/common.ts';
+import { TestBlockBuilder, testMempoolTx } from '../test-builders.ts';
+import { migrate } from '../../test-helpers.ts';
+import { beforeEach, afterEach, describe, test } from 'node:test';
+
+describe('nakamoto re-org handling', () => {
+  let db: PgWriteStore;
+
+  const SIGNER_BITVEC = '1111';
+
+  /**
+   * Builds a signer-validated (Nakamoto) test block. `hash` is used for both `block_hash` and
+   * `index_block_hash` to keep test chains easy to follow.
+   */
+  function nakamotoBlock(args: {
+    height: number;
+    hash: string;
+    parent: string;
+    txId?: string;
+  }): TestBlockBuilder {
+    const builder = new TestBlockBuilder({
+      block_height: args.height,
+      block_hash: args.hash,
+      index_block_hash: args.hash,
+      parent_index_block_hash: args.parent,
+      signer_bitvec: SIGNER_BITVEC,
+    });
+    if (args.txId) {
+      // Give each tx a unique sender so mempool prune/restore logic (which also matches txs by
+      // sender and nonce) treats them as independent.
+      builder.addTx({ tx_id: args.txId, sender_address: `SP${args.txId}` });
+    }
+    return builder;
+  }
+
+  beforeEach(async () => {
+    await migrate('up');
+    db = await PgWriteStore.connect({
+      usageName: 'tests',
+      withNotifier: false,
+      skipMigrations: true,
+    });
+  });
+
+  afterEach(async () => {
+    await db.close();
+    await migrate('down');
+  });
+
+  test('switches to a same-height sibling block immediately', async () => {
+    await db.updateMempoolTxs({
+      mempoolTxs: [testMempoolTx({ tx_id: '0x0301', sender_address: 'SP0x0301' })],
+    });
+
+    await db.update(nakamotoBlock({ height: 1, hash: '0xa1', parent: '0x00' }).build());
+    await db.update(nakamotoBlock({ height: 2, hash: '0xa2', parent: '0xa1', txId: '0x0201' }).build());
+    await db.update(nakamotoBlock({ height: 3, hash: '0xa3', parent: '0xa2', txId: '0x0301' }).build());
+
+    // The mempool tx was mined in block 0xa3.
+    const mempoolQuery1 = await db.getMempoolTx({ txId: '0x0301', includeUnanchored: false });
+    assert.equal(mempoolQuery1.found, false);
+    let chainTip = await db.getChainTip(db.sql);
+    assert.equal(chainTip.block_height, 3);
+    assert.equal(chainTip.index_block_hash, '0xa3');
+    assert.equal(chainTip.tx_count, 2);
+
+    // A sibling block at the same height arrives. It must become the canonical chain tip
+    // immediately, without waiting for the fork to become the longest chain.
+    await db.update(nakamotoBlock({ height: 3, hash: '0xb3', parent: '0xa2', txId: '0x0302' }).build());
+
+    chainTip = await db.getChainTip(db.sql);
+    assert.equal(chainTip.block_height, 3);
+    assert.equal(chainTip.index_block_hash, '0xb3');
+    assert.equal(chainTip.block_count, 3);
+    assert.equal(chainTip.tx_count, 2);
+    assert.equal(chainTip.tx_count_unanchored, 2);
+
+    const blockA3 = await db.getBlock({ hash: '0xa3' });
+    assert.equal(blockA3.result?.canonical, false);
+    const blockB3 = await db.getBlock({ hash: '0xb3' });
+    assert.equal(blockB3.result?.canonical, true);
+
+    const txA = await db.getTx({ txId: '0x0301', includeUnanchored: false });
+    assert.equal(txA.result?.canonical, false);
+    const txB = await db.getTx({ txId: '0x0302', includeUnanchored: false });
+    assert.equal(txB.result?.canonical, true);
+
+    // The orphaned block's tx is restored to the mempool.
+    const mempoolQuery2 = await db.getMempoolTx({ txId: '0x0301', includeUnanchored: false });
+    assert.equal(mempoolQuery2.found, true);
+    assert.equal(mempoolQuery2.result?.status, DbTxStatus.Pending);
+  });
+
+  test('moves the chain tip backwards when a shorter fork becomes canonical', async () => {
+    await db.updateMempoolTxs({
+      mempoolTxs: [testMempoolTx({ tx_id: '0x0401', sender_address: 'SP0x0401' })],
+    });
+
+    await db.update(nakamotoBlock({ height: 1, hash: '0xa1', parent: '0x00' }).build());
+    await db.update(nakamotoBlock({ height: 2, hash: '0xa2', parent: '0xa1', txId: '0x0201' }).build());
+    await db.update(nakamotoBlock({ height: 3, hash: '0xa3', parent: '0xa2', txId: '0x0301' }).build());
+    await db.update(nakamotoBlock({ height: 4, hash: '0xa4', parent: '0xa3', txId: '0x0401' }).build());
+    await db.update(nakamotoBlock({ height: 5, hash: '0xa5', parent: '0xa4', txId: '0x0501' }).build());
+
+    let chainTip = await db.getChainTip(db.sql);
+    assert.equal(chainTip.block_height, 5);
+    assert.equal(chainTip.tx_count, 4);
+
+    // A fork block arrives at height 3, building off canonical block 2. The chain tip must move
+    // backwards to height 3 and blocks 3, 4 and 5 must be orphaned.
+    await db.update(nakamotoBlock({ height: 3, hash: '0xb3', parent: '0xa2', txId: '0x0302' }).build());
+
+    chainTip = await db.getChainTip(db.sql);
+    assert.equal(chainTip.block_height, 3);
+    assert.equal(chainTip.index_block_hash, '0xb3');
+    assert.equal(chainTip.block_count, 3);
+    assert.equal(chainTip.tx_count, 2);
+    assert.equal(chainTip.tx_count_unanchored, 2);
+
+    for (const orphaned of ['0xa3', '0xa4', '0xa5']) {
+      const block = await db.getBlock({ hash: orphaned });
+      assert.equal(block.result?.canonical, false, `block ${orphaned} should be orphaned`);
+    }
+    // Note: txs 0x0401 and 0x0501 sit above the new chain tip height so they are not visible via
+    // `getTx`; check their canonical flags directly.
+    for (const orphanedTx of ['0x0301', '0x0401', '0x0501']) {
+      const txResult = await db.sql<{ canonical: boolean }[]>`
+        SELECT canonical FROM txs WHERE tx_id = ${orphanedTx}
+      `;
+      assert.equal(txResult.length, 1);
+      assert.equal(txResult[0].canonical, false, `tx ${orphanedTx} should be non-canonical`);
+    }
+    const txB = await db.getTx({ txId: '0x0302', includeUnanchored: false });
+    assert.equal(txB.result?.canonical, true);
+
+    // The orphaned tx that was in the mempool is restored.
+    const mempoolQuery = await db.getMempoolTx({ txId: '0x0401', includeUnanchored: false });
+    assert.equal(mempoolQuery.found, true);
+    assert.equal(mempoolQuery.result?.status, DbTxStatus.Pending);
+  });
+
+  test('restores a previously orphaned chain when a new block builds on it', async () => {
+    await db.update(nakamotoBlock({ height: 1, hash: '0xa1', parent: '0x00' }).build());
+    await db.update(nakamotoBlock({ height: 2, hash: '0xa2', parent: '0xa1', txId: '0x0201' }).build());
+    await db.update(nakamotoBlock({ height: 3, hash: '0xa3', parent: '0xa2', txId: '0x0301' }).build());
+    await db.update(nakamotoBlock({ height: 4, hash: '0xa4', parent: '0xa3', txId: '0x0401' }).build());
+    await db.update(nakamotoBlock({ height: 5, hash: '0xa5', parent: '0xa4', txId: '0x0501' }).build());
+    // Shorter fork wins at height 3.
+    await db.update(nakamotoBlock({ height: 3, hash: '0xb3', parent: '0xa2', txId: '0x0302' }).build());
+
+    // Now a block arrives building off the previously orphaned block 0xa4: blocks 0xa3 and 0xa4
+    // are restored, 0xb3 is orphaned, and the new block becomes the tip.
+    await db.update(nakamotoBlock({ height: 5, hash: '0xc5', parent: '0xa4', txId: '0x0502' }).build());
+
+    const chainTip = await db.getChainTip(db.sql);
+    assert.equal(chainTip.block_height, 5);
+    assert.equal(chainTip.index_block_hash, '0xc5');
+    assert.equal(chainTip.block_count, 5);
+    assert.equal(chainTip.tx_count, 4);
+
+    const canonical = ['0xa1', '0xa2', '0xa3', '0xa4', '0xc5'];
+    const nonCanonical = ['0xa5', '0xb3'];
+    for (const hash of canonical) {
+      const block = await db.getBlock({ hash });
+      assert.equal(block.result?.canonical, true, `block ${hash} should be canonical`);
+    }
+    for (const hash of nonCanonical) {
+      const block = await db.getBlock({ hash });
+      assert.equal(block.result?.canonical, false, `block ${hash} should be orphaned`);
+    }
+
+    for (const txId of ['0x0201', '0x0301', '0x0401', '0x0502']) {
+      const tx = await db.getTx({ txId, includeUnanchored: false });
+      assert.equal(tx.result?.canonical, true, `tx ${txId} should be canonical`);
+    }
+    for (const txId of ['0x0302', '0x0501']) {
+      const tx = await db.getTx({ txId, includeUnanchored: false });
+      assert.equal(tx.result?.canonical, false, `tx ${txId} should be non-canonical`);
+    }
+  });
+
+  test('switches when the new block builds on a non-canonical sibling of the tip', async () => {
+    await db.update(nakamotoBlock({ height: 1, hash: '0xa1', parent: '0x00' }).build());
+    await db.update(nakamotoBlock({ height: 2, hash: '0xa2', parent: '0xa1', txId: '0x0201' }).build());
+    await db.update(nakamotoBlock({ height: 3, hash: '0xa3', parent: '0xa2', txId: '0x0301' }).build());
+    // Sibling switch at height 3.
+    await db.update(nakamotoBlock({ height: 3, hash: '0xb3', parent: '0xa2', txId: '0x0302' }).build());
+    // A block at height 4 builds off the now-orphaned 0xa3.
+    await db.update(nakamotoBlock({ height: 4, hash: '0xc4', parent: '0xa3', txId: '0x0402' }).build());
+
+    const chainTip = await db.getChainTip(db.sql);
+    assert.equal(chainTip.block_height, 4);
+    assert.equal(chainTip.index_block_hash, '0xc4');
+    assert.equal(chainTip.tx_count, 3);
+
+    const blockA3 = await db.getBlock({ hash: '0xa3' });
+    assert.equal(blockA3.result?.canonical, true);
+    const blockB3 = await db.getBlock({ hash: '0xb3' });
+    assert.equal(blockB3.result?.canonical, false);
+
+    const txA = await db.getTx({ txId: '0x0301', includeUnanchored: false });
+    assert.equal(txA.result?.canonical, true);
+    const txB = await db.getTx({ txId: '0x0302', includeUnanchored: false });
+    assert.equal(txB.result?.canonical, false);
+  });
+
+  test('ignores duplicate block events', async () => {
+    await db.update(nakamotoBlock({ height: 1, hash: '0xa1', parent: '0x00' }).build());
+    await db.update(nakamotoBlock({ height: 2, hash: '0xa2', parent: '0xa1', txId: '0x0201' }).build());
+    await db.update(nakamotoBlock({ height: 3, hash: '0xa3', parent: '0xa2', txId: '0x0301' }).build());
+    // Sibling switch at height 3.
+    await db.update(nakamotoBlock({ height: 3, hash: '0xb3', parent: '0xa2', txId: '0x0302' }).build());
+
+    // Re-delivering the now-orphaned block must not flip it back to canonical.
+    await db.update(nakamotoBlock({ height: 3, hash: '0xa3', parent: '0xa2', txId: '0x0301' }).build());
+    let chainTip = await db.getChainTip(db.sql);
+    assert.equal(chainTip.block_height, 3);
+    assert.equal(chainTip.index_block_hash, '0xb3');
+    assert.equal(chainTip.tx_count, 2);
+    const blockA3 = await db.getBlock({ hash: '0xa3' });
+    assert.equal(blockA3.result?.canonical, false);
+    const txA = await db.getTx({ txId: '0x0301', includeUnanchored: false });
+    assert.equal(txA.result?.canonical, false);
+
+    // Re-delivering the canonical chain tip is also a no-op.
+    await db.update(nakamotoBlock({ height: 3, hash: '0xb3', parent: '0xa2', txId: '0x0302' }).build());
+    chainTip = await db.getChainTip(db.sql);
+    assert.equal(chainTip.block_height, 3);
+    assert.equal(chainTip.index_block_hash, '0xb3');
+    assert.equal(chainTip.tx_count, 2);
+  });
+});

--- a/tests/api/redis/redis-notifier.test.ts
+++ b/tests/api/redis/redis-notifier.test.ts
@@ -125,4 +125,72 @@ describe('redis notifier', () => {
     ]);
     assert.deepEqual(payload3.rollback_blocks, [{ hash: '0x1235', index: 2, time: 1234 }]);
   });
+
+  test('updates redis with nakamoto re-orgs', async () => {
+    // Nakamoto blocks (signer_bitvec set) become canonical immediately, so a fork block that
+    // doesn't extend past the current chain tip still emits a message, with the replaced blocks
+    // as rollbacks.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        block_hash: '0x1234',
+        index_block_hash: '0x1234',
+        block_time: 1234,
+        signer_bitvec: '1111',
+      }).build()
+    );
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        block_hash: '0x1235',
+        index_block_hash: '0x1235',
+        parent_index_block_hash: '0x1234',
+        block_time: 1234,
+        signer_bitvec: '1111',
+      }).build()
+    );
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 3,
+        block_hash: '0x1236',
+        index_block_hash: '0x1236',
+        parent_index_block_hash: '0x1235',
+        block_time: 1234,
+        signer_bitvec: '1111',
+      }).build()
+    );
+    assert.equal(messages.length, 3);
+
+    // A sibling block at height 2 moves the chain tip backwards: blocks 2 and 3 are rolled back.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        block_hash: '0x1235bb',
+        index_block_hash: '0x1235bb',
+        parent_index_block_hash: '0x1234',
+        block_time: 1234,
+        signer_bitvec: '1111',
+      }).build()
+    );
+    assert.equal(messages.length, 4);
+    const payload = JSON.parse(messages[3]).payload;
+    assert.deepEqual(payload.apply_blocks, [{ hash: '0x1235bb', index: 2, time: 1234 }]);
+    assert.deepEqual(payload.rollback_blocks, [
+      { hash: '0x1235', index: 2, time: 1234 },
+      { hash: '0x1236', index: 3, time: 1234 },
+    ]);
+
+    // A duplicate event for an already ingested block emits nothing.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        block_hash: '0x1235bb',
+        index_block_hash: '0x1235bb',
+        parent_index_block_hash: '0x1234',
+        block_time: 1234,
+        signer_bitvec: '1111',
+      }).build()
+    );
+    assert.equal(messages.length, 4);
+  });
 });


### PR DESCRIPTION
Closes #2299.

Since Stacks 3.x, blocks only reach the API's event stream after signers have validated them, so every `/new_block` event is the node's canonical tip. The API still applied the 2.x "longest chain wins" rule, so during a re-org onto a shorter fork it kept serving the stale chain until the fork overtook the old tip. This PR makes every incoming **Nakamoto** block immediately canonical (even when that moves the chain tip *backwards*) while keeping legacy behavior for pre-Nakamoto blocks so 2.x event replay is unchanged.