### PR TITLE
chore: deprecate v1 pox2/pox3/pox4 endpoints

### DIFF
--- a/src/api/routes/v1/pox.ts
+++ b/src/api/routes/v1/pox.ts
@@ -15,6 +15,11 @@ import { NotFoundError } from '../../../errors.js';
 import { PaginatedResponse } from '../../schemas/v1/util.js';
 import { PoolDelegation, PoolDelegationSchema } from '../../schemas/v1/entities/pox.js';
 
+const HISTORICAL_DEPRECATION_NOTE =
+  '**Deprecated:** this endpoint serves historical pox-4 and earlier data only.';
+const HISTORICAL_DEPRECATION_MESSAGE =
+  'Historical pox-4 and earlier data only. See /extended/v3/principals/{principal}/staking for pox-5 data.';
+
 export const PoxEventRoutes: FastifyPluginAsync<
   Record<never, never>,
   Server,
@@ -47,8 +52,10 @@ export const PoxRoutes: FastifyPluginAsync<
       preHandler: handleChainTipCache,
       schema: {
         // operationId: '',
+        deprecated: true,
+        deprecatedMessage: HISTORICAL_DEPRECATION_MESSAGE,
         summary: 'Get latest PoX events',
-        // description: ``,
+        description: `Retrieves the most recent PoX events. ${HISTORICAL_DEPRECATION_NOTE}`,
         tags: ['Stacking'],
         params: Type.Object({
           pox: Type.Enum({ pox2: 'pox2', pox3: 'pox3', pox4: 'pox4' }),
@@ -85,8 +92,10 @@ export const PoxRoutes: FastifyPluginAsync<
       preHandler: handleChainTipCache,
       schema: {
         // operationId: '',
+        deprecated: true,
+        deprecatedMessage: HISTORICAL_DEPRECATION_MESSAGE,
         summary: 'Get PoX events for a transaction',
-        // description: ``,
+        description: `Retrieves the PoX events produced by a given transaction. ${HISTORICAL_DEPRECATION_NOTE}`,
         tags: ['Stacking'],
         params: Type.Object({
           pox: Type.Enum({ pox2: 'pox2', pox3: 'pox3', pox4: 'pox4' }),
@@ -119,8 +128,10 @@ export const PoxRoutes: FastifyPluginAsync<
       preHandler: handleChainTipCache,
       schema: {
         // operationId: '',
+        deprecated: true,
+        deprecatedMessage: HISTORICAL_DEPRECATION_MESSAGE,
         summary: 'Get events for a stacking address',
-        // description: ``,
+        description: `Retrieves the PoX events for a given stacker principal. ${HISTORICAL_DEPRECATION_NOTE}`,
         tags: ['Stacking'],
         params: Type.Object({
           pox: Type.Enum({ pox2: 'pox2', pox3: 'pox3', pox4: 'pox4' }),
@@ -153,8 +164,10 @@ export const PoxRoutes: FastifyPluginAsync<
       preHandler: handleChainTipCache,
       schema: {
         operationId: 'get_pool_delegations',
+        deprecated: true,
+        deprecatedMessage: HISTORICAL_DEPRECATION_MESSAGE,
         summary: 'Stacking pool members',
-        description: `Retrieves the list of stacking pool members for a given delegator principal.`,
+        description: `Retrieves the list of stacking pool members for a given delegator principal. ${HISTORICAL_DEPRECATION_NOTE}`,
         tags: ['Stacking'],
         params: Type.Object({
           pox: Type.Enum({ pox2: 'pox2', pox3: 'pox3', pox4: 'pox4' }),

--- a/src/api/routes/v1/pox.ts
+++ b/src/api/routes/v1/pox.ts
@@ -15,10 +15,16 @@ import { NotFoundError } from '../../../errors.js';
 import { PaginatedResponse } from '../../schemas/v1/util.js';
 import { PoolDelegation, PoolDelegationSchema } from '../../schemas/v1/entities/pox.js';
 
-const HISTORICAL_DEPRECATION_NOTE =
-  '**Deprecated:** this endpoint serves historical pox-4 and earlier data only.';
-const HISTORICAL_DEPRECATION_MESSAGE =
-  'Historical pox-4 and earlier data only. See /extended/v3/principals/{principal}/staking for pox-5 data.';
+/**
+ * Shared opening line for the deprecation notices below: every route in this file reads the
+ * `pox2_events` / `pox3_events` / `pox4_events` tables and has no pox-5 counterpart. What follows
+ * it differs per route — two have a partial pox-5 equivalent, two have none, so the rest of each
+ * message is written inline at the route.
+ *
+ * These strings reach consumers in the `Warning` header, and in the `410 Gone` body once
+ * `ENABLE_DEPRECATED_ENDPOINTS` is turned off, so they are plain text rather than markdown.
+ */
+const HISTORICAL = 'Historical pox-4 and earlier data only.';
 
 export const PoxEventRoutes: FastifyPluginAsync<
   Record<never, never>,
@@ -53,9 +59,9 @@ export const PoxRoutes: FastifyPluginAsync<
       schema: {
         // operationId: '',
         deprecated: true,
-        deprecatedMessage: HISTORICAL_DEPRECATION_MESSAGE,
+        deprecatedMessage: `${HISTORICAL} No pox-5 replacement; there is no global pox-5 event feed.`,
         summary: 'Get latest PoX events',
-        description: `Retrieves the most recent PoX events. ${HISTORICAL_DEPRECATION_NOTE}`,
+        description: `Retrieves the most recent PoX events. **Deprecated:** ${HISTORICAL} No pox-5 replacement; there is no global pox-5 event feed.`,
         tags: ['Stacking'],
         params: Type.Object({
           pox: Type.Enum({ pox2: 'pox2', pox3: 'pox3', pox4: 'pox4' }),
@@ -93,9 +99,9 @@ export const PoxRoutes: FastifyPluginAsync<
       schema: {
         // operationId: '',
         deprecated: true,
-        deprecatedMessage: HISTORICAL_DEPRECATION_MESSAGE,
+        deprecatedMessage: `${HISTORICAL} No pox-5 replacement; v3 transaction events do not carry decoded pox operations.`,
         summary: 'Get PoX events for a transaction',
-        description: `Retrieves the PoX events produced by a given transaction. ${HISTORICAL_DEPRECATION_NOTE}`,
+        description: `Retrieves the PoX events produced by a given transaction. **Deprecated:** ${HISTORICAL} No pox-5 replacement; v3 transaction events do not carry decoded pox operations.`,
         tags: ['Stacking'],
         params: Type.Object({
           pox: Type.Enum({ pox2: 'pox2', pox3: 'pox3', pox4: 'pox4' }),
@@ -129,9 +135,9 @@ export const PoxRoutes: FastifyPluginAsync<
       schema: {
         // operationId: '',
         deprecated: true,
-        deprecatedMessage: HISTORICAL_DEPRECATION_MESSAGE,
+        deprecatedMessage: `${HISTORICAL} For a principal's current pox-5 position see /extended/v3/principals/{principal}/staking; there is no pox-5 event history equivalent.`,
         summary: 'Get events for a stacking address',
-        description: `Retrieves the PoX events for a given stacker principal. ${HISTORICAL_DEPRECATION_NOTE}`,
+        description: `Retrieves the PoX events for a given stacker principal. **Deprecated:** ${HISTORICAL} For a principal's current pox-5 position see /extended/v3/principals/{principal}/staking; there is no pox-5 event history equivalent.`,
         tags: ['Stacking'],
         params: Type.Object({
           pox: Type.Enum({ pox2: 'pox2', pox3: 'pox3', pox4: 'pox4' }),
@@ -165,9 +171,9 @@ export const PoxRoutes: FastifyPluginAsync<
       schema: {
         operationId: 'get_pool_delegations',
         deprecated: true,
-        deprecatedMessage: HISTORICAL_DEPRECATION_MESSAGE,
+        deprecatedMessage: `${HISTORICAL} See /extended/v3/staking/signers/{principal}/stakers for the pox-5 equivalent.`,
         summary: 'Stacking pool members',
-        description: `Retrieves the list of stacking pool members for a given delegator principal. ${HISTORICAL_DEPRECATION_NOTE}`,
+        description: `Retrieves the list of stacking pool members for a given delegator principal. **Deprecated:** ${HISTORICAL} See /extended/v3/staking/signers/{principal}/stakers for the pox-5 equivalent.`,
         tags: ['Stacking'],
         params: Type.Object({
           pox: Type.Enum({ pox2: 'pox2', pox3: 'pox3', pox4: 'pox4' }),

--- a/tests/api/pox5/v1-pox-deprecation.test.ts
+++ b/tests/api/pox5/v1-pox-deprecation.test.ts
@@ -13,17 +13,49 @@ import { migrate } from '../../test-helpers.ts';
  * pox-5 counterpart, so they serve historical data only. They live in this suite because it is
  * the stacking-focused one; the routes themselves are v1, not pox-5.
  *
- * The `Warning` header is attached by `DeprecationPlugin` on `onSend`, which runs for error
- * responses too — so the 404s below still assert the deprecation contract without needing
- * fixture data.
+ * Each route carries its own message, because the pox-5 pointer differs per route — the
+ * assertions below pin the exact text, since it is what consumers see in the `Warning` header
+ * and in the `410 Gone` body after sunset.
+ *
+ * The header is attached by `DeprecationPlugin` on `onSend`, which runs for error responses too —
+ * so the 404s below still assert the deprecation contract without needing fixture data.
  */
 
-const EXPECTED_WARNING =
-  '299 - "Deprecated: Historical pox-4 and earlier data only. ' +
-  'See /extended/v3/principals/{principal}/staking for pox-5 data."';
+const HISTORICAL = 'Historical pox-4 and earlier data only.';
+const warning = (message: string) => `299 - "Deprecated: ${message}"`;
 
 const PRINCIPAL = 'ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP';
 const TX_ID = '0x' + '11'.repeat(32);
+
+const ROUTES = [
+  {
+    name: 'events',
+    path: (pox: string) => `/extended/v1/${pox}/events`,
+    warning: warning(`${HISTORICAL} No pox-5 replacement; there is no global pox-5 event feed.`),
+  },
+  {
+    name: 'tx/:tx_id',
+    path: (pox: string) => `/extended/v1/${pox}/tx/${TX_ID}`,
+    warning: warning(
+      `${HISTORICAL} No pox-5 replacement; v3 transaction events do not carry decoded pox operations.`
+    ),
+  },
+  {
+    name: 'stacker/:principal',
+    path: (pox: string) => `/extended/v1/${pox}/stacker/${PRINCIPAL}`,
+    warning: warning(
+      `${HISTORICAL} For a principal's current pox-5 position see ` +
+        `/extended/v3/principals/{principal}/staking; there is no pox-5 event history equivalent.`
+    ),
+  },
+  {
+    name: ':pool_principal/delegations',
+    path: (pox: string) => `/extended/v1/${pox}/${PRINCIPAL}/delegations`,
+    warning: warning(
+      `${HISTORICAL} See /extended/v3/staking/signers/{principal}/stakers for the pox-5 equivalent.`
+    ),
+  },
+];
 
 describe('v1 pox endpoint deprecation', () => {
   let db: PgWriteStore;
@@ -45,30 +77,21 @@ describe('v1 pox endpoint deprecation', () => {
     await migrate('down');
   });
 
-  // Each route, for every pox version it accepts. `/events` is the only one that resolves
-  // without fixture data; the rest 404, which still exercises the `onSend` hook.
   for (const pox of ['pox2', 'pox3', 'pox4']) {
-    test(`GET /extended/v1/${pox}/events is deprecated`, async () => {
-      const res = await supertest(api.server).get(`/extended/v1/${pox}/events`);
-      assert.equal(res.status, 200);
-      assert.equal(res.headers['warning'], EXPECTED_WARNING);
-    });
-
-    test(`GET /extended/v1/${pox}/tx/:tx_id is deprecated`, async () => {
-      const res = await supertest(api.server).get(`/extended/v1/${pox}/tx/${TX_ID}`);
-      assert.equal(res.headers['warning'], EXPECTED_WARNING);
-    });
-
-    test(`GET /extended/v1/${pox}/stacker/:principal is deprecated`, async () => {
-      const res = await supertest(api.server).get(`/extended/v1/${pox}/stacker/${PRINCIPAL}`);
-      assert.equal(res.headers['warning'], EXPECTED_WARNING);
-    });
-
-    test(`GET /extended/v1/${pox}/:pool_principal/delegations is deprecated`, async () => {
-      const res = await supertest(api.server).get(`/extended/v1/${pox}/${PRINCIPAL}/delegations`);
-      assert.equal(res.headers['warning'], EXPECTED_WARNING);
-    });
+    for (const route of ROUTES) {
+      test(`GET /extended/v1/${pox}/${route.name} carries its own deprecation warning`, async () => {
+        const res = await supertest(api.server).get(route.path(pox));
+        assert.equal(res.headers['warning'], route.warning);
+      });
+    }
   }
+
+  test('each route advertises a distinct replacement', async () => {
+    // Guards against a future refactor collapsing these back into one shared message: the whole
+    // point is that the pox-5 pointer differs per route.
+    const warnings = new Set(ROUTES.map(r => r.warning));
+    assert.equal(warnings.size, ROUTES.length);
+  });
 
   test('the deprecated routes are still served, not disabled', async () => {
     // `ENABLE_DEPRECATED_ENDPOINTS` defaults to true, so deprecation must not turn into 410 here.

--- a/tests/api/pox5/v1-pox-deprecation.test.ts
+++ b/tests/api/pox5/v1-pox-deprecation.test.ts
@@ -1,0 +1,79 @@
+import supertest from 'supertest';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { STACKS_TESTNET } from '@stacks/network';
+import { ApiServer, startApiServer } from '../../../src/api/init.ts';
+import { PgWriteStore } from '../../../src/datastore/pg-write-store.ts';
+import { migrate } from '../../test-helpers.ts';
+
+/**
+ * Deprecation coverage for the legacy `/extended/v1/pox{2,3,4}` routes.
+ *
+ * These endpoints read the `pox2_events` / `pox3_events` / `pox4_events` tables and have no
+ * pox-5 counterpart, so they serve historical data only. They live in this suite because it is
+ * the stacking-focused one; the routes themselves are v1, not pox-5.
+ *
+ * The `Warning` header is attached by `DeprecationPlugin` on `onSend`, which runs for error
+ * responses too — so the 404s below still assert the deprecation contract without needing
+ * fixture data.
+ */
+
+const EXPECTED_WARNING =
+  '299 - "Deprecated: Historical pox-4 and earlier data only. ' +
+  'See /extended/v3/principals/{principal}/staking for pox-5 data."';
+
+const PRINCIPAL = 'ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP';
+const TX_ID = '0x' + '11'.repeat(32);
+
+describe('v1 pox endpoint deprecation', () => {
+  let db: PgWriteStore;
+  let api: ApiServer;
+
+  beforeEach(async () => {
+    await migrate('up');
+    db = await PgWriteStore.connect({
+      usageName: 'tests',
+      withNotifier: false,
+      skipMigrations: true,
+    });
+    api = await startApiServer({ datastore: db, chainId: STACKS_TESTNET.chainId });
+  });
+
+  afterEach(async () => {
+    await api.terminate();
+    await db?.close();
+    await migrate('down');
+  });
+
+  // Each route, for every pox version it accepts. `/events` is the only one that resolves
+  // without fixture data; the rest 404, which still exercises the `onSend` hook.
+  for (const pox of ['pox2', 'pox3', 'pox4']) {
+    test(`GET /extended/v1/${pox}/events is deprecated`, async () => {
+      const res = await supertest(api.server).get(`/extended/v1/${pox}/events`);
+      assert.equal(res.status, 200);
+      assert.equal(res.headers['warning'], EXPECTED_WARNING);
+    });
+
+    test(`GET /extended/v1/${pox}/tx/:tx_id is deprecated`, async () => {
+      const res = await supertest(api.server).get(`/extended/v1/${pox}/tx/${TX_ID}`);
+      assert.equal(res.headers['warning'], EXPECTED_WARNING);
+    });
+
+    test(`GET /extended/v1/${pox}/stacker/:principal is deprecated`, async () => {
+      const res = await supertest(api.server).get(`/extended/v1/${pox}/stacker/${PRINCIPAL}`);
+      assert.equal(res.headers['warning'], EXPECTED_WARNING);
+    });
+
+    test(`GET /extended/v1/${pox}/:pool_principal/delegations is deprecated`, async () => {
+      const res = await supertest(api.server).get(`/extended/v1/${pox}/${PRINCIPAL}/delegations`);
+      assert.equal(res.headers['warning'], EXPECTED_WARNING);
+    });
+  }
+
+  test('the deprecated routes are still served, not disabled', async () => {
+    // `ENABLE_DEPRECATED_ENDPOINTS` defaults to true, so deprecation must not turn into 410 here.
+    const res = await supertest(api.server).get('/extended/v1/pox4/events');
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.body.results, []);
+  });
+});


### PR DESCRIPTION
Marks the four legacy `/extended/v1/pox{2,3,4}` endpoints as deprecated:

- `GET /extended/v1/pox{2,3,4}/events`
- `GET /extended/v1/pox{2,3,4}/tx/{tx_id}`
- `GET /extended/v1/pox{2,3,4}/stacker/{principal}`
- `GET /extended/v1/pox{2,3,4}/{pool_principal}/delegations`

These routes read the `pox2_events` / `pox3_events` / `pox4_events` tables — the `poxTables` map in `src/api/routes/v1/pox.ts` has no `pox5` entry, so they structurally cannot serve pox-5 data.