### PR TITLE
feat: add v3 smart contract endpoint and resolve null clarity versions

### DIFF
--- a/migrations/1779800000013_backfill-clarity-versions.ts
+++ b/migrations/1779800000013_backfill-clarity-versions.ts
@@ -40,8 +40,8 @@ export const BACKFILL_TXS_SQL = `
 /**
  * Backfills the Clarity version of contracts deployed with an unversioned `SmartContract` payload.
  *
- * Such a payload carries no Clarity version on the wire — the node resolves it from the epoch at
- * execution time — so the API recorded `null` for every one of them. The node does report the
+ * Such a payload carries no Clarity version on the wire (the node resolves it from the epoch at
+ * execution time) so the API recorded `null` for every one of them. The node does report the
  * resolved version in the contract interface it sends to event observers, and that whole blob is
  * already stored in `smart_contracts.abi`, so the value can be recovered without touching the node.
  *

--- a/migrations/1779800000013_backfill-clarity-versions.ts
+++ b/migrations/1779800000013_backfill-clarity-versions.ts
@@ -3,19 +3,6 @@ import type { ColumnDefinitions, MigrationBuilder } from 'node-pg-migrate';
 export const shorthands: ColumnDefinitions | undefined = undefined;
 
 /**
- * Backfills the Clarity version of contracts deployed with an unversioned `SmartContract` payload.
- *
- * Two columns hold it. `smart_contracts.clarity_version` is the one the ABI sits next to;
- * `txs.smart_contract_clarity_version` is a denormalized copy (the `txs` table has no ABI column)
- * and is what the v3 smart contract endpoint reads, so both are patched.
- *
- * Rows whose ABI predates stacks-core adding `clarity_version` to the contract interface (Jan 2023)
- * have nothing to recover from, as do failed deploys, which have no interface at all. Those are set
- * to the sentinel `0`, which is not a real Clarity version, so the columns end up free of nulls for
- * every contract deploy and the API can serve a non-nullable field.
- */
-
-/**
  * Recovers the version from the ABI. It is serialized as the `ClarityVersion` enum variant name,
  * e.g. `Clarity3`.
  */
@@ -31,46 +18,47 @@ export const BACKFILL_SMART_CONTRACTS_SQL = `
 /**
  * Copies the recovered version onto the tx rows. Driven from the (much smaller) smart_contracts
  * side, so this is an index lookup per contract against the unique index on txs
- * (tx_id, index_block_hash, microblock_hash) rather than a scan of txs. Every copy of a tx across
- * re-org forks is patched, which is what we want.
+ * (tx_id, index_block_hash, microblock_hash) rather than a scan of txs.
+ *
+ * Matched on that full location tuple rather than `tx_id` alone. A transaction retained on several
+ * forks has one row per fork in both tables, so a `tx_id`-only join is a cross product and
+ * Postgres would update each `txs` copy from an arbitrary `smart_contracts` row. Those rows can
+ * legitimately disagree: an unversioned deploy re-executed across an epoch boundary resolves to a
+ * different Clarity version on either side. Every copy is still patched, each from its own fork.
  */
 export const BACKFILL_TXS_SQL = `
   UPDATE txs t
   SET smart_contract_clarity_version = sc.clarity_version
   FROM smart_contracts sc
   WHERE t.tx_id = sc.tx_id
+    AND t.index_block_hash = sc.index_block_hash
+    AND t.microblock_hash = sc.microblock_hash
     AND t.smart_contract_clarity_version IS NULL
     AND sc.clarity_version IS NOT NULL
 `;
 
-/** Sentinel for a contract whose Clarity version could not be recovered. Not a real version. */
-export const UNKNOWN_CLARITY_VERSION = 0;
-
-/** Every `smart_contracts` row is a contract deploy, so anything still null gets the sentinel. */
-export const DEFAULT_SMART_CONTRACTS_SQL = `
-  UPDATE smart_contracts
-  SET clarity_version = ${UNKNOWN_CLARITY_VERSION}
-  WHERE clarity_version IS NULL
-`;
-
 /**
- * Scoped to contract-deploy transactions by `type_id` (which is indexed). Every other kind of
- * transaction has a legitimately null `smart_contract_clarity_version` and must be left alone.
- * `1` is `SmartContract`, `6` is `VersionedSmartContract` — a versioned deploy always carries its
- * own version, so in practice only the former matches.
+ * Backfills the Clarity version of contracts deployed with an unversioned `SmartContract` payload.
+ *
+ * Such a payload carries no Clarity version on the wire — the node resolves it from the epoch at
+ * execution time — so the API recorded `null` for every one of them. The node does report the
+ * resolved version in the contract interface it sends to event observers, and that whole blob is
+ * already stored in `smart_contracts.abi`, so the value can be recovered without touching the node.
+ *
+ * Two columns hold it. `smart_contracts.clarity_version` is the one the ABI sits next to;
+ * `txs.smart_contract_clarity_version` is a denormalized copy (the `txs` table has no ABI column)
+ * and is what the v3 smart contract endpoint reads, so both are patched.
+ *
+ * Rows whose ABI predates stacks-core adding `clarity_version` to the contract interface (Jan 2023)
+ * have nothing to recover from and stay null, as do failed deploys, which have no interface at all.
+ * In practice that should not happen here: a node re-syncing from genesis rebuilds every contract
+ * interface with the current binary, so a chainstate synced any time after Jan 2023 has the version
+ * for even the oldest contracts. Nulls only survive on a chainstate descending from an older
+ * archive, since event-replay reproduces the original payloads verbatim.
  */
-export const DEFAULT_TXS_SQL = `
-  UPDATE txs
-  SET smart_contract_clarity_version = ${UNKNOWN_CLARITY_VERSION}
-  WHERE smart_contract_clarity_version IS NULL
-    AND type_id IN (1, 6)
-`;
-
 export const up = (pgm: MigrationBuilder) => {
   pgm.sql(BACKFILL_SMART_CONTRACTS_SQL);
   pgm.sql(BACKFILL_TXS_SQL);
-  pgm.sql(DEFAULT_SMART_CONTRACTS_SQL);
-  pgm.sql(DEFAULT_TXS_SQL);
 };
 
 export const down = () => {

--- a/migrations/1779800000013_backfill-clarity-versions.ts
+++ b/migrations/1779800000013_backfill-clarity-versions.ts
@@ -1,0 +1,79 @@
+import type { ColumnDefinitions, MigrationBuilder } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+/**
+ * Backfills the Clarity version of contracts deployed with an unversioned `SmartContract` payload.
+ *
+ * Two columns hold it. `smart_contracts.clarity_version` is the one the ABI sits next to;
+ * `txs.smart_contract_clarity_version` is a denormalized copy (the `txs` table has no ABI column)
+ * and is what the v3 smart contract endpoint reads, so both are patched.
+ *
+ * Rows whose ABI predates stacks-core adding `clarity_version` to the contract interface (Jan 2023)
+ * have nothing to recover from, as do failed deploys, which have no interface at all. Those are set
+ * to the sentinel `0`, which is not a real Clarity version, so the columns end up free of nulls for
+ * every contract deploy and the API can serve a non-nullable field.
+ */
+
+/**
+ * Recovers the version from the ABI. It is serialized as the `ClarityVersion` enum variant name,
+ * e.g. `Clarity3`.
+ */
+export const BACKFILL_SMART_CONTRACTS_SQL = `
+  UPDATE smart_contracts
+  SET clarity_version =
+    CAST(substring(abi->>'clarity_version' FROM '^Clarity([0-9]+)$') AS smallint)
+  WHERE clarity_version IS NULL
+    AND jsonb_typeof(abi) = 'object'
+    AND abi->>'clarity_version' ~ '^Clarity[0-9]+$'
+`;
+
+/**
+ * Copies the recovered version onto the tx rows. Driven from the (much smaller) smart_contracts
+ * side, so this is an index lookup per contract against the unique index on txs
+ * (tx_id, index_block_hash, microblock_hash) rather than a scan of txs. Every copy of a tx across
+ * re-org forks is patched, which is what we want.
+ */
+export const BACKFILL_TXS_SQL = `
+  UPDATE txs t
+  SET smart_contract_clarity_version = sc.clarity_version
+  FROM smart_contracts sc
+  WHERE t.tx_id = sc.tx_id
+    AND t.smart_contract_clarity_version IS NULL
+    AND sc.clarity_version IS NOT NULL
+`;
+
+/** Sentinel for a contract whose Clarity version could not be recovered. Not a real version. */
+export const UNKNOWN_CLARITY_VERSION = 0;
+
+/** Every `smart_contracts` row is a contract deploy, so anything still null gets the sentinel. */
+export const DEFAULT_SMART_CONTRACTS_SQL = `
+  UPDATE smart_contracts
+  SET clarity_version = ${UNKNOWN_CLARITY_VERSION}
+  WHERE clarity_version IS NULL
+`;
+
+/**
+ * Scoped to contract-deploy transactions by `type_id` (which is indexed). Every other kind of
+ * transaction has a legitimately null `smart_contract_clarity_version` and must be left alone.
+ * `1` is `SmartContract`, `6` is `VersionedSmartContract` — a versioned deploy always carries its
+ * own version, so in practice only the former matches.
+ */
+export const DEFAULT_TXS_SQL = `
+  UPDATE txs
+  SET smart_contract_clarity_version = ${UNKNOWN_CLARITY_VERSION}
+  WHERE smart_contract_clarity_version IS NULL
+    AND type_id IN (1, 6)
+`;
+
+export const up = (pgm: MigrationBuilder) => {
+  pgm.sql(BACKFILL_SMART_CONTRACTS_SQL);
+  pgm.sql(BACKFILL_TXS_SQL);
+  pgm.sql(DEFAULT_SMART_CONTRACTS_SQL);
+  pgm.sql(DEFAULT_TXS_SQL);
+};
+
+export const down = () => {
+  // Deliberately irreversible. The backfilled values are recoveries of the version each contract
+  // has always run under, and the nulls they replaced carry no information worth restoring.
+};

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -58,6 +58,7 @@ import { StakingCyclesRoutes } from './routes/v3/staking-cycles.js';
 import { StakingSignersRoutes } from './routes/v3/staking-signers.js';
 import { TokensStxRoutes } from './routes/v3/tokens-stx.js';
 import { TokensFtRoutes } from './routes/v3/tokens-ft.js';
+import { SmartContractsRoutes } from './routes/v3/smart-contracts.js';
 
 export interface ApiServer {
   fastifyApp: FastifyInstance;
@@ -113,6 +114,7 @@ export const StacksApiRoutes: FastifyPluginAsync<
       await fastify.register(BlocksRoutes);
       await fastify.register(MempoolRoutes);
       await fastify.register(PrincipalsRoutes);
+      await fastify.register(SmartContractsRoutes);
       await fastify.register(StakingBondsRoutes);
       await fastify.register(StakingCyclesRoutes);
       await fastify.register(StakingSignersRoutes);

--- a/src/api/routes/v1/contract.ts
+++ b/src/api/routes/v1/contract.ts
@@ -10,6 +10,9 @@ import { ClarityAbi } from '@stacks/transactions';
 import { SmartContractSchema } from '../../schemas/v1/entities/smart-contracts.js';
 import { TransactionEventSchema } from '../../schemas/v1/entities/transaction-events.js';
 
+const BY_TRAIT_DEPRECATION_NOTE = '**Deprecated:** this endpoint has no direct v3 replacement.';
+const BY_TRAIT_DEPRECATION_MESSAGE = 'This endpoint has no direct v3 replacement.';
+
 export const ContractRoutes: FastifyPluginAsync<
   Record<never, never>,
   Server,
@@ -21,8 +24,10 @@ export const ContractRoutes: FastifyPluginAsync<
       preHandler: handleChainTipCache,
       schema: {
         operationId: 'get_contracts_by_trait',
+        deprecated: true,
+        deprecatedMessage: BY_TRAIT_DEPRECATION_MESSAGE,
         summary: 'Get contracts by trait',
-        description: `Retrieves a list of contracts based on the following traits listed in JSON format -  functions, variables, maps, fungible tokens and non-fungible tokens`,
+        description: `Retrieves a list of contracts based on the following traits listed in JSON format -  functions, variables, maps, fungible tokens and non-fungible tokens. ${BY_TRAIT_DEPRECATION_NOTE}`,
         tags: ['Smart Contracts'],
         querystring: Type.Object({
           trait_abi: Type.String({
@@ -71,8 +76,10 @@ export const ContractRoutes: FastifyPluginAsync<
       preHandler: handleChainTipCache,
       schema: {
         operationId: 'get_contract_by_id',
+        deprecated: true,
         summary: 'Get contract info',
-        description: 'Retrieves details of a contract with a given `contract_id`',
+        description:
+          'Retrieves details of a contract with a given `contract_id`. **Deprecated:** use `GET /extended/v3/smart-contracts/{contract_id}` instead. For the contract ABI, use the Stacks node RPC endpoint `GET /v2/contracts/interface/{address}/{name}`.',
         tags: ['Smart Contracts'],
         params: Type.Object({
           contract_id: Type.String({

--- a/src/api/routes/v3/smart-contracts.ts
+++ b/src/api/routes/v3/smart-contracts.ts
@@ -1,0 +1,59 @@
+import { FastifyPluginAsync } from 'fastify';
+import { Server } from 'node:http';
+import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
+import { handleChainTipCache } from '../../controllers/cache-controller.js';
+import { SmartContractIdSchema } from '../../schemas/v3/entities/common.js';
+import {
+  SmartContractIncludeFieldSchema,
+  SmartContractSchema,
+} from '../../schemas/v3/entities/smart-contracts.js';
+import { serializeDbSmartContract } from '../../serializers/v3/smart-contracts.js';
+import { NotFoundError } from '../../../errors.js';
+
+export const SmartContractsRoutes: FastifyPluginAsync<
+  Record<never, never>,
+  Server,
+  TypeBoxTypeProvider
+> = async fastify => {
+  fastify.get(
+    '/smart-contracts/:contract_id',
+    {
+      preHandler: handleChainTipCache,
+      schema: {
+        operationId: 'get_smart_contract',
+        summary: 'Get smart contract',
+        description:
+          'Retrieves a deployed smart contract, along with the transaction that deployed it. ' +
+          'Only successfully deployed contracts are returned; a contract id whose deploy ' +
+          'transaction failed is not found.',
+        tags: ['Smart Contracts'],
+        params: Type.Object({
+          contract_id: SmartContractIdSchema,
+        }),
+        querystring: Type.Object({
+          include: Type.Optional(
+            Type.Array(SmartContractIncludeFieldSchema, {
+              uniqueItems: true,
+              description: 'Heavy fields to include in the response.',
+            })
+          ),
+        }),
+        response: {
+          200: SmartContractSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const contract = await fastify.db.v3.getSmartContract({
+        contractId: req.params.contract_id,
+        include: req.query.include,
+      });
+      if (!contract) {
+        throw new NotFoundError('Smart contract not found');
+      }
+      await reply.send(serializeDbSmartContract(contract));
+    }
+  );
+
+  await Promise.resolve();
+};

--- a/src/api/schemas/v3/entities/mempool-transaction-summaries.ts
+++ b/src/api/schemas/v3/entities/mempool-transaction-summaries.ts
@@ -68,7 +68,9 @@ export const SmartContractMempoolTransactionSummarySchema = Type.Composite(
         clarity_version: Nullable(
           Type.Number({
             description:
-              'The Clarity version of the contract, only specified for versioned contract transactions, otherwise null',
+              'The Clarity version of the contract, only specified for versioned contract ' +
+              'transactions, otherwise null. A pending deploy has not been executed, so the ' +
+              'version an unversioned one will resolve to is not yet known.',
           })
         ),
         contract_id: Type.String({

--- a/src/api/schemas/v3/entities/smart-contracts.ts
+++ b/src/api/schemas/v3/entities/smart-contracts.ts
@@ -1,4 +1,5 @@
 import { Static, Type } from '@sinclair/typebox';
+import { Nullable } from '../../v1/util.js';
 import {
   BitcoinBlockPositionSchema,
   BlockPositionSchema,
@@ -9,10 +10,17 @@ import {
 export const SmartContractSchema = Type.Object(
   {
     contract_id: SmartContractIdSchema,
-    clarity_version: Type.Integer({
-      description: 'The Clarity version the contract runs under.',
-      examples: [3],
-    }),
+    clarity_version: Nullable(
+      Type.Integer({
+        description:
+          'The Clarity version the contract runs under. Contracts deployed with a versioned ' +
+          'payload declare their own version; for the rest it is the version the node resolved ' +
+          'from the epoch they were deployed in. Null when it could not be determined, which ' +
+          'only happens for contracts indexed from a chainstate predating the point where the ' +
+          'Stacks node began reporting it.',
+        examples: [3],
+      })
+    ),
     tx_id: Type.String({
       ...TransactionIdSchema,
       description: 'ID of the transaction that deployed this contract',

--- a/src/api/schemas/v3/entities/smart-contracts.ts
+++ b/src/api/schemas/v3/entities/smart-contracts.ts
@@ -1,5 +1,4 @@
 import { Static, Type } from '@sinclair/typebox';
-import { Nullable } from '../../v1/util.js';
 import {
   BitcoinBlockPositionSchema,
   BlockPositionSchema,
@@ -10,13 +9,10 @@ import {
 export const SmartContractSchema = Type.Object(
   {
     contract_id: SmartContractIdSchema,
-    clarity_version: Nullable(
-      Type.Integer({
-        description:
-          'The Clarity version the contract was deployed with. Null for contracts deployed ' +
-          'before versioned contract transactions existed.',
-      })
-    ),
+    clarity_version: Type.Integer({
+      description: 'The Clarity version the contract runs under.',
+      examples: [3],
+    }),
     tx_id: Type.String({
       ...TransactionIdSchema,
       description: 'ID of the transaction that deployed this contract',

--- a/src/api/schemas/v3/entities/smart-contracts.ts
+++ b/src/api/schemas/v3/entities/smart-contracts.ts
@@ -1,0 +1,43 @@
+import { Static, Type } from '@sinclair/typebox';
+import { Nullable } from '../../v1/util.js';
+import {
+  BitcoinBlockPositionSchema,
+  BlockPositionSchema,
+  SmartContractIdSchema,
+  TransactionIdSchema,
+} from './common.js';
+
+export const SmartContractSchema = Type.Object(
+  {
+    contract_id: SmartContractIdSchema,
+    clarity_version: Nullable(
+      Type.Integer({
+        description:
+          'The Clarity version the contract was deployed with. Null for contracts deployed ' +
+          'before versioned contract transactions existed.',
+      })
+    ),
+    tx_id: Type.String({
+      ...TransactionIdSchema,
+      description: 'ID of the transaction that deployed this contract',
+    }),
+    block: BlockPositionSchema,
+    bitcoin_block: BitcoinBlockPositionSchema,
+    source_code: Type.Optional(
+      Type.String({
+        description:
+          'The Clarity source code of the contract. Only present when requested via the ' +
+          '`include=source_code` query param.',
+      })
+    ),
+  },
+  { title: 'SmartContract' }
+);
+export type SmartContract = Static<typeof SmartContractSchema>;
+
+/**
+ * Heavy fields that callers can opt into via `?include=...`. Omitted by default to keep the
+ * response lean, since contract source code is unbounded in size.
+ */
+export const SmartContractIncludeFieldSchema = Type.Literal('source_code');
+export type SmartContractIncludeField = Static<typeof SmartContractIncludeFieldSchema>;

--- a/src/api/schemas/v3/entities/transaction-summaries.ts
+++ b/src/api/schemas/v3/entities/transaction-summaries.ts
@@ -89,7 +89,11 @@ export const SmartContractTransactionSummarySchema = Type.Composite(
         clarity_version: Nullable(
           Type.Number({
             description:
-              'The Clarity version of the contract, only specified for versioned contract transactions, otherwise null',
+              'The Clarity version of the contract. Versioned contract transactions declare it; ' +
+              'for the rest it is the version the node resolved from the epoch the contract was ' +
+              'deployed in. Null only when it could not be determined, which happens for ' +
+              'contracts indexed from a chainstate predating the point where the Stacks node ' +
+              'began reporting it.',
           })
         ),
         contract_id: Type.String({

--- a/src/api/serializers/v3/smart-contracts.ts
+++ b/src/api/serializers/v3/smart-contracts.ts
@@ -11,7 +11,7 @@ import { SmartContract } from '../../schemas/v3/entities/smart-contracts.js';
 export function serializeDbSmartContract(contract: DbSmartContractDetail): SmartContract {
   const result: SmartContract = {
     contract_id: contract.contract_id,
-    clarity_version: contract.clarity_version,
+    clarity_version: contract.clarity_version ?? 0,
     tx_id: contract.tx_id,
     block: {
       height: contract.block_height,

--- a/src/api/serializers/v3/smart-contracts.ts
+++ b/src/api/serializers/v3/smart-contracts.ts
@@ -1,0 +1,32 @@
+import { DbSmartContractDetail } from '../../../datastore/v3/types.js';
+import { SmartContract } from '../../schemas/v3/entities/smart-contracts.js';
+
+/**
+ * Serializes a database smart contract into a smart contract response entity. `source_code` is
+ * only present on the database row when the caller opted into it, so its presence here mirrors
+ * the requested `include` fields.
+ * @param contract - The database smart contract.
+ * @returns The serialized smart contract.
+ */
+export function serializeDbSmartContract(contract: DbSmartContractDetail): SmartContract {
+  const result: SmartContract = {
+    contract_id: contract.contract_id,
+    clarity_version: contract.clarity_version,
+    tx_id: contract.tx_id,
+    block: {
+      height: contract.block_height,
+      hash: contract.block_hash,
+      index_hash: contract.index_block_hash,
+      time: contract.block_time,
+      tx_index: contract.tx_index,
+    },
+    bitcoin_block: {
+      height: contract.burn_block_height,
+      time: contract.burn_block_time,
+    },
+  };
+  if (contract.source_code !== undefined) {
+    result.source_code = contract.source_code;
+  }
+  return result;
+}

--- a/src/api/serializers/v3/smart-contracts.ts
+++ b/src/api/serializers/v3/smart-contracts.ts
@@ -11,7 +11,7 @@ import { SmartContract } from '../../schemas/v3/entities/smart-contracts.js';
 export function serializeDbSmartContract(contract: DbSmartContractDetail): SmartContract {
   const result: SmartContract = {
     contract_id: contract.contract_id,
-    clarity_version: contract.clarity_version ?? 0,
+    clarity_version: contract.clarity_version,
     tx_id: contract.tx_id,
     block: {
       height: contract.block_height,

--- a/src/datastore/helpers.ts
+++ b/src/datastore/helpers.ts
@@ -412,6 +412,36 @@ export function parseMempoolTxQueryResult(result: MempoolTxQueryResult): DbMempo
 }
 
 /**
+ * Reads the Clarity version out of a contract's ABI.
+ *
+ * A contract deployed with an unversioned `SmartContract` payload carries no Clarity version on the
+ * wire, the node resolves it from the epoch at execution time and reports the result in the
+ * contract interface it sends to event observers as a serialized `ClarityVersion` variant name
+ * (`"Clarity3"`). Contracts deployed before stacks-core added that field (Jan 2023) have an ABI
+ * without it.
+ * @param abi - The `contract_interface` (or legacy `contract_abi`) from the node, if any.
+ * @returns The Clarity version, or null if the ABI does not report one.
+ */
+export function parseClarityVersionFromAbi(abi: unknown): number | null {
+  if (!abi || typeof abi !== 'object') {
+    return null;
+  }
+  const version = (abi as { clarity_version?: unknown }).clarity_version;
+  // Serialized as the enum variant name, e.g. `Clarity3`. Tolerate a bare number in case the
+  // node's serialization ever changes.
+  if (typeof version === 'number' && Number.isInteger(version)) {
+    return version;
+  }
+  if (typeof version === 'string') {
+    const match = /^Clarity(\d+)$/.exec(version);
+    if (match) {
+      return parseInt(match[1], 10);
+    }
+  }
+  return null;
+}
+
+/**
  * The consumers of db responses expect `abi` fields to be a stringified JSON if
  * exists, otherwise `undefined`.
  * The pg query returns a JSON object, `null` (or the string 'null').

--- a/src/datastore/v3/pg-store-v3.ts
+++ b/src/datastore/v3/pg-store-v3.ts
@@ -20,6 +20,7 @@ import {
   DbPrincipalTransactionSummary,
   DbStxTransferDirection,
   DbSignerStaker,
+  DbSmartContractDetail,
   DbStakingSigner,
   DbStakingSignerDetail,
   DbTransaction,
@@ -47,6 +48,7 @@ import { normalizeHashString } from '../../helpers.js';
 import { BlockIdParam } from '../../api/routes/v2/schemas.js';
 import { InvalidRequestError, InvalidRequestErrorType } from '../../errors.js';
 import { TransactionIncludeField } from '../../api/schemas/v3/entities/transactions.js';
+import { SmartContractIncludeField } from '../../api/schemas/v3/entities/smart-contracts.js';
 import type {
   BondCursor,
   FtBalanceCursor,
@@ -70,7 +72,7 @@ import {
   resolveEventPositionCursor,
   resolveTransactionCursor,
 } from './helpers.js';
-import { DbEventTypeId, DbSignerKeyGrantKind, DbTxTypeId } from '../common.js';
+import { DbEventTypeId, DbSignerKeyGrantKind, DbTxStatus, DbTxTypeId } from '../common.js';
 
 export class PgStoreV3 extends BasePgStoreModule {
   /**
@@ -2421,6 +2423,49 @@ export class PgStoreV3 extends BasePgStoreModule {
         results: results.map(r => ({ principal: r.principal, balance: r.balance })),
       };
     });
+  }
+
+  /**
+   * Gets a successfully deployed smart contract by its contract id, together with the block
+   * position of its deployment transaction. Deploy transactions that failed (or were skipped) do
+   * not create a contract, so they are excluded.
+   *
+   * Everything is sourced from `txs`, which carries the contract's clarity version and source code
+   * alongside the block position, so no join is required.
+   * @param args - The arguments for the query.
+   * @returns The smart contract, or null if it was never successfully deployed.
+   */
+  async getSmartContract(args: {
+    contractId: string;
+    include?: SmartContractIncludeField[];
+  }): Promise<DbSmartContractDetail | null> {
+    const sourceCode = args.include?.includes('source_code')
+      ? this.sql`, smart_contract_source_code AS source_code`
+      : this.sql``;
+    // Only one successful deploy can exist per contract id, but order by canonical chain position
+    // anyway so the row is deterministic if a reorg ever leaves duplicates behind.
+    const [result] = await this.sql<DbSmartContractDetail[]>`
+      SELECT
+        smart_contract_contract_id AS contract_id,
+        smart_contract_clarity_version AS clarity_version,
+        tx_id,
+        block_height,
+        block_hash,
+        index_block_hash,
+        block_time,
+        tx_index,
+        burn_block_height,
+        burn_block_time
+        ${sourceCode}
+      FROM txs
+      WHERE smart_contract_contract_id = ${args.contractId}
+        AND canonical = true
+        AND microblock_canonical = true
+        AND status = ${DbTxStatus.Success}
+      ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC
+      LIMIT 1
+    `;
+    return result ?? null;
   }
 
   /**

--- a/src/datastore/v3/types.ts
+++ b/src/datastore/v3/types.ts
@@ -369,3 +369,22 @@ export interface DbPrincipalNftBalance {
   /** The NFT instance value (Clarity value) as a `0x`-prefixed hex string. */
   value: string;
 }
+
+/**
+ * A successfully deployed smart contract, with the block position of its deployment transaction.
+ * `source_code` is only selected when the caller opts into it.
+ */
+export interface DbSmartContractDetail {
+  contract_id: string;
+  /** Null for contracts deployed before versioned contract transactions existed. */
+  clarity_version: number | null;
+  tx_id: string;
+  block_height: number;
+  block_hash: string;
+  index_block_hash: string;
+  block_time: number;
+  tx_index: number;
+  burn_block_height: number;
+  burn_block_time: number;
+  source_code?: string;
+}

--- a/src/datastore/v3/types.ts
+++ b/src/datastore/v3/types.ts
@@ -376,7 +376,11 @@ export interface DbPrincipalNftBalance {
  */
 export interface DbSmartContractDetail {
   contract_id: string;
-  /** Null for contracts deployed before versioned contract transactions existed. */
+  /**
+   * Declared by a versioned deploy, otherwise the version the node resolved from the deploy epoch
+   * and reported in the contract interface. Null only when it could not be recovered from that
+   * interface, i.e. a chainstate predating the point where the node began reporting it.
+   */
   clarity_version: number | null;
   tx_id: string;
   block_height: number;

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -55,6 +55,7 @@ import {
   createDbMempoolTxFromCoreMsg,
   createDbTxFromCoreMsg,
   getTxDbStatus,
+  parseClarityVersionFromAbi,
 } from '../datastore/helpers.js';
 import { handleBnsImport } from '../import-v1/index.js';
 import { hexToBuffer, isProdEnv, logger, PINO_LOGGER_CONFIG, stopwatch } from '@stacks/api-toolkit';
@@ -318,19 +319,28 @@ function parseDataStoreTxEventData(
       case TxPayloadTypeID.VersionedSmartContract:
       case TxPayloadTypeID.SmartContract: {
         const contractId = `${tx.sender_address}.${tx.parsed_tx.payload.contract_name}`;
+        const abi = tx.core_tx.contract_interface ?? tx.core_tx.contract_abi;
+        // An unversioned `SmartContract` payload declares no Clarity version; the node resolves it
+        // from the deploy epoch and reports the result in the contract interface, so fall back to
+        // that. Stays null for a failed deploy (no interface) or an ABI predating the field.
         const clarityVersion =
           tx.parsed_tx.payload.type_id == TxPayloadTypeID.VersionedSmartContract
             ? tx.parsed_tx.payload.clarity_version
-            : null;
+            : parseClarityVersionFromAbi(abi);
         dbTx.smartContracts.push({
           tx_id: tx.core_tx.txid,
           contract_id: contractId,
           block_height: blockData.block_height,
           clarity_version: clarityVersion,
           source_code: tx.parsed_tx.payload.code_body,
-          abi: JSON.stringify(tx.core_tx.contract_interface ?? tx.core_tx.contract_abi),
+          abi: JSON.stringify(abi),
           canonical: true,
         });
+        // Keep the denormalized copy on the tx row in step with the contract row. `txs` has no
+        // ABI column, so this is the only place the resolved version can reach it.
+        if (clarityVersion !== null) {
+          dbTx.tx.smart_contract_clarity_version = clarityVersion;
+        }
         break;
       }
       case TxPayloadTypeID.ContractCall: {

--- a/tests/api/smart-contracts/clarity-version-ingest.test.ts
+++ b/tests/api/smart-contracts/clarity-version-ingest.test.ts
@@ -1,0 +1,178 @@
+import { describe, test, beforeEach, afterEach } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { STACKS_TESTNET } from '@stacks/network';
+import { PgWriteStore } from '../../../src/datastore/pg-write-store.ts';
+import { ApiServer, startApiServer } from '../../../src/api/init.ts';
+import { EventStreamServer, startEventServer } from '../../../src/event-stream/event-server.ts';
+import { httpPostRequest } from '../../../src/helpers.ts';
+import { migrate } from '../../test-helpers.ts';
+
+/**
+ * An unversioned `SmartContract` deploy (payload type id 1), which carries no Clarity version on
+ * the wire. Deploys `hello-world` from ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.
+ */
+const UNVERSIONED_DEPLOY_RAW_TX =
+  '0x808000000004006d78de7b0625dfbfc16c3a8a5735f6dc3dc3f2ce000000000000000000000000000000c8' +
+  '0000c4e4b5ccb0001d3dba300fea573316f2bd4f4bc0e23507dc539a7e7591142b66161bb4aa3a96d6d33ab5445' +
+  'd4a2717a5adac36009d855c41087452aa9d1f03b0030200000000010b68656c6c6f2d776f726c640000001f2864' +
+  '6566696e652d7075626c6963202868656c6c6f2920286f6b2075312929';
+const TX_ID = '0x93f5d67bbff343245d539033a9bbee22001d4f406f8c80ee5a6a4e0115b409c8';
+const CONTRACT_ID = 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.hello-world';
+
+/** A contract interface as the node sends it for a deploy it just executed. */
+function contractInterface(clarityVersion: string | null) {
+  return {
+    functions: [],
+    variables: [],
+    maps: [],
+    fungible_tokens: [],
+    non_fungible_tokens: [],
+    ...(clarityVersion ? { epoch: 'Epoch21', clarity_version: clarityVersion } : {}),
+  };
+}
+
+function newBlockPayload(contract_interface: object | null) {
+  return {
+    block_height: 1,
+    block_hash: '0x9947cef1f6758fd2074aa62189f4daa4dcdae1a46410ef9cb4dd0224aa10814f',
+    index_block_hash: '0x7d0cf996be2f9f18a2c791de4b374ec90ad6fb26405d0d27f0e5c368be74b575',
+    parent_block_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    parent_index_block_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    parent_microblock: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    parent_microblock_sequence: 0,
+    burn_block_hash: '0x3f96d68c6f023d9f209956b372bfbd56e1790fab59597b954a1d70e864fd39c1',
+    burn_block_height: 713000,
+    burn_block_time: 1729517584,
+    block_time: 1729517589,
+    parent_burn_block_hash: '0x3f96d68c6f023d9f209956b372bfbd56e1790fab59597b954a1d70e864fd39c1',
+    parent_burn_block_height: 712999,
+    parent_burn_block_timestamp: 1729517584,
+    miner_txid: '0x50aee39a8f19ddda51765338b54f631b0845907d44402c925d6cc1c12143ed7c',
+    events: [],
+    matured_miner_rewards: [],
+    reward_set: null,
+    cycle_number: null,
+    signer_bitvec: null,
+    anchored_cost: {
+      runtime: 0,
+      read_count: 0,
+      read_length: 0,
+      write_count: 0,
+      write_length: 0,
+    },
+    confirmed_microblocks_cost: {
+      runtime: 0,
+      read_count: 0,
+      read_length: 0,
+      write_count: 0,
+      write_length: 0,
+    },
+    transactions: [
+      {
+        txid: TX_ID,
+        raw_tx: UNVERSIONED_DEPLOY_RAW_TX,
+        status: 'success',
+        tx_index: 0,
+        raw_result: '0x0703',
+        burnchain_op: null,
+        contract_interface,
+        contract_abi: null,
+        execution_cost: {
+          runtime: 0,
+          read_count: 0,
+          read_length: 0,
+          write_count: 0,
+          write_length: 0,
+        },
+        microblock_hash: null,
+        microblock_sequence: null,
+        microblock_parent_hash: null,
+      },
+    ],
+  };
+}
+
+describe('clarity version ingestion', () => {
+  let db: PgWriteStore;
+  let api: ApiServer;
+  let eventServer: EventStreamServer;
+
+  beforeEach(async () => {
+    await migrate('up');
+    db = await PgWriteStore.connect({
+      usageName: 'tests',
+      withNotifier: false,
+      skipMigrations: true,
+    });
+    api = await startApiServer({ datastore: db, chainId: STACKS_TESTNET.chainId });
+    eventServer = await startEventServer({
+      datastore: db,
+      chainId: STACKS_TESTNET.chainId,
+      serverHost: '127.0.0.1',
+      serverPort: 0,
+    });
+  });
+
+  afterEach(async () => {
+    await eventServer.closeAsync();
+    await api.terminate();
+    await db?.close();
+    await migrate('down');
+  });
+
+  async function ingest(contract_interface: object | null) {
+    await httpPostRequest({
+      host: '127.0.0.1',
+      port: eventServer.serverAddress.port,
+      path: '/new_block',
+      headers: { 'Content-Type': 'application/json' },
+      body: Buffer.from(JSON.stringify(newBlockPayload(contract_interface)), 'utf8'),
+      throwOnNotOK: true,
+    });
+  }
+
+  async function storedVersions() {
+    const [contract] = await db.sql<{ clarity_version: number | null }[]>`
+      SELECT clarity_version FROM smart_contracts WHERE contract_id = ${CONTRACT_ID}
+    `;
+    const [tx] = await db.sql<{ smart_contract_clarity_version: number | null }[]>`
+      SELECT smart_contract_clarity_version FROM txs WHERE tx_id = ${TX_ID}
+    `;
+    return {
+      smartContract: contract?.clarity_version ?? null,
+      tx: tx?.smart_contract_clarity_version ?? null,
+    };
+  }
+
+  async function endpointVersion() {
+    const res = await api.fastifyApp.inject({
+      method: 'GET',
+      url: `/extended/v3/smart-contracts/${CONTRACT_ID}`,
+    });
+    assert.equal(res.statusCode, 200);
+    return JSON.parse(res.body).clarity_version;
+  }
+
+  test('records the version the node resolved for an unversioned deploy', async () => {
+    await ingest(contractInterface('Clarity2'));
+
+    // Both stored copies, since `txs` is what the endpoint reads and `smart_contracts` is where
+    // the ABI lives.
+    assert.deepEqual(await storedVersions(), { smartContract: 2, tx: 2 });
+    assert.equal(await endpointVersion(), 2);
+  });
+
+  test('stays null when the node reports no version', async () => {
+    // A contract interface from a node predating the `clarity_version` field.
+    await ingest(contractInterface(null));
+
+    assert.deepEqual(await storedVersions(), { smartContract: null, tx: null });
+    assert.equal(await endpointVersion(), null);
+  });
+
+  test('stays null when there is no contract interface at all', async () => {
+    await ingest(null);
+
+    assert.deepEqual(await storedVersions(), { smartContract: null, tx: null });
+  });
+});

--- a/tests/api/smart-contracts/smart-contract-v3.test.ts
+++ b/tests/api/smart-contracts/smart-contract-v3.test.ts
@@ -1,0 +1,179 @@
+import { describe, test, beforeEach, afterEach } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { STACKS_TESTNET } from '@stacks/network';
+import { PgWriteStore } from '../../../src/datastore/pg-write-store.ts';
+import { ApiServer, startApiServer } from '../../../src/api/init.ts';
+import { migrate } from '../../test-helpers.ts';
+import { TestBlockBuilder } from '../test-builders.ts';
+import { DbTxStatus, DbTxTypeId } from '../../../src/datastore/common.ts';
+import { hex } from '../test-helpers.ts';
+
+const CONTRACT_ID = 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world';
+const SOURCE_CODE = '(define-public (hello) (ok u1))';
+
+describe('v3 smart contract', () => {
+  let db: PgWriteStore;
+  let api: ApiServer;
+
+  beforeEach(async () => {
+    await migrate('up');
+    db = await PgWriteStore.connect({
+      usageName: 'tests',
+      withNotifier: false,
+      skipMigrations: true,
+    });
+    api = await startApiServer({ datastore: db, chainId: STACKS_TESTNET.chainId });
+  });
+
+  afterEach(async () => {
+    await api.terminate();
+    await db?.close();
+    await migrate('down');
+  });
+
+  async function get(contractId: string, query = '') {
+    return await api.fastifyApp.inject({
+      method: 'GET',
+      url: `/extended/v3/smart-contracts/${contractId}${query}`,
+    });
+  }
+
+  /** Deploys a contract in its own block. */
+  async function deploy(args: {
+    blockHeight: number;
+    txId: string;
+    contractId?: string;
+    status?: DbTxStatus;
+    clarityVersion?: number;
+    typeId?: DbTxTypeId;
+  }) {
+    await db.update(
+      new TestBlockBuilder({
+        block_height: args.blockHeight,
+        index_block_hash: hex(args.blockHeight),
+        parent_index_block_hash: hex(args.blockHeight - 1),
+      })
+        .addTx({
+          tx_id: args.txId,
+          type_id: args.typeId ?? DbTxTypeId.VersionedSmartContract,
+          status: args.status ?? DbTxStatus.Success,
+          smart_contract_contract_id: args.contractId ?? CONTRACT_ID,
+          smart_contract_source_code: SOURCE_CODE,
+          smart_contract_clarity_version: args.clarityVersion ?? 3,
+        })
+        .build()
+    );
+  }
+
+  test('returns a deployed contract with its deployment transaction', async () => {
+    await deploy({ blockHeight: 1, txId: hex(0x11) });
+
+    const res = await get(CONTRACT_ID);
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+
+    assert.equal(body.contract_id, CONTRACT_ID);
+    assert.equal(body.clarity_version, 3);
+    assert.equal(body.tx_id, hex(0x11));
+    assert.equal(body.block.height, 1);
+    assert.equal(typeof body.block.hash, 'string');
+    assert.equal(typeof body.block.index_hash, 'string');
+    assert.equal(typeof body.block.time, 'number');
+    assert.equal(body.block.tx_index, 0);
+    assert.equal(typeof body.bitcoin_block.height, 'number');
+    assert.equal(typeof body.bitcoin_block.time, 'number');
+  });
+
+  test('omits source code unless requested', async () => {
+    await deploy({ blockHeight: 1, txId: hex(0x11) });
+
+    const lean = JSON.parse((await get(CONTRACT_ID)).body);
+    assert.equal(lean.source_code, undefined);
+
+    const included = JSON.parse((await get(CONTRACT_ID, '?include=source_code')).body);
+    assert.equal(included.source_code, SOURCE_CODE);
+  });
+
+  test('rejects an unknown include field', async () => {
+    await deploy({ blockHeight: 1, txId: hex(0x11) });
+
+    const res = await get(CONTRACT_ID, '?include=abi');
+    assert.equal(res.statusCode, 400);
+  });
+
+  test('404s for a contract that was never deployed', async () => {
+    await deploy({ blockHeight: 1, txId: hex(0x11) });
+
+    const res = await get('ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.nonexistent');
+    assert.equal(res.statusCode, 404);
+  });
+
+  test('404s when the deploy transaction failed', async () => {
+    await deploy({ blockHeight: 1, txId: hex(0x11), status: DbTxStatus.AbortByResponse });
+
+    const res = await get(CONTRACT_ID);
+    assert.equal(res.statusCode, 404);
+  });
+
+  test('ignores a failed deploy and returns the successful one', async () => {
+    await deploy({ blockHeight: 1, txId: hex(0x11), status: DbTxStatus.AbortByResponse });
+    await deploy({ blockHeight: 2, txId: hex(0x22), status: DbTxStatus.Success });
+
+    const res = await get(CONTRACT_ID);
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    assert.equal(body.tx_id, hex(0x22));
+    assert.equal(body.block.height, 2);
+  });
+
+  test('returns a null clarity version for an unversioned deploy', async () => {
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        index_block_hash: hex(1),
+        parent_index_block_hash: hex(0),
+      })
+        .addTx({
+          tx_id: hex(0x11),
+          type_id: DbTxTypeId.SmartContract,
+          status: DbTxStatus.Success,
+          smart_contract_contract_id: CONTRACT_ID,
+          smart_contract_source_code: SOURCE_CODE,
+        })
+        .build()
+    );
+
+    const res = await get(CONTRACT_ID);
+    assert.equal(res.statusCode, 200);
+    assert.equal(JSON.parse(res.body).clarity_version, null);
+  });
+
+  test('404s once the deploy block is reorged out', async () => {
+    await deploy({ blockHeight: 1, txId: hex(0x11) });
+    assert.equal((await get(CONTRACT_ID)).statusCode, 200);
+
+    // Re-org: a competing chain replaces block 1, orphaning the deploy.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        block_hash: hex(0xaa),
+        index_block_hash: hex(0xbb),
+        parent_index_block_hash: hex(0),
+      })
+        .addTx({ tx_id: hex(0x99) })
+        .build()
+    );
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        block_hash: hex(0xcc),
+        index_block_hash: hex(0xdd),
+        parent_index_block_hash: hex(0xbb),
+      })
+        .addTx({ tx_id: hex(0x98) })
+        .build()
+    );
+
+    assert.equal((await get(CONTRACT_ID)).statusCode, 404);
+  });
+});

--- a/tests/api/smart-contracts/smart-contract-v3.test.ts
+++ b/tests/api/smart-contracts/smart-contract-v3.test.ts
@@ -151,6 +151,30 @@ describe('v3 smart contract', () => {
     assert.equal(JSON.parse(res.body).clarity_version, 2);
   });
 
+  test('serves a null clarity version when it could not be determined', async () => {
+    // Only reachable for contracts indexed from a chainstate predating the point where the node
+    // began reporting the resolved version in the contract interface.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        index_block_hash: hex(1),
+        parent_index_block_hash: hex(0),
+      })
+        .addTx({
+          tx_id: hex(0x11),
+          type_id: DbTxTypeId.SmartContract,
+          status: DbTxStatus.Success,
+          smart_contract_contract_id: CONTRACT_ID,
+          smart_contract_source_code: SOURCE_CODE,
+        })
+        .build()
+    );
+
+    const res = await get(CONTRACT_ID);
+    assert.equal(res.statusCode, 200);
+    assert.equal(JSON.parse(res.body).clarity_version, null);
+  });
+
   test('404s once the deploy block is reorged out', async () => {
     await deploy({ blockHeight: 1, txId: hex(0x11) });
     assert.equal((await get(CONTRACT_ID)).statusCode, 200);

--- a/tests/api/smart-contracts/smart-contract-v3.test.ts
+++ b/tests/api/smart-contracts/smart-contract-v3.test.ts
@@ -126,7 +126,9 @@ describe('v3 smart contract', () => {
     assert.equal(body.block.height, 2);
   });
 
-  test('returns a null clarity version for an unversioned deploy', async () => {
+  test('serves the clarity version an unversioned deploy resolved to', async () => {
+    // An unversioned deploy declares no version; ingestion records the one the node reported in
+    // the contract interface, so the endpoint still serves a concrete version.
     await db.update(
       new TestBlockBuilder({
         block_height: 1,
@@ -139,13 +141,14 @@ describe('v3 smart contract', () => {
           status: DbTxStatus.Success,
           smart_contract_contract_id: CONTRACT_ID,
           smart_contract_source_code: SOURCE_CODE,
+          smart_contract_clarity_version: 2,
         })
         .build()
     );
 
     const res = await get(CONTRACT_ID);
     assert.equal(res.statusCode, 200);
-    assert.equal(JSON.parse(res.body).clarity_version, null);
+    assert.equal(JSON.parse(res.body).clarity_version, 2);
   });
 
   test('404s once the deploy block is reorged out', async () => {


### PR DESCRIPTION
Adds a v3 replacement for `GET /extended/v1/contract/{contract_id}`, deprecates the two v1 contract endpoints, and fixes the long-standing `clarity_version: null` problem at its source.

### New endpoint

`GET /extended/v3/smart-contracts/{contract_id}`

```json
{
  "contract_id": "ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world",
  "clarity_version": 2,
  "tx_id": "0xf6bd5f4a7b26184a3466340b2e99fd003b4962c0e382a7e4b6a13df3dd7a91c6",
  "block": {
    "height": 1,
    "hash": "0x123456",
    "index_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
    "time": 94869287,
    "tx_index": 0
  },
  "bitcoin_block": {
    "height": 1,
    "time": 94869286
  }
}
```

`GET /extended/v3/smart-contracts/{contract_id}?include=source_code` returns the same object plus:

```json
  "source_code": "(define-public (hello)\n  (ok u1))"
```

### Resolving `clarity_version`

An unversioned `SmartContract` payload carries no Clarity version on the wire (the node resolves it from the epoch at execution time) so the API recorded `null` for every one of them. This is not confined to old contracts: the unversioned payload is not deprecated and new deploys keep arriving that way.

The node does report the version it resolved, in the `contract_interface` it sends to event observers, and we already persist that whole blob in `smart_contracts.abi`. So:

- **Ingest** now falls back to the ABI's `clarity_version` for unversioned deploys, writing it to both `smart_contracts.clarity_version` and the denormalized `txs.smart_contract_clarity_version`. `txs` has no ABI column, so that second write is the only path by which the value reaches the column the endpoint reads.
- **A migration** recovers the same value for existing rows.

`clarity_version` stays nullable. Where the ABI cannot supply a version, the field is `null` rather than a fabricated value.
