### PR TITLE
feat: add v3 batch transaction summaries endpoint and deprecate v1 tx/multiple

### DIFF
--- a/src/api/query-helpers.ts
+++ b/src/api/query-helpers.ts
@@ -1,6 +1,7 @@
 import { isValidPrincipal } from './../helpers.js';
 import { InvalidRequestError, InvalidRequestErrorType } from '../errors.js';
 import { has0xPrefix, hexToBuffer } from '@stacks/api-toolkit';
+import type { FastifyReply, FastifyRequest, HookHandlerDoneFunction } from 'fastify';
 
 /**
  * Determines if the query parameters of a request are intended to include data for a specific block height,
@@ -93,4 +94,25 @@ export function isValidTxId(tx_id: string) {
   } catch {
     return false;
   }
+}
+
+/**
+ * Builds a `preValidation` hook that normalizes an array-typed querystring parameter accepted in
+ * two forms: repeated (`?tx_id=A&tx_id=B`) and comma-separated (`?tx_id=A,B`).
+ *
+ * Fastify's `qs` parser already yields an array for the repeated form, so only the comma-separated
+ * form needs splitting and only before validation runs, since the schema declares the parameter as
+ * an array and would otherwise reject the single string.
+ * @param param - Name of the querystring parameter to normalize.
+ * @returns A `preValidation` hook that splits the parameter when it arrives as a string.
+ */
+export function splitCommaSeparatedQueryParam(param: string) {
+  return (req: FastifyRequest, _reply: FastifyReply, done: HookHandlerDoneFunction) => {
+    const query = req.query as Record<string, unknown>;
+    const value = query[param];
+    if (typeof value === 'string') {
+      query[param] = value.split(',');
+    }
+    done();
+  };
 }

--- a/src/api/routes/v1/tx.ts
+++ b/src/api/routes/v1/tx.ts
@@ -8,7 +8,11 @@ import {
 } from '../../controllers/db-controller.js';
 import { isValidC32Address, isValidPrincipal, parseEventTypeStrings } from '../../../helpers.js';
 import { InvalidRequestError, InvalidRequestErrorType, NotFoundError } from '../../../errors.js';
-import { validateRequestHexInput, validatePrincipal } from '../../query-helpers.js';
+import {
+  validateRequestHexInput,
+  validatePrincipal,
+  splitCommaSeparatedQueryParam,
+} from '../../query-helpers.js';
 import { getPagingQueryLimit, parsePagingQueryInput, ResourceType } from '../../pagination.js';
 import {
   handleChainTipCache,
@@ -59,12 +63,7 @@ export const TxRoutes: FastifyPluginAsync<
     '/',
     {
       preHandler: handleChainTipCache,
-      preValidation: (req, _reply, done) => {
-        if (typeof req.query.type === 'string') {
-          req.query.type = (req.query.type as string).split(',') as typeof req.query.type;
-        }
-        done();
-      },
+      preValidation: splitCommaSeparatedQueryParam('type'),
       schema: {
         operationId: 'get_transaction_list',
         deprecated: true,
@@ -201,16 +200,15 @@ export const TxRoutes: FastifyPluginAsync<
     '/multiple',
     {
       preHandler: handleMempoolCache,
-      preValidation: (req, _reply, done) => {
-        if (typeof req.query.tx_id === 'string') {
-          req.query.tx_id = (req.query.tx_id as string).split(',') as typeof req.query.tx_id;
-        }
-        done();
-      },
+      preValidation: splitCommaSeparatedQueryParam('tx_id'),
       schema: {
         operationId: 'get_tx_list_details',
+        deprecated: true,
+        deprecatedMessage:
+          'Use GET /extended/v3/transactions/batch instead. It returns mined transactions only, ' +
+          'and omits ids it cannot resolve rather than reporting them as not found.',
         summary: 'Get list of details for transactions',
-        description: `Retrieves a list of transactions for a given list of transaction IDs`,
+        description: `Retrieves a list of transactions for a given list of transaction IDs. **Deprecated:** use \`GET /extended/v3/transactions/batch\` instead. Note two differences: the v3 endpoint returns mined transactions only, so use \`GET /extended/v3/transactions/{tx_id}\` for a transaction that may still be in the mempool; and it returns a \`results\` array rather than a map keyed by transaction id, so ids that do not resolve are absent from the response instead of being reported as \`found: false\`.`,
         tags: ['Transactions'],
         querystring: Type.Object({
           tx_id: Type.Array(TransactionIdParamSchema),
@@ -350,12 +348,7 @@ export const TxRoutes: FastifyPluginAsync<
     '/events',
     {
       preHandler: handleChainTipCache,
-      preValidation: (req, _reply, done) => {
-        if (typeof req.query.type === 'string') {
-          req.query.type = (req.query.type as string).split(',') as typeof req.query.type;
-        }
-        done();
-      },
+      preValidation: splitCommaSeparatedQueryParam('type'),
       schema: {
         operationId: 'get_filtered_events',
         deprecated: true,

--- a/src/api/routes/v3/principals.ts
+++ b/src/api/routes/v3/principals.ts
@@ -53,6 +53,7 @@ import {
 import {
   PrincipalBalanceChangeCursorSchema,
   PrincipalTransactionBalanceChangeCursorSchema,
+  TransactionIdsQuerystringParam,
 } from '../../schemas/v3/params.js';
 import {
   PrincipalBalanceChangeSchema,
@@ -61,6 +62,7 @@ import {
 import { PrincipalNoncesSchema } from '../../schemas/v3/entities/principal-nonces.js';
 import { MempoolTransactionSummarySchema } from '../../schemas/v3/entities/mempool-transaction-summaries.js';
 import { serializeDbMempoolTransactionSummary } from '../../serializers/v3/mempool-transactions.js';
+import { splitCommaSeparatedQueryParam } from '../../query-helpers.js';
 
 export const PrincipalsRoutes: FastifyPluginAsync<
   Record<never, never>,
@@ -293,15 +295,7 @@ export const PrincipalsRoutes: FastifyPluginAsync<
     '/principals/:principal/balance-changes',
     {
       preHandler: handlePrincipalCache,
-      // Accept both repeated (`?tx_id=A&tx_id=B`) and comma-separated (`?tx_id=A,B`) forms.
-      // The repeated form is already an array via Fastify's qs parser; this hook normalizes
-      // the comma-separated form. Mirrors the convention used by `/extended/v1/tx/multiple`.
-      preValidation: (req, _reply, done) => {
-        if (typeof req.query.tx_id === 'string') {
-          req.query.tx_id = (req.query.tx_id as string).split(',') as typeof req.query.tx_id;
-        }
-        done();
-      },
+      preValidation: splitCommaSeparatedQueryParam('tx_id'),
       schema: {
         operationId: 'get_principal_balance_changes',
         summary: 'Get principal balance changes',
@@ -311,14 +305,7 @@ export const PrincipalsRoutes: FastifyPluginAsync<
         querystring: Type.Composite([
           CursorPaginationQuerystring(PrincipalBalanceChangeCursorSchema, ResourceType.Tx),
           Type.Object({
-            tx_id: Type.Array(TransactionIdSchema, {
-              minItems: 1,
-              maxItems: getPagingQueryLimit(ResourceType.Tx),
-              description:
-                'Transaction IDs to query balance changes for. Provide as repeated ' +
-                'querystring values (`?tx_id=A&tx_id=B`) or as a single comma-separated ' +
-                'value (`?tx_id=A,B`).',
-            }),
+            tx_id: TransactionIdsQuerystringParam('Transaction ids to query balance changes for.'),
           }),
         ]),
         response: {

--- a/src/api/routes/v3/transactions.ts
+++ b/src/api/routes/v3/transactions.ts
@@ -23,6 +23,8 @@ import { MempoolTransactionSchema } from '../../schemas/v3/entities/mempool-tran
 import { NotFoundError } from '../../../errors.js';
 import { TransactionEventSchema } from '../../schemas/v3/entities/transaction-events.js';
 import { serializeDbTransactionEvent } from '../../serializers/v3/transaction-events.js';
+import { splitCommaSeparatedQueryParam } from '../../query-helpers.js';
+import { TransactionIdsQuerystringParam } from '../../schemas/v3/params.js';
 
 export const TransactionsRoutes: FastifyPluginAsync<
   Record<never, never>,
@@ -67,19 +69,50 @@ export const TransactionsRoutes: FastifyPluginAsync<
   );
 
   fastify.get(
+    '/transactions/batch',
+    {
+      preHandler: handleChainTipCache,
+      preValidation: splitCommaSeparatedQueryParam('tx_id'),
+      schema: {
+        operationId: 'get_transactions_batch',
+        summary: 'Get a batch of transactions',
+        description:
+          'Retrieves the summaries of up to 20 mined transactions in a single call, given their ' +
+          'transaction ids. Provide them as repeated querystring values (`?tx_id=A&tx_id=B`) or ' +
+          'as a single comma-separated value (`?tx_id=A,B`). Results are returned in canonical ' +
+          'chain order (newest first), not in the order the ids were supplied. Only transactions ' +
+          'mined in the canonical chain are returned: an id that is unknown, non-canonical, or ' +
+          'still in the mempool is absent from `results` rather than reported as an error, so ' +
+          'compare the response against the ids you sent to find the ones that did not resolve. ' +
+          'Use `GET /extended/v3/transactions/{tx_id}` for a single transaction, which also ' +
+          'covers mempool transactions.',
+        tags: ['Transactions'],
+        querystring: Type.Object({
+          tx_id: TransactionIdsQuerystringParam('Transaction ids to fetch summaries for.'),
+        }),
+        response: {
+          200: Type.Object(
+            {
+              results: Type.Array(TransactionSummarySchema),
+            },
+            { title: 'TransactionBatchResponse' }
+          ),
+        },
+      },
+    },
+    async (req, reply) => {
+      const results = await fastify.db.v3.getTransactionSummariesByTxIds({
+        txIds: req.query.tx_id,
+      });
+      await reply.send({ results: results.map(r => serializeDbTransactionSummary(r)) });
+    }
+  );
+
+  fastify.get(
     '/transactions/:tx_id',
     {
       preHandler: handleTransactionCache,
-      // Accept both repeated (`?include=A&include=B`) and comma-separated (`?include=A,B`)
-      // forms. The repeated form is already an array via Fastify's qs parser; this hook
-      // normalizes the comma-separated form. Mirrors the convention used by
-      // `/principals/:principal/balance-changes`.
-      preValidation: (req, _reply, done) => {
-        if (typeof req.query.include === 'string') {
-          req.query.include = (req.query.include as string).split(',') as typeof req.query.include;
-        }
-        done();
-      },
+      preValidation: splitCommaSeparatedQueryParam('include'),
       schema: {
         operationId: 'get_transaction',
         summary: 'Get transaction',

--- a/src/api/schemas/v3/params.ts
+++ b/src/api/schemas/v3/params.ts
@@ -1,6 +1,7 @@
 import { ObjectOptions, TSchema, Type } from '@sinclair/typebox';
-import { pagingQueryLimits, ResourceType } from '../../pagination.js';
+import { getPagingQueryLimit, pagingQueryLimits, ResourceType } from '../../pagination.js';
 import { Nullable } from '../v1/util.js';
+import { TransactionIdSchema } from './entities/common.js';
 
 /**
  * Cursor pagination querystring
@@ -71,3 +72,22 @@ export const PrincipalBalanceChangeCursorSchema = Type.String({
     'Format: `<block_height>:<microblock_sequence>:<tx_index>:<asset_type>:<asset_identifier>`.',
   pattern: '^[0-9]+:[0-9]+:[0-9]+:[0-9]+:\\S+$',
 });
+
+/**
+ * Querystring parameter for endpoints that take an explicit set of transaction ids.
+ *
+ * Accepted in two forms: repeated (`?tx_id=A&tx_id=B`) and comma-separated (`?tx_id=A,B`); the
+ * latter normalized before validation by the `splitCommaSeparatedQueryParam('tx_id')`
+ * `preValidation` hook, which every route using this parameter must register.
+ * @param description - What the ids select
+ * @returns The `tx_id` array schema.
+ */
+export const TransactionIdsQuerystringParam = (description: string) =>
+  Type.Array(TransactionIdSchema, {
+    minItems: 1,
+    maxItems: getPagingQueryLimit(ResourceType.Tx),
+    uniqueItems: true,
+    description:
+      `${description} Provide as repeated querystring values (\`?tx_id=A&tx_id=B\`) or as a ` +
+      'single comma-separated value (`?tx_id=A,B`).',
+  });

--- a/src/datastore/v3/pg-store-v3.ts
+++ b/src/datastore/v3/pg-store-v3.ts
@@ -79,6 +79,32 @@ import { DbEventTypeId, DbSignerKeyGrantKind, DbTxStatus, DbTxTypeId } from '../
 
 export class PgStoreV3 extends BasePgStoreModule {
   /**
+   * Gets the summaries for a specific set of mined transactions, in canonical order.
+   *
+   * Unlike {@link getTransactionSummaries} this is not paginated: the caller supplies an explicit,
+   * bounded set of transaction ids, so there is nothing to page through. Ids that are not mined in
+   * the canonical chain — unknown, or still in the mempool — are simply absent from the result,
+   * which is why the caller cannot rely on positional matching against its input.
+   * @param args - The arguments for the query.
+   * @returns The summaries of the mined transactions among `txIds`.
+   */
+  async getTransactionSummariesByTxIds(args: { txIds: string[] }): Promise<DbTransactionSummary[]> {
+    if (args.txIds.length === 0) {
+      return [];
+    }
+    return await this.sqlTransaction(async sql => {
+      return await sql<DbTransactionSummary[]>`
+        SELECT ${sql(TX_SUMMARY_COLUMNS)}
+        FROM txs
+        WHERE canonical = true
+          AND microblock_canonical = true
+          AND tx_id IN ${sql(args.txIds)}
+        ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC
+      `;
+    });
+  }
+
+  /**
    * Gets the summaries for all transactions.
    * @param args - The arguments for the query.
    * @returns The summaries for all transactions.

--- a/tests/api/principal-v3/principals.test.ts
+++ b/tests/api/principal-v3/principals.test.ts
@@ -711,6 +711,24 @@ describe('principals', () => {
       assert.equal(response.statusCode, 400);
     });
 
+    test('should reject duplicate tx_ids', async () => {
+      const response = await api.fastifyApp.inject({
+        method: 'GET',
+        url: `/extended/v3/principals/${testAddr1}/balance-changes`,
+        query: { tx_id: [hex(3), hex(3)] },
+      });
+      assert.equal(response.statusCode, 400);
+    });
+
+    test('should reject more than 20 tx_ids', async () => {
+      const response = await api.fastifyApp.inject({
+        method: 'GET',
+        url: `/extended/v3/principals/${testAddr1}/balance-changes`,
+        query: { tx_id: Array.from({ length: 21 }, (_, i) => hex(1000 + i)) },
+      });
+      assert.equal(response.statusCode, 400);
+    });
+
     test('should return an empty list when the principal has no activity on the requested txs', async () => {
       const response = await api.fastifyApp.inject({
         method: 'GET',

--- a/tests/api/transactions/tx-batch-v3.test.ts
+++ b/tests/api/transactions/tx-batch-v3.test.ts
@@ -1,0 +1,274 @@
+import { describe, test, beforeEach, afterEach } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { STACKS_TESTNET } from '@stacks/network';
+import { PgWriteStore } from '../../../src/datastore/pg-write-store.ts';
+import { ApiServer, startApiServer } from '../../../src/api/init.ts';
+import { migrate } from '../../test-helpers.ts';
+import { hex } from '../test-helpers.ts';
+import { TestBlockBuilder, testMempoolTx } from '../test-builders.ts';
+import { DbTxStatus, DbTxTypeId } from '../../../src/datastore/common.ts';
+
+/**
+ * `GET /extended/v3/transactions/batch` — the v3 replacement for `GET /extended/v1/tx/multiple`.
+ *
+ * The contract under test: mined canonical transactions only, canonical order regardless of the
+ * order ids were supplied, and ids that do not resolve are absent rather than an error. Ids are
+ * accepted both as repeated `tx_id` params and as one comma-separated value.
+ */
+
+const SENDER = 'SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27';
+const RECIPIENT = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
+
+const TX_1 = hex(1);
+const TX_2 = hex(2);
+const TX_3 = hex(3);
+const MEMPOOL_TX = hex(9);
+const UNKNOWN_TX = hex(0xdead);
+
+/** Repeated-param form: `?tx_id=A&tx_id=B`. */
+const get = (api: ApiServer, txIds: string[], headers?: Record<string, string>) =>
+  api.fastifyApp.inject({
+    method: 'GET',
+    url: '/extended/v3/transactions/batch',
+    query: txIds.length === 1 ? { tx_id: txIds[0] } : { tx_id: txIds },
+    headers,
+  });
+
+/** Comma-separated form: `?tx_id=A,B`. */
+const getCsv = (api: ApiServer, txIds: string[]) =>
+  api.fastifyApp.inject({
+    method: 'GET',
+    url: '/extended/v3/transactions/batch',
+    query: { tx_id: txIds.join(',') },
+  });
+
+/** Raw querystring, for cases the typed helpers cannot express. */
+const getRaw = (api: ApiServer, query: string) =>
+  api.fastifyApp.inject({ method: 'GET', url: `/extended/v3/transactions/batch${query}` });
+
+describe('v3 transactions batch', () => {
+  let db: PgWriteStore;
+  let api: ApiServer;
+
+  beforeEach(async () => {
+    await migrate('up');
+    db = await PgWriteStore.connect({
+      usageName: 'tests',
+      withNotifier: false,
+      skipMigrations: true,
+    });
+    api = await startApiServer({ datastore: db, chainId: STACKS_TESTNET.chainId });
+
+    // Three mined txs across two blocks, so canonical ordering is observable, plus one that only
+    // ever reaches the mempool.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        index_block_hash: '0x0001',
+        parent_index_block_hash: '0x0000',
+        parent_block_hash: '0x0000',
+      })
+        .addTx({
+          tx_id: TX_1,
+          tx_index: 0,
+          block_hash: '0x0001',
+          index_block_hash: '0x0001',
+          type_id: DbTxTypeId.Coinbase,
+          status: DbTxStatus.Success,
+          sender_address: SENDER,
+        })
+        .addTx({
+          tx_id: TX_2,
+          tx_index: 1,
+          block_hash: '0x0001',
+          index_block_hash: '0x0001',
+          type_id: DbTxTypeId.TokenTransfer,
+          status: DbTxStatus.Success,
+          sender_address: SENDER,
+          token_transfer_recipient_address: RECIPIENT,
+          token_transfer_amount: 100n,
+          token_transfer_memo: '0x0d0000000568656c6c6f',
+        })
+        .build()
+    );
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        index_block_hash: '0x0002',
+        parent_index_block_hash: '0x0001',
+        parent_block_hash: '0x0001',
+      })
+        .addTx({
+          tx_id: TX_3,
+          tx_index: 0,
+          block_hash: '0x0002',
+          index_block_hash: '0x0002',
+          type_id: DbTxTypeId.Coinbase,
+          status: DbTxStatus.Success,
+          sender_address: SENDER,
+        })
+        .build()
+    );
+    await db.updateMempoolTxs({
+      mempoolTxs: [
+        testMempoolTx({
+          tx_id: MEMPOOL_TX,
+          receipt_time: 1000,
+          type_id: DbTxTypeId.TokenTransfer,
+          sender_address: SENDER,
+          token_transfer_recipient_address: RECIPIENT,
+          token_transfer_amount: 500n,
+        }),
+      ],
+    });
+  });
+
+  afterEach(async () => {
+    await api.terminate();
+    await db?.close();
+    await migrate('down');
+  });
+
+  test('returns summaries for the requested transactions', async () => {
+    const res = await get(api, [TX_1, TX_3]);
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    assert.deepEqual(
+      body.results.map((r: { tx_id: string }) => r.tx_id),
+      [TX_3, TX_1]
+    );
+    // Summary shape, not full transaction: no event_count / execution_cost / post_conditions.
+    const summary = body.results[0];
+    assert.equal(summary.block.height, 2);
+    assert.equal(summary.sender.address, SENDER);
+    assert.equal(summary.status, 'success');
+    assert.equal(summary.type, 'coinbase');
+    assert.equal('event_count' in summary, false);
+    assert.equal('execution_cost' in summary, false);
+  });
+
+  test('orders results canonically, not by the order ids were supplied', async () => {
+    const res = await get(api, [TX_1, TX_3, TX_2]);
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    // block 2 tx first, then block 1 by descending tx_index.
+    assert.deepEqual(
+      body.results.map((r: { tx_id: string }) => r.tx_id),
+      [TX_3, TX_2, TX_1]
+    );
+  });
+
+  test('omits unknown transaction ids instead of erroring', async () => {
+    const res = await get(api, [TX_1, UNKNOWN_TX]);
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    assert.deepEqual(
+      body.results.map((r: { tx_id: string }) => r.tx_id),
+      [TX_1]
+    );
+  });
+
+  test('omits mempool transactions — mined only', async () => {
+    const res = await get(api, [TX_1, MEMPOOL_TX]);
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    assert.deepEqual(
+      body.results.map((r: { tx_id: string }) => r.tx_id),
+      [TX_1]
+    );
+  });
+
+  test('returns an empty result set when nothing resolves', async () => {
+    const res = await get(api, [UNKNOWN_TX]);
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(JSON.parse(res.body).results, []);
+  });
+
+  // The cap is `getPagingQueryLimit(ResourceType.Tx)` (20), matching the `tx_id` filter on
+  // `/principals/{principal}/balance-changes`.
+  test('rejects more than 20 transaction ids', async () => {
+    const tx_ids = Array.from({ length: 21 }, (_, i) => hex(1000 + i));
+    const res = await get(api, tx_ids);
+    assert.equal(res.statusCode, 400);
+  });
+
+  test('accepts exactly 20 transaction ids', async () => {
+    const tx_ids = [TX_1, ...Array.from({ length: 19 }, (_, i) => hex(1000 + i))];
+    const res = await get(api, tx_ids);
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(
+      JSON.parse(res.body).results.map((r: { tx_id: string }) => r.tx_id),
+      [TX_1]
+    );
+  });
+
+  test('accepts a single comma-separated tx_id value', async () => {
+    const res = await getCsv(api, [TX_1, TX_3, TX_2]);
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(
+      JSON.parse(res.body).results.map((r: { tx_id: string }) => r.tx_id),
+      [TX_3, TX_2, TX_1]
+    );
+  });
+
+  test('the comma-separated and repeated forms agree', async () => {
+    const repeated = await get(api, [TX_1, TX_2]);
+    const csv = await getCsv(api, [TX_1, TX_2]);
+    assert.equal(repeated.statusCode, 200);
+    assert.equal(csv.statusCode, 200);
+    assert.deepEqual(JSON.parse(csv.body), JSON.parse(repeated.body));
+  });
+
+  test('rejects duplicate transaction ids', async () => {
+    const res = await get(api, [TX_1, TX_1]);
+    assert.equal(res.statusCode, 400);
+  });
+
+  test('rejects a malformed transaction id', async () => {
+    const res = await get(api, ['0x0001']);
+    assert.equal(res.statusCode, 400);
+  });
+
+  test('rejects a malformed id inside a comma-separated value', async () => {
+    const res = await getCsv(api, [TX_1, '0x0001']);
+    assert.equal(res.statusCode, 400);
+  });
+
+  test('rejects a missing tx_id param', async () => {
+    const res = await getRaw(api, '');
+    assert.equal(res.statusCode, 400);
+  });
+
+  test('rejects an empty tx_id param', async () => {
+    const res = await getRaw(api, '?tx_id=');
+    assert.equal(res.statusCode, 400);
+  });
+
+  test('the v1 endpoint it replaces is deprecated and points here', async () => {
+    const res = await api.fastifyApp.inject({
+      method: 'GET',
+      url: '/extended/v1/tx/multiple',
+      query: { tx_id: TX_1 },
+    });
+    assert.equal(res.statusCode, 200);
+    assert.equal(
+      res.headers['warning'],
+      '299 - "Deprecated: Use GET /extended/v3/transactions/batch instead. It returns mined ' +
+        'transactions only, and omits ids it cannot resolve rather than reporting them as not ' +
+        'found."'
+    );
+  });
+
+  test('sets a chain-tip ETag and honours If-None-Match', async () => {
+    const first = await get(api, [TX_1, TX_3]);
+    assert.equal(first.statusCode, 200);
+    const etag = first.headers['etag'] as string;
+    assert.ok(etag, 'expected an ETag');
+    assert.equal(first.headers['cache-control'], 'public, no-cache, must-revalidate');
+
+    // Same URL, same chain tip — revalidation is a 304. Caches key on the URL, so a different
+    // `tx_id` set is a separate cache entry and never reuses this response.
+    const revalidated = await get(api, [TX_1, TX_3], { 'if-none-match': etag });
+    assert.equal(revalidated.statusCode, 304);
+  });
+});


### PR DESCRIPTION
Adds `GET /extended/v3/transactions/batch`, the v3 replacement for `GET /extended/v1/tx/multiple`, and deprecates the v1 endpoint. This new endpoint only covers mined transactions, not pending.

`GET /extended/v3/transactions/batch?tx_id=0x…0001,0x…0003`

```json
{
  "results": [
    {
      "tx_id": "0x0000000000000000000000000000000000000000000000000000000000000003",
      "sender": { "address": "SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27", "nonce": 0 },
      "sponsor": null,
      "fee_rate": "50",
      "block": {
        "height": 2,
        "hash": "0x0002",
        "index_hash": "0x0002",
        "time": 94869287,
        "tx_index": 0
      },
      "bitcoin_block": { "height": 2, "time": 94869286 },
      "status": "success",
      "type": "coinbase",
      "coinbase": { "alt_recipient": null }
    },
    {
      "tx_id": "0x0000000000000000000000000000000000000000000000000000000000000001",
      "sender": { "address": "SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27", "nonce": 0 },
      "sponsor": null,
      "fee_rate": "50",
      "block": {
        "height": 1,
        "hash": "0x0001",
        "index_hash": "0x0001",
        "time": 94869287,
        "tx_index": 0
      },
      "bitcoin_block": { "height": 1, "time": 94869286 },
      "status": "success",
      "type": "coinbase",
      "coinbase": { "alt_recipient": null }
    }
  ]
}
```