### PR TITLE
chore: log pending and running SQL migration names at startup

### DIFF
--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -225,8 +225,13 @@ export class PgWriteStore extends PgStore {
         logger: {
           debug: _msg => {},
           info: msg => {
+            if (isTestEnv) return;
             if (msg.includes('Migrating files')) {
-              logger.info(`Performing SQL migration, this may take a while...`);
+              logger.info(`Performing SQL migrations, this may take a while...`);
+            } else if (msg.startsWith('> - ')) {
+              logger.info(`Pending migration: ${msg.substring(4)}`);
+            } else if (msg.startsWith('### MIGRATION')) {
+              logger.info(`Running migration: ${msg.replace(/#/g, '').trim().substring(10)}`);
             }
           },
           warn: msg => logger.warn(msg),


### PR DESCRIPTION
Improves migration logging in `PgWriteStore.connect`. Previously the only signal was a generic `Performing SQL migration, this may take a while...` line. Now the migration logger surfaces the per-migration messages node-pg-migrate already emits:

```
Performing SQL migrations, this may take a while...
Pending migration: 1779800000013_backfill-clarity-versions
Pending migration: 1779800000013_nft-events-history-index
Running migration: 1779800000013_backfill-clarity-versions (UP)
Running migration: 1779800000013_nft-events-history-index (UP)
```