### PR TITLE
fix: burnchain reward canonical state, persist per-burn-block burn/reward totals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           [
             api:blocks,
             api:bns,
+            api:burnchain,
             api:cache,
             api:datastore,
             api:event-replay,

--- a/migrations/1779800000014_burnchain-canonical-repair.ts
+++ b/migrations/1779800000014_burnchain-canonical-repair.ts
@@ -49,39 +49,10 @@ export const up = (pgm: MigrationBuilder) => {
     'burnchain_rewards_unique_idx',
     'UNIQUE(burn_block_hash, reward_index)'
   );
-  // Same per-height repair for pox txs. The table has no insert-order column, so ties between
-  // hashes not anchored by any canonical Stacks block are broken by the repaired rewards table.
-  pgm.sql(`
-    WITH winners AS (
-      SELECT DISTINCT ON (burn_block_height) burn_block_height, burn_block_hash
-      FROM burn_block_pox_txs p
-      ORDER BY burn_block_height,
-        EXISTS (
-          SELECT 1 FROM blocks b
-          WHERE b.burn_block_hash = p.burn_block_hash AND b.canonical = true
-        ) DESC,
-        EXISTS (
-          SELECT 1 FROM burnchain_rewards r
-          WHERE r.burn_block_hash = p.burn_block_hash AND r.canonical = true
-        ) DESC,
-        burn_block_hash DESC
-    )
-    UPDATE burn_block_pox_txs p
-    SET canonical = (p.burn_block_hash = w.burn_block_hash)
-    FROM winners w
-    WHERE p.burn_block_height = w.burn_block_height
-      AND p.canonical != (p.burn_block_hash = w.burn_block_hash)
-  `);
-  pgm.sql(`
-    DELETE FROM burn_block_pox_tx_counts
-  `);
-  pgm.sql(`
-    INSERT INTO burn_block_pox_tx_counts (recipient, count)
-    (SELECT recipient, COUNT(*) AS count FROM burn_block_pox_txs WHERE canonical = true GROUP BY recipient)
-  `);
   // Same dedup and per-height repair for reward slot holders. Beyond fork/duplicate damage, this
   // also restores rows the legacy write path wrongly orphaned above a re-delivered old burn block's
-  // height.
+  // height. Resolved before pox txs so the shared evidence chain (blocks anchor, then rewards, then
+  // slot holders, then a last-resort tie-break) yields one winner per height across all tables.
   pgm.sql(`
     DELETE FROM reward_slot_holders a
     USING reward_slot_holders b
@@ -115,6 +86,41 @@ export const up = (pgm: MigrationBuilder) => {
     'reward_slot_holders_unique_idx',
     'UNIQUE(burn_block_hash, slot_index)'
   );
+  // Same per-height repair for pox txs, deferring to the tables repaired above so every table
+  // crowns the same hash per height. The table has no insert-order column, so the lexicographic
+  // tie-break only ever applies when it is the sole table holding rows for a height.
+  pgm.sql(`
+    WITH winners AS (
+      SELECT DISTINCT ON (burn_block_height) burn_block_height, burn_block_hash
+      FROM burn_block_pox_txs p
+      ORDER BY burn_block_height,
+        EXISTS (
+          SELECT 1 FROM blocks b
+          WHERE b.burn_block_hash = p.burn_block_hash AND b.canonical = true
+        ) DESC,
+        EXISTS (
+          SELECT 1 FROM burnchain_rewards r
+          WHERE r.burn_block_hash = p.burn_block_hash AND r.canonical = true
+        ) DESC,
+        EXISTS (
+          SELECT 1 FROM reward_slot_holders s
+          WHERE s.burn_block_hash = p.burn_block_hash AND s.canonical = true
+        ) DESC,
+        burn_block_hash DESC
+    )
+    UPDATE burn_block_pox_txs p
+    SET canonical = (p.burn_block_hash = w.burn_block_hash)
+    FROM winners w
+    WHERE p.burn_block_height = w.burn_block_height
+      AND p.canonical != (p.burn_block_hash = w.burn_block_hash)
+  `);
+  pgm.sql(`
+    DELETE FROM burn_block_pox_tx_counts
+  `);
+  pgm.sql(`
+    INSERT INTO burn_block_pox_tx_counts (recipient, count)
+    (SELECT recipient, COUNT(*) AS count FROM burn_block_pox_txs WHERE canonical = true GROUP BY recipient)
+  `);
 };
 
 export const down = (pgm: MigrationBuilder) => {

--- a/migrations/1779800000014_burnchain-canonical-repair.ts
+++ b/migrations/1779800000014_burnchain-canonical-repair.ts
@@ -1,0 +1,124 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+/**
+ * Repairs canonical state for burnchain-level tables and enforces natural-key uniqueness.
+ *
+ * Historical write paths allowed several kinds of corruption in `burnchain_rewards`,
+ * `burn_block_pox_txs` and `reward_slot_holders`:
+ *  - duplicate rows from re-delivered `/new_burn_block` events (no unique constraint),
+ *  - rows from orphaned burnchain forks left canonical forever,
+ *  - canonical flips driven by Stacks-level re-orgs, which don't correspond to burnchain forks, and
+ *  - rows above a re-delivered old burn block's height wrongly orphaned (`reward_slot_holders`).
+ *
+ * The burnchain is linear, so exactly one burn block hash is canonical per height. This migration
+ * dedupes rows, recomputes canonical per height (preferring a hash anchored by a canonical Stacks
+ * block, falling back to the most recently inserted rows), adds the unique constraints the write
+ * path now relies on for idempotency, and reseeds the pox tx counts table.
+ */
+export const up = (pgm: MigrationBuilder) => {
+  // Remove duplicate reward rows from re-delivered events, keeping the latest insert.
+  pgm.sql(`
+    DELETE FROM burnchain_rewards a
+    USING burnchain_rewards b
+    WHERE a.burn_block_hash = b.burn_block_hash
+      AND a.reward_index = b.reward_index
+      AND a.id < b.id
+  `);
+  // One canonical hash per burn block height. A hash anchored by a canonical Stacks block is proven
+  // canonical on the burnchain; otherwise the last-received hash wins, matching the order in which
+  // the node announces replacement blocks during a burnchain fork.
+  pgm.sql(`
+    WITH winners AS (
+      SELECT DISTINCT ON (burn_block_height) burn_block_height, burn_block_hash
+      FROM burnchain_rewards r
+      ORDER BY burn_block_height,
+        EXISTS (
+          SELECT 1 FROM blocks b
+          WHERE b.burn_block_hash = r.burn_block_hash AND b.canonical = true
+        ) DESC,
+        id DESC
+    )
+    UPDATE burnchain_rewards r
+    SET canonical = (r.burn_block_hash = w.burn_block_hash)
+    FROM winners w
+    WHERE r.burn_block_height = w.burn_block_height
+      AND r.canonical != (r.burn_block_hash = w.burn_block_hash)
+  `);
+  pgm.addConstraint(
+    'burnchain_rewards',
+    'burnchain_rewards_unique_idx',
+    'UNIQUE(burn_block_hash, reward_index)'
+  );
+  // Same per-height repair for pox txs. The table has no insert-order column, so ties between
+  // hashes not anchored by any canonical Stacks block are broken by the repaired rewards table.
+  pgm.sql(`
+    WITH winners AS (
+      SELECT DISTINCT ON (burn_block_height) burn_block_height, burn_block_hash
+      FROM burn_block_pox_txs p
+      ORDER BY burn_block_height,
+        EXISTS (
+          SELECT 1 FROM blocks b
+          WHERE b.burn_block_hash = p.burn_block_hash AND b.canonical = true
+        ) DESC,
+        EXISTS (
+          SELECT 1 FROM burnchain_rewards r
+          WHERE r.burn_block_hash = p.burn_block_hash AND r.canonical = true
+        ) DESC,
+        burn_block_hash DESC
+    )
+    UPDATE burn_block_pox_txs p
+    SET canonical = (p.burn_block_hash = w.burn_block_hash)
+    FROM winners w
+    WHERE p.burn_block_height = w.burn_block_height
+      AND p.canonical != (p.burn_block_hash = w.burn_block_hash)
+  `);
+  pgm.sql(`
+    DELETE FROM burn_block_pox_tx_counts
+  `);
+  pgm.sql(`
+    INSERT INTO burn_block_pox_tx_counts (recipient, count)
+    (SELECT recipient, COUNT(*) AS count FROM burn_block_pox_txs WHERE canonical = true GROUP BY recipient)
+  `);
+  // Same dedup and per-height repair for reward slot holders. Beyond fork/duplicate damage, this
+  // also restores rows the legacy write path wrongly orphaned above a re-delivered old burn block's
+  // height.
+  pgm.sql(`
+    DELETE FROM reward_slot_holders a
+    USING reward_slot_holders b
+    WHERE a.burn_block_hash = b.burn_block_hash
+      AND a.slot_index = b.slot_index
+      AND a.id < b.id
+  `);
+  pgm.sql(`
+    WITH winners AS (
+      SELECT DISTINCT ON (burn_block_height) burn_block_height, burn_block_hash
+      FROM reward_slot_holders s
+      ORDER BY burn_block_height,
+        EXISTS (
+          SELECT 1 FROM blocks b
+          WHERE b.burn_block_hash = s.burn_block_hash AND b.canonical = true
+        ) DESC,
+        EXISTS (
+          SELECT 1 FROM burnchain_rewards r
+          WHERE r.burn_block_hash = s.burn_block_hash AND r.canonical = true
+        ) DESC,
+        id DESC
+    )
+    UPDATE reward_slot_holders s
+    SET canonical = (s.burn_block_hash = w.burn_block_hash)
+    FROM winners w
+    WHERE s.burn_block_height = w.burn_block_height
+      AND s.canonical != (s.burn_block_hash = w.burn_block_hash)
+  `);
+  pgm.addConstraint(
+    'reward_slot_holders',
+    'reward_slot_holders_unique_idx',
+    'UNIQUE(burn_block_hash, slot_index)'
+  );
+};
+
+export const down = (pgm: MigrationBuilder) => {
+  // The data repair is one-way; only the constraints are reversible.
+  pgm.dropConstraint('burnchain_rewards', 'burnchain_rewards_unique_idx');
+  pgm.dropConstraint('reward_slot_holders', 'reward_slot_holders_unique_idx');
+};

--- a/migrations/1779800000014_burnchain-canonical-repair.ts
+++ b/migrations/1779800000014_burnchain-canonical-repair.ts
@@ -24,35 +24,12 @@ export const up = (pgm: MigrationBuilder) => {
       AND a.reward_index = b.reward_index
       AND a.id < b.id
   `);
-  // One canonical hash per burn block height. A hash anchored by a canonical Stacks block is proven
-  // canonical on the burnchain; otherwise the last-received hash wins, matching the order in which
-  // the node announces replacement blocks during a burnchain fork.
-  pgm.sql(`
-    WITH winners AS (
-      SELECT DISTINCT ON (burn_block_height) burn_block_height, burn_block_hash
-      FROM burnchain_rewards r
-      ORDER BY burn_block_height,
-        EXISTS (
-          SELECT 1 FROM blocks b
-          WHERE b.burn_block_hash = r.burn_block_hash AND b.canonical = true
-        ) DESC,
-        id DESC
-    )
-    UPDATE burnchain_rewards r
-    SET canonical = (r.burn_block_hash = w.burn_block_hash)
-    FROM winners w
-    WHERE r.burn_block_height = w.burn_block_height
-      AND r.canonical != (r.burn_block_hash = w.burn_block_hash)
-  `);
   pgm.addConstraint(
     'burnchain_rewards',
     'burnchain_rewards_unique_idx',
     'UNIQUE(burn_block_hash, reward_index)'
   );
-  // Same dedup and per-height repair for reward slot holders. Beyond fork/duplicate damage, this
-  // also restores rows the legacy write path wrongly orphaned above a re-delivered old burn block's
-  // height. Resolved before pox txs so the shared evidence chain (blocks anchor, then rewards, then
-  // slot holders, then a last-resort tie-break) yields one winner per height across all tables.
+  // Same dedup for reward slot holders.
   pgm.sql(`
     DELETE FROM reward_slot_holders a
     USING reward_slot_holders b
@@ -60,59 +37,69 @@ export const up = (pgm: MigrationBuilder) => {
       AND a.slot_index = b.slot_index
       AND a.id < b.id
   `);
-  pgm.sql(`
-    WITH winners AS (
-      SELECT DISTINCT ON (burn_block_height) burn_block_height, burn_block_hash
-      FROM reward_slot_holders s
-      ORDER BY burn_block_height,
-        EXISTS (
-          SELECT 1 FROM blocks b
-          WHERE b.burn_block_hash = s.burn_block_hash AND b.canonical = true
-        ) DESC,
-        EXISTS (
-          SELECT 1 FROM burnchain_rewards r
-          WHERE r.burn_block_hash = s.burn_block_hash AND r.canonical = true
-        ) DESC,
-        id DESC
-    )
-    UPDATE reward_slot_holders s
-    SET canonical = (s.burn_block_hash = w.burn_block_hash)
-    FROM winners w
-    WHERE s.burn_block_height = w.burn_block_height
-      AND s.canonical != (s.burn_block_hash = w.burn_block_hash)
-  `);
   pgm.addConstraint(
     'reward_slot_holders',
     'reward_slot_holders_unique_idx',
     'UNIQUE(burn_block_hash, slot_index)'
   );
-  // Same per-height repair for pox txs, deferring to the tables repaired above so every table
-  // crowns the same hash per height. The table has no insert-order column, so the lexicographic
-  // tie-break only ever applies when it is the sole table holding rows for a height.
+  // One shared winner per burn block height, computed over the union of every hash any burnchain
+  // table has seen -- a hash present in only one table must still compete at its height, or tables
+  // could each crown their own only-candidate and diverge. Evidence order: a canonical Stacks block
+  // anchor is proof; otherwise arrival order in `burnchain_rewards`, then in `reward_slot_holders`
+  // (the tables with insert-order ids); a lexicographic tie-break is the last resort for hashes
+  // seen only by `burn_block_pox_txs`. Applied uniformly to all three tables below.
   pgm.sql(`
-    WITH winners AS (
-      SELECT DISTINCT ON (burn_block_height) burn_block_height, burn_block_hash
-      FROM burn_block_pox_txs p
-      ORDER BY burn_block_height,
-        EXISTS (
-          SELECT 1 FROM blocks b
-          WHERE b.burn_block_hash = p.burn_block_hash AND b.canonical = true
-        ) DESC,
-        EXISTS (
-          SELECT 1 FROM burnchain_rewards r
-          WHERE r.burn_block_hash = p.burn_block_hash AND r.canonical = true
-        ) DESC,
-        EXISTS (
-          SELECT 1 FROM reward_slot_holders s
-          WHERE s.burn_block_hash = p.burn_block_hash AND s.canonical = true
-        ) DESC,
-        burn_block_hash DESC
+    CREATE TEMPORARY TABLE burnchain_canonical_winners AS
+    WITH candidates AS (
+      SELECT burn_block_height, burn_block_hash, MAX(id) AS max_reward_id, NULL::int AS max_slot_id
+      FROM burnchain_rewards GROUP BY 1, 2
+      UNION ALL
+      SELECT burn_block_height, burn_block_hash, NULL, MAX(id)
+      FROM reward_slot_holders GROUP BY 1, 2
+      UNION ALL
+      SELECT burn_block_height, burn_block_hash, NULL, NULL
+      FROM burn_block_pox_txs GROUP BY 1, 2
+    ),
+    merged AS (
+      SELECT burn_block_height, burn_block_hash,
+        MAX(max_reward_id) AS max_reward_id,
+        MAX(max_slot_id) AS max_slot_id
+      FROM candidates GROUP BY 1, 2
     )
+    SELECT DISTINCT ON (burn_block_height) burn_block_height, burn_block_hash
+    FROM merged m
+    ORDER BY burn_block_height,
+      EXISTS (
+        SELECT 1 FROM blocks b
+        WHERE b.burn_block_hash = m.burn_block_hash AND b.canonical = true
+      ) DESC,
+      max_reward_id DESC NULLS LAST,
+      max_slot_id DESC NULLS LAST,
+      burn_block_hash DESC
+  `);
+  pgm.sql(`
+    UPDATE burnchain_rewards r
+    SET canonical = (r.burn_block_hash = w.burn_block_hash)
+    FROM burnchain_canonical_winners w
+    WHERE r.burn_block_height = w.burn_block_height
+      AND r.canonical != (r.burn_block_hash = w.burn_block_hash)
+  `);
+  pgm.sql(`
+    UPDATE reward_slot_holders s
+    SET canonical = (s.burn_block_hash = w.burn_block_hash)
+    FROM burnchain_canonical_winners w
+    WHERE s.burn_block_height = w.burn_block_height
+      AND s.canonical != (s.burn_block_hash = w.burn_block_hash)
+  `);
+  pgm.sql(`
     UPDATE burn_block_pox_txs p
     SET canonical = (p.burn_block_hash = w.burn_block_hash)
-    FROM winners w
+    FROM burnchain_canonical_winners w
     WHERE p.burn_block_height = w.burn_block_height
       AND p.canonical != (p.burn_block_hash = w.burn_block_hash)
+  `);
+  pgm.sql(`
+    DROP TABLE burnchain_canonical_winners
   `);
   pgm.sql(`
     DELETE FROM burn_block_pox_tx_counts

--- a/migrations/1779800000015_burn-blocks.ts
+++ b/migrations/1779800000015_burn-blocks.ts
@@ -1,0 +1,113 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+/**
+ * Persists per-burn-block data from `/new_burn_block` events, most importantly `burn_amount`: the
+ * total BTC burned by the block's commits. Historically this value was only stored as a column
+ * duplicated onto `burnchain_rewards` rows, so burn blocks with zero reward recipients (every pox-1
+ * through pox-4 prepare-phase block, where commits burn 100%) never persisted it at all. This table
+ * records it for every burn block, with the same one-canonical-hash-per-height semantics as the
+ * other burnchain tables.
+ *
+ * The backfill sources historical blocks from the raw `/new_burn_block` payloads in
+ * `event_observer_requests`, then fills any remaining gaps from `burnchain_rewards` (which only
+ * covers blocks that paid at least one recipient). Note `burn_amount` never included the 2.0-era
+ * PoX sunset-ramp surcharge (`sunset_burn` was a separate commit field the node never reported).
+ */
+export const up = (pgm: MigrationBuilder) => {
+  pgm.createTable('burn_blocks', {
+    id: {
+      type: 'serial',
+      primaryKey: true,
+    },
+    canonical: {
+      type: 'boolean',
+      notNull: true,
+    },
+    burn_block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
+    burn_block_height: {
+      type: 'integer',
+      notNull: true,
+    },
+    burn_amount: {
+      type: 'numeric',
+      notNull: true,
+    },
+    reward_amount: {
+      type: 'numeric',
+      notNull: true,
+    },
+  });
+  pgm.addConstraint('burn_blocks', 'burn_blocks_unique_idx', 'UNIQUE(burn_block_hash)');
+  pgm.createIndex('burn_blocks', [{ name: 'burn_block_height', sort: 'DESC' }]);
+
+  // Backfill from raw events: the latest payload per burn block hash, inserted in event order so
+  // ids preserve arrival order for the canonical tie-break below.
+  pgm.sql(`
+    WITH latest_events AS (
+      SELECT DISTINCT ON (payload->>'burn_block_hash')
+        decode(substring(payload->>'burn_block_hash' from 3), 'hex') AS burn_block_hash,
+        (payload->>'burn_block_height')::int AS burn_block_height,
+        (payload->>'burn_amount')::numeric AS burn_amount,
+        (
+          SELECT COALESCE(SUM((r->>'amt')::numeric), 0)
+          FROM jsonb_array_elements(payload->'reward_recipients') AS r
+        ) AS reward_amount,
+        id
+      FROM event_observer_requests
+      WHERE event_path = '/new_burn_block'
+      ORDER BY payload->>'burn_block_hash', id DESC
+    )
+    INSERT INTO burn_blocks (canonical, burn_block_hash, burn_block_height, burn_amount, reward_amount)
+    SELECT false, burn_block_hash, burn_block_height, burn_amount, reward_amount
+    FROM latest_events
+    ORDER BY id
+  `);
+  // Fill gaps from burnchain_rewards for eras where raw events were pruned or disabled. Rewards
+  // rows duplicate the block-level burn_amount per recipient, so any row's value works.
+  pgm.sql(`
+    INSERT INTO burn_blocks (canonical, burn_block_hash, burn_block_height, burn_amount, reward_amount)
+    SELECT false, burn_block_hash, burn_block_height, MAX(burn_amount), SUM(reward_amount)
+    FROM burnchain_rewards
+    GROUP BY burn_block_hash, burn_block_height
+    ON CONFLICT ON CONSTRAINT burn_blocks_unique_idx DO NOTHING
+  `);
+  // One canonical hash per height, preferring a hash anchored by a canonical Stacks block and
+  // falling back to arrival order. The same rule as the other burnchain table repairs.
+  pgm.sql(`
+    WITH winners AS (
+      SELECT DISTINCT ON (burn_block_height) burn_block_height, burn_block_hash
+      FROM burn_blocks c
+      ORDER BY burn_block_height,
+        EXISTS (
+          SELECT 1 FROM blocks b
+          WHERE b.burn_block_hash = c.burn_block_hash AND b.canonical = true
+        ) DESC,
+        id DESC
+    )
+    UPDATE burn_blocks c
+    SET canonical = (c.burn_block_hash = w.burn_block_hash)
+    FROM winners w
+    WHERE c.burn_block_height = w.burn_block_height
+      AND c.canonical != (c.burn_block_hash = w.burn_block_hash)
+  `);
+  // `burn_amount` is a block-level fact now owned by this table; the copy duplicated onto every
+  // reward row (and absent for zero-recipient blocks) is redundant. Reads join through
+  // `burn_blocks` instead.
+  pgm.dropColumn('burnchain_rewards', 'burn_amount');
+};
+
+export const down = (pgm: MigrationBuilder) => {
+  // Restores the column shape only; the per-row values are not recoverable (rebuild them by
+  // re-running `up`, which sources burn amounts from raw events and this table's data is lost).
+  pgm.addColumn('burnchain_rewards', {
+    burn_amount: {
+      type: 'numeric',
+      notNull: true,
+      default: 0,
+    },
+  });
+  pgm.dropTable('burn_blocks');
+};

--- a/migrations/1779800000015_burn-blocks.ts
+++ b/migrations/1779800000015_burn-blocks.ts
@@ -11,12 +11,12 @@ import type { MigrationBuilder } from 'node-pg-migrate';
  * The backfill sources historical blocks from the raw `/new_burn_block` payloads in
  * `event_observer_requests`, then fills any remaining gaps from `burnchain_rewards` (which only
  * covers blocks that paid at least one recipient). Canonical winners are resolved per height from
- * the strongest evidence available -- a canonical Stacks block anchor, then raw-event arrival
- * order, with legacy-table state consulted only for heights raw events don't cover -- and then
- * propagated back to the legacy burnchain tables, repairing forks those tables couldn't represent
- * (e.g. a zero-recipient replacement block orphaning a reward-paying rival). Note `burn_amount`
- * never included the 2.0-era PoX sunset-ramp surcharge (`sunset_burn` was a separate commit field
- * the node never reported).
+ * the strongest evidence available (a canonical Stacks block anchor, then raw-event arrival order,
+ * with legacy-table state consulted only for heights raw events don't cover) and then propagated
+ * back to the legacy burnchain tables, repairing forks those tables couldn't represent (e.g. a
+ * zero-recipient replacement block orphaning a reward-paying rival). Note `burn_amount` never
+ * included the 2.0-era PoX sunset-ramp surcharge (`sunset_burn` was a separate commit field the
+ * node never reported).
  */
 export const up = (pgm: MigrationBuilder) => {
   pgm.createTable('burn_blocks', {

--- a/migrations/1779800000015_burn-blocks.ts
+++ b/migrations/1779800000015_burn-blocks.ts
@@ -130,6 +130,28 @@ export const up = (pgm: MigrationBuilder) => {
     WHERE c.burn_block_height = w.burn_block_height
       AND c.canonical != (c.burn_block_hash = w.burn_block_hash)
   `);
+  // Anchor override across all rows, regardless of source: a hash anchored by a canonical Stacks
+  // block is proof of burnchain canonicality and must win even when the passes above resolved its
+  // height from weaker evidence e.g. a partially pruned raw archive where only the losing fork
+  // side's event survives while the anchored winner was gap-filled from burnchain_rewards. At most
+  // one hash per height can carry a canonical anchor (the canonical Stacks chain sees one linear
+  // burnchain), so this pass is deterministic.
+  pgm.sql(`
+    WITH anchored AS (
+      SELECT DISTINCT ON (burn_block_height) burn_block_height, burn_block_hash
+      FROM burn_blocks c
+      WHERE EXISTS (
+        SELECT 1 FROM blocks b
+        WHERE b.burn_block_hash = c.burn_block_hash AND b.canonical = true
+      )
+      ORDER BY burn_block_height, id DESC
+    )
+    UPDATE burn_blocks c
+    SET canonical = (c.burn_block_hash = a.burn_block_hash)
+    FROM anchored a
+    WHERE c.burn_block_height = a.burn_block_height
+      AND c.canonical != (c.burn_block_hash = a.burn_block_hash)
+  `);
   // Propagate the resolved winners back to the legacy burnchain tables so they agree with the
   // raw-event evidence. In particular, a zero-recipient replacement block (visible only in raw
   // events) orphans the rival hash's rewards, slot holders, and pox txs -- the historical

--- a/migrations/1779800000015_burn-blocks.ts
+++ b/migrations/1779800000015_burn-blocks.ts
@@ -66,16 +66,20 @@ export const up = (pgm: MigrationBuilder) => {
     ORDER BY id
   `);
   // Fill gaps from burnchain_rewards for eras where raw events were pruned or disabled. Rewards
-  // rows duplicate the block-level burn_amount per recipient, so any row's value works.
+  // rows duplicate the block-level burn_amount per recipient, so any row's value works. Groups are
+  // ordered by their latest reward-row id so the assigned burn_blocks ids preserve arrival order
+  // for the canonical tie-break below.
   pgm.sql(`
     INSERT INTO burn_blocks (canonical, burn_block_hash, burn_block_height, burn_amount, reward_amount)
     SELECT false, burn_block_hash, burn_block_height, MAX(burn_amount), SUM(reward_amount)
     FROM burnchain_rewards
     GROUP BY burn_block_hash, burn_block_height
+    ORDER BY MAX(id)
     ON CONFLICT ON CONSTRAINT burn_blocks_unique_idx DO NOTHING
   `);
-  // One canonical hash per height, preferring a hash anchored by a canonical Stacks block and
-  // falling back to arrival order. The same rule as the other burnchain table repairs.
+  // One canonical hash per height, preferring a hash anchored by a canonical Stacks block, then one
+  // canonical in the (already repaired) rewards table -- keeping this table consistent with the
+  // legacy tables -- and falling back to arrival order. The same rule as the other repairs.
   pgm.sql(`
     WITH winners AS (
       SELECT DISTINCT ON (burn_block_height) burn_block_height, burn_block_hash
@@ -84,6 +88,10 @@ export const up = (pgm: MigrationBuilder) => {
         EXISTS (
           SELECT 1 FROM blocks b
           WHERE b.burn_block_hash = c.burn_block_hash AND b.canonical = true
+        ) DESC,
+        EXISTS (
+          SELECT 1 FROM burnchain_rewards r
+          WHERE r.burn_block_hash = c.burn_block_hash AND r.canonical = true
         ) DESC,
         id DESC
     )

--- a/migrations/1779800000015_burn-blocks.ts
+++ b/migrations/1779800000015_burn-blocks.ts
@@ -10,8 +10,13 @@ import type { MigrationBuilder } from 'node-pg-migrate';
  *
  * The backfill sources historical blocks from the raw `/new_burn_block` payloads in
  * `event_observer_requests`, then fills any remaining gaps from `burnchain_rewards` (which only
- * covers blocks that paid at least one recipient). Note `burn_amount` never included the 2.0-era
- * PoX sunset-ramp surcharge (`sunset_burn` was a separate commit field the node never reported).
+ * covers blocks that paid at least one recipient). Canonical winners are resolved per height from
+ * the strongest evidence available -- a canonical Stacks block anchor, then raw-event arrival
+ * order, with legacy-table state consulted only for heights raw events don't cover -- and then
+ * propagated back to the legacy burnchain tables, repairing forks those tables couldn't represent
+ * (e.g. a zero-recipient replacement block orphaning a reward-paying rival). Note `burn_amount`
+ * never included the 2.0-era PoX sunset-ramp surcharge (`sunset_burn` was a separate commit field
+ * the node never reported).
  */
 export const up = (pgm: MigrationBuilder) => {
   pgm.createTable('burn_blocks', {
@@ -65,10 +70,30 @@ export const up = (pgm: MigrationBuilder) => {
     FROM latest_events
     ORDER BY id
   `);
+  // Resolve winners among raw-event rows first: a canonical Stacks block anchoring a hash is the
+  // strongest evidence, then raw-event arrival order (the node announces replacement blocks after
+  // the blocks they orphan). This runs before the rewards gap-fill so legacy-table state -- which
+  // cannot represent zero-recipient replacement blocks -- can never override raw-event evidence.
+  pgm.sql(`
+    WITH winners AS (
+      SELECT DISTINCT ON (burn_block_height) burn_block_height, burn_block_hash
+      FROM burn_blocks c
+      ORDER BY burn_block_height,
+        EXISTS (
+          SELECT 1 FROM blocks b
+          WHERE b.burn_block_hash = c.burn_block_hash AND b.canonical = true
+        ) DESC,
+        id DESC
+    )
+    UPDATE burn_blocks c
+    SET canonical = (c.burn_block_hash = w.burn_block_hash)
+    FROM winners w
+    WHERE c.burn_block_height = w.burn_block_height
+      AND c.canonical != (c.burn_block_hash = w.burn_block_hash)
+  `);
   // Fill gaps from burnchain_rewards for eras where raw events were pruned or disabled. Rewards
   // rows duplicate the block-level burn_amount per recipient, so any row's value works. Groups are
-  // ordered by their latest reward-row id so the assigned burn_blocks ids preserve arrival order
-  // for the canonical tie-break below.
+  // ordered by their latest reward-row id so the assigned burn_blocks ids preserve arrival order.
   pgm.sql(`
     INSERT INTO burn_blocks (canonical, burn_block_hash, burn_block_height, burn_amount, reward_amount)
     SELECT false, burn_block_hash, burn_block_height, MAX(burn_amount), SUM(reward_amount)
@@ -77,13 +102,17 @@ export const up = (pgm: MigrationBuilder) => {
     ORDER BY MAX(id)
     ON CONFLICT ON CONSTRAINT burn_blocks_unique_idx DO NOTHING
   `);
-  // One canonical hash per height, preferring a hash anchored by a canonical Stacks block, then one
-  // canonical in the (already repaired) rewards table -- keeping this table consistent with the
-  // legacy tables -- and falling back to arrival order. The same rule as the other repairs.
+  // Resolve winners for heights with no raw-event evidence (no canonical row yet): prefer a
+  // canonical Stacks block anchor, then the hash canonical in the (already repaired) rewards
+  // table, then arrival order. Heights already resolved from raw events are left untouched.
   pgm.sql(`
     WITH winners AS (
       SELECT DISTINCT ON (burn_block_height) burn_block_height, burn_block_hash
       FROM burn_blocks c
+      WHERE NOT EXISTS (
+        SELECT 1 FROM burn_blocks c2
+        WHERE c2.burn_block_height = c.burn_block_height AND c2.canonical = true
+      )
       ORDER BY burn_block_height,
         EXISTS (
           SELECT 1 FROM blocks b
@@ -100,6 +129,41 @@ export const up = (pgm: MigrationBuilder) => {
     FROM winners w
     WHERE c.burn_block_height = w.burn_block_height
       AND c.canonical != (c.burn_block_hash = w.burn_block_hash)
+  `);
+  // Propagate the resolved winners back to the legacy burnchain tables so they agree with the
+  // raw-event evidence. In particular, a zero-recipient replacement block (visible only in raw
+  // events) orphans the rival hash's rewards, slot holders, and pox txs -- the historical
+  // counterpart of what the write path now does on ingestion.
+  pgm.sql(`
+    UPDATE burnchain_rewards r
+    SET canonical = (r.burn_block_hash = w.burn_block_hash)
+    FROM burn_blocks w
+    WHERE w.canonical = true
+      AND w.burn_block_height = r.burn_block_height
+      AND r.canonical != (r.burn_block_hash = w.burn_block_hash)
+  `);
+  pgm.sql(`
+    UPDATE reward_slot_holders s
+    SET canonical = (s.burn_block_hash = w.burn_block_hash)
+    FROM burn_blocks w
+    WHERE w.canonical = true
+      AND w.burn_block_height = s.burn_block_height
+      AND s.canonical != (s.burn_block_hash = w.burn_block_hash)
+  `);
+  pgm.sql(`
+    UPDATE burn_block_pox_txs p
+    SET canonical = (p.burn_block_hash = w.burn_block_hash)
+    FROM burn_blocks w
+    WHERE w.canonical = true
+      AND w.burn_block_height = p.burn_block_height
+      AND p.canonical != (p.burn_block_hash = w.burn_block_hash)
+  `);
+  pgm.sql(`
+    DELETE FROM burn_block_pox_tx_counts
+  `);
+  pgm.sql(`
+    INSERT INTO burn_block_pox_tx_counts (recipient, count)
+    (SELECT recipient, COUNT(*) AS count FROM burn_block_pox_txs WHERE canonical = true GROUP BY recipient)
   `);
   // `burn_amount` is a block-level fact now owned by this table; the copy duplicated onto every
   // reward row (and absent for zero-recipient blocks) is redundant. Reads join through

--- a/migrations/1779800000015_burn-blocks.ts
+++ b/migrations/1779800000015_burn-blocks.ts
@@ -172,8 +172,9 @@ export const up = (pgm: MigrationBuilder) => {
 };
 
 export const down = (pgm: MigrationBuilder) => {
-  // Restores the column shape only; the per-row values are not recoverable (rebuild them by
-  // re-running `up`, which sources burn amounts from raw events and this table's data is lost).
+  // Restore the legacy per-reward column and refill it from this table before dropping it, so
+  // historical API `burn_amount` reads survive a rollback. Only blocks with no reward rows (which
+  // the legacy column never represented anyway) lose their burn amounts.
   pgm.addColumn('burnchain_rewards', {
     burn_amount: {
       type: 'numeric',
@@ -181,5 +182,11 @@ export const down = (pgm: MigrationBuilder) => {
       default: 0,
     },
   });
+  pgm.sql(`
+    UPDATE burnchain_rewards r
+    SET burn_amount = b.burn_amount
+    FROM burn_blocks b
+    WHERE b.burn_block_hash = r.burn_block_hash
+  `);
   pgm.dropTable('burn_blocks');
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:client": "npm run generate:git-info && npm run generate:openapi && npm run generate:client",
     "test:api:blocks": "NODE_ENV=test node --import tsx --test --test-global-setup=./tests/api/setup.ts --test-concurrency=1 ./tests/api/blocks/**/*.test.ts",
     "test:api:bns": "NODE_ENV=test node --import tsx --test --test-global-setup=./tests/api/setup.ts --test-concurrency=1 ./tests/api/bns/**/*.test.ts",
+    "test:api:burnchain": "NODE_ENV=test node --import tsx --test --test-global-setup=./tests/api/setup.ts --test-concurrency=1 ./tests/api/burnchain/**/*.test.ts",
     "test:api:cache": "NODE_ENV=test node --import tsx --test --test-global-setup=./tests/api/setup.ts --test-concurrency=1 ./tests/api/cache/**/*.test.ts",
     "test:api:datastore": "NODE_ENV=test node --import tsx --test --test-global-setup=./tests/api/setup.ts --test-concurrency=1 ./tests/api/datastore/**/*.test.ts",
     "test:api:event-replay": "NODE_ENV=test node --import tsx --test --test-global-setup=./tests/api/setup.ts --test-concurrency=1 ./tests/api/event-replay/**/*.test.ts",

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -65,10 +65,22 @@ export interface DbBurnchainReward {
   canonical: boolean;
   burn_block_hash: string;
   burn_block_height: number;
-  burn_amount: bigint;
   reward_recipient: string;
   reward_amount: bigint;
   reward_index: number;
+}
+
+/** A burnchain reward read joined with its block's `burn_amount` from `burn_blocks`. */
+export interface DbBurnchainRewardWithBurnAmount extends DbBurnchainReward {
+  burn_amount: bigint;
+}
+
+export interface DbBurnchainBlock {
+  canonical: boolean;
+  burn_block_hash: string;
+  burn_block_height: number;
+  burn_amount: bigint;
+  reward_amount: bigint;
 }
 
 export interface DbPoxSetSigners {
@@ -1457,10 +1469,17 @@ export interface BurnchainRewardInsertValues {
   canonical: boolean;
   burn_block_hash: PgBytea;
   burn_block_height: number;
-  burn_amount: PgNumeric;
   reward_recipient: string;
   reward_amount: bigint;
   reward_index: number;
+}
+
+export interface BurnchainBlockInsertValues {
+  canonical: boolean;
+  burn_block_hash: PgBytea;
+  burn_block_height: number;
+  burn_amount: PgNumeric;
+  reward_amount: PgNumeric;
 }
 
 export interface BnsNameInsertValues {

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -23,7 +23,7 @@ import {
   DbBnsNamespace,
   DbBnsSubdomain,
   DbBnsZoneFile,
-  DbBurnchainReward,
+  DbBurnchainRewardWithBurnAmount,
   DbChainTip,
   DbEvent,
   DbEventTypeId,
@@ -856,31 +856,33 @@ export class PgStore extends BasePgStore {
     burnchainRecipient?: string;
     limit: number;
     offset: number;
-  }): Promise<DbBurnchainReward[]> {
+  }): Promise<DbBurnchainRewardWithBurnAmount[]> {
     const queryResults = await this.sql<
       {
         burn_block_hash: string;
         burn_block_height: number;
-        burn_amount: string;
+        burn_amount: string | null;
         reward_recipient: string;
         reward_amount: string;
         reward_index: number;
       }[]
     >`
-      SELECT burn_block_hash, burn_block_height, burn_amount, reward_recipient, reward_amount, reward_index
-      FROM burnchain_rewards
-      WHERE canonical = true
-        ${burnchainRecipient ? this.sql`AND reward_recipient = ${burnchainRecipient}` : this.sql``}
-      ORDER BY burn_block_height DESC, reward_index DESC
+      SELECT r.burn_block_hash, r.burn_block_height, b.burn_amount, r.reward_recipient,
+        r.reward_amount, r.reward_index
+      FROM burnchain_rewards r
+      LEFT JOIN burn_blocks b USING (burn_block_hash)
+      WHERE r.canonical = true
+        ${burnchainRecipient ? this.sql`AND r.reward_recipient = ${burnchainRecipient}` : this.sql``}
+      ORDER BY r.burn_block_height DESC, r.reward_index DESC
       LIMIT ${limit}
       OFFSET ${offset}
     `;
     return queryResults.map(r => {
-      const parsed: DbBurnchainReward = {
+      const parsed: DbBurnchainRewardWithBurnAmount = {
         canonical: true,
         burn_block_hash: r.burn_block_hash,
         burn_block_height: r.burn_block_height,
-        burn_amount: BigInt(r.burn_amount),
+        burn_amount: BigInt(r.burn_amount ?? 0),
         reward_recipient: r.reward_recipient,
         reward_amount: BigInt(r.reward_amount),
         reward_index: r.reward_index,

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -3074,8 +3074,6 @@ export class PgStore extends BasePgStore {
       ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
     `;
 
-    // TODO: should mining rewards be added?
-
     const txs = parseTxsWithAssetTransfers(resultQuery, args.stxAddress);
     const txTransfers = [...txs.values()];
     txTransfers.sort((a, b) => {
@@ -3183,7 +3181,6 @@ export class PgStore extends BasePgStore {
   }
 
   async searchHash({ hash }: { hash: string }): Promise<FoundOrNot<DbSearchResult>> {
-    // TODO(mb): add support for searching for microblock by hash
     return await this.sqlTransaction(async sql => {
       const txQuery = await sql<ContractTxQueryResult[]>`
         SELECT ${sql(TX_COLUMNS)}, ${abiColumn(sql)}

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -37,6 +37,7 @@ import {
   NftEventInsertValues,
   SmartContractEventInsertValues,
   MicroblockQueryResult,
+  BurnchainBlockInsertValues,
   BurnchainRewardInsertValues,
   TxInsertValues,
   MempoolTxInsertValues,
@@ -1535,57 +1536,89 @@ export class PgWriteStore extends PgStore {
     slotHolders: DbRewardSlotHolder[];
   }): Promise<void> {
     await this.sqlWriteTransaction(async sql => {
-      const existingSlotHolders = await sql<{ address: string }[]>`
+      // Same-height fork handling; see `updateBurnchainRewards` for the reasoning.
+      const orphanedSlotHolders = await sql<{ address: string }[]>`
         UPDATE reward_slot_holders
         SET canonical = false
-        WHERE canonical = true
-          AND (burn_block_hash = ${burnchainBlockHash}
-            OR burn_block_height >= ${burnchainBlockHeight})
+        WHERE burn_block_height = ${burnchainBlockHeight}
+          AND burn_block_hash != ${burnchainBlockHash}
+          AND canonical = true
       `;
-      if (existingSlotHolders.count > 0) {
+      if (orphanedSlotHolders.count > 0) {
         logger.warn(
-          `Invalidated ${existingSlotHolders.count} burnchain reward slot holders after fork detected at burnchain block ${burnchainBlockHash}`
+          `Invalidated ${orphanedSlotHolders.count} burnchain reward slot holders after fork detected at burnchain block ${burnchainBlockHash}`
         );
       }
       if (slotHolders.length === 0) {
         return;
       }
       const values: RewardSlotHolderInsertValues[] = slotHolders.map(val => ({
-        canonical: val.canonical,
+        canonical: true,
         burn_block_hash: val.burn_block_hash,
         burn_block_height: val.burn_block_height,
         address: val.address,
         slot_index: val.slot_index,
       }));
-      const result = await sql`
+      await sql`
         INSERT INTO reward_slot_holders ${sql(values)}
+        ON CONFLICT ON CONSTRAINT reward_slot_holders_unique_idx DO UPDATE
+        SET canonical = true
+        WHERE reward_slot_holders.canonical = false
       `;
-      if (result.count !== slotHolders.length) {
-        throw new Error(
-          `Unexpected row count after inserting reward slot holders: ${result.count} vs ${slotHolders.length}`
-        );
-      }
     });
   }
 
-  async updateBurnBlockPoxTxs(args: { burnBlockPoxTxs: DbBurnBlockPoxTx[] }): Promise<void> {
-    if (args.burnBlockPoxTxs.length === 0) return;
-    await this.sql`
-      WITH inserts AS (
-        INSERT INTO burn_block_pox_txs ${this.sql(args.burnBlockPoxTxs)}
-        ON CONFLICT ON CONSTRAINT burn_block_pox_txs_unique_idx DO NOTHING
-        RETURNING recipient, canonical
-      ),
-      count_deltas AS (
-        SELECT recipient, COUNT(*) AS count
-        FROM inserts
-        WHERE canonical = true
-        GROUP BY recipient
-      )
-      INSERT INTO burn_block_pox_tx_counts (recipient, count)
-      (SELECT recipient, count FROM count_deltas)
-      ON CONFLICT (recipient) DO UPDATE SET count = burn_block_pox_tx_counts.count + EXCLUDED.count
-    `;
+  async updateBurnBlockPoxTxs(args: {
+    burnchainBlockHash: string;
+    burnchainBlockHeight: number;
+    burnBlockPoxTxs: DbBurnBlockPoxTx[];
+  }): Promise<void> {
+    await this.sqlWriteTransaction(async sql => {
+      // Orphan same-height rows under a different hash (burnchain fork), keeping the materialized
+      // per-recipient counts in sync. See `updateBurnchainRewards` for the reasoning; this too must
+      // run even when the new burn block carries no pox txs.
+      await sql`
+        WITH orphaned AS (
+          UPDATE burn_block_pox_txs
+          SET canonical = false
+          WHERE burn_block_height = ${args.burnchainBlockHeight}
+            AND burn_block_hash != ${args.burnchainBlockHash}
+            AND canonical = true
+          RETURNING recipient
+        ),
+        count_deltas AS (
+          SELECT recipient, COUNT(*) AS count
+          FROM orphaned
+          GROUP BY recipient
+        )
+        UPDATE burn_block_pox_tx_counts AS pc
+        SET count = pc.count - cd.count
+        FROM count_deltas AS cd
+        WHERE pc.recipient = cd.recipient
+      `;
+      if (args.burnBlockPoxTxs.length === 0) return;
+      // Re-delivered rows that are already canonical conflict without updating and are excluded
+      // from the count deltas. Rows restored from a previously orphaned fork flip back to
+      // canonical and count again.
+      await sql`
+        WITH inserts AS (
+          INSERT INTO burn_block_pox_txs ${sql(args.burnBlockPoxTxs)}
+          ON CONFLICT ON CONSTRAINT burn_block_pox_txs_unique_idx DO UPDATE
+          SET canonical = true
+          WHERE burn_block_pox_txs.canonical = false
+          RETURNING recipient, canonical
+        ),
+        count_deltas AS (
+          SELECT recipient, COUNT(*) AS count
+          FROM inserts
+          WHERE canonical = true
+          GROUP BY recipient
+        )
+        INSERT INTO burn_block_pox_tx_counts (recipient, count)
+        (SELECT recipient, count FROM count_deltas)
+        ON CONFLICT (recipient) DO UPDATE SET count = burn_block_pox_tx_counts.count + EXCLUDED.count
+      `;
+    });
   }
 
   async updateMicroblocks(data: DataStoreMicroblockUpdateData): Promise<void> {
@@ -3313,25 +3346,87 @@ export class PgWriteStore extends PgStore {
     };
   }
 
-  async updateBurnchainRewards({ rewards }: { rewards: DbBurnchainReward[] }): Promise<void> {
+  async updateBurnchainBlock({
+    burnchainBlockHash,
+    burnchainBlockHeight,
+    burnAmount,
+    rewardAmount,
+  }: {
+    burnchainBlockHash: string;
+    burnchainBlockHeight: number;
+    burnAmount: bigint;
+    rewardAmount: bigint;
+  }): Promise<void> {
     return await this.sqlWriteTransaction(async sql => {
-      for (const reward of rewards) {
-        const values: BurnchainRewardInsertValues = {
-          canonical: true,
-          burn_block_hash: reward.burn_block_hash,
-          burn_block_height: reward.burn_block_height,
-          burn_amount: reward.burn_amount.toString(),
-          reward_recipient: reward.reward_recipient,
-          reward_amount: reward.reward_amount,
-          reward_index: reward.reward_index,
-        };
-        const rewardInsertResult = await sql`
-          INSERT into burnchain_rewards ${sql(values)}
-        `;
-        if (rewardInsertResult.count !== 1) {
-          throw new Error(`Failed to insert burnchain reward at block ${reward.burn_block_hash}`);
-        }
+      // Same-height fork handling; see `updateBurnchainRewards` for the reasoning.
+      await sql`
+        UPDATE burn_blocks
+        SET canonical = false
+        WHERE burn_block_height = ${burnchainBlockHeight}
+          AND burn_block_hash != ${burnchainBlockHash}
+          AND canonical = true
+      `;
+      const values: BurnchainBlockInsertValues = {
+        canonical: true,
+        burn_block_hash: burnchainBlockHash,
+        burn_block_height: burnchainBlockHeight,
+        burn_amount: burnAmount.toString(),
+        reward_amount: rewardAmount.toString(),
+      };
+      await sql`
+        INSERT INTO burn_blocks ${sql(values)}
+        ON CONFLICT ON CONSTRAINT burn_blocks_unique_idx DO UPDATE
+        SET canonical = true
+        WHERE burn_blocks.canonical = false
+      `;
+    });
+  }
+
+  async updateBurnchainRewards({
+    burnchainBlockHash,
+    burnchainBlockHeight,
+    rewards,
+  }: {
+    burnchainBlockHash: string;
+    burnchainBlockHeight: number;
+    rewards: DbBurnchainReward[];
+  }): Promise<void> {
+    return await this.sqlWriteTransaction(async sql => {
+      // The burnchain is linear: a new burn block at this height means any rewards previously
+      // stored at the same height under a different hash belong to an orphaned burnchain fork. This
+      // must run even when `rewards` is empty. A zero-recipient burn block is how the node reports
+      // a replacement block that paid no rewards. Heights above this one are never touched: the
+      // node announces every replacement block of a burnchain fork individually, and it may also
+      // re-deliver old burn blocks out of order, which must not orphan newer data.
+      const orphanedRewards = await sql`
+        UPDATE burnchain_rewards
+        SET canonical = false
+        WHERE burn_block_height = ${burnchainBlockHeight}
+          AND burn_block_hash != ${burnchainBlockHash}
+          AND canonical = true
+      `;
+      if (orphanedRewards.count > 0) {
+        logger.warn(
+          `Invalidated ${orphanedRewards.count} burnchain rewards after fork detected at burnchain block ${burnchainBlockHash}`
+        );
       }
+      if (rewards.length === 0) return;
+      const values: BurnchainRewardInsertValues[] = rewards.map(reward => ({
+        canonical: true,
+        burn_block_hash: reward.burn_block_hash,
+        burn_block_height: reward.burn_block_height,
+        reward_recipient: reward.reward_recipient,
+        reward_amount: reward.reward_amount,
+        reward_index: reward.reward_index,
+      }));
+      // Idempotent against re-delivered events. The conflict update restores canonical status when
+      // the burnchain forks back to a previously orphaned block.
+      await sql`
+        INSERT INTO burnchain_rewards ${sql(values)}
+        ON CONFLICT ON CONSTRAINT burnchain_rewards_unique_idx DO UPDATE
+        SET canonical = true
+        WHERE burnchain_rewards.canonical = false
+      `;
     });
   }
 
@@ -3342,44 +3437,6 @@ export class PgWriteStore extends PgStore {
     `;
     if (this.metrics && result.length > 0) {
       this.metrics.burnBlockHeight.set(result[0].burn_block_height);
-    }
-  }
-
-  async insertSlotHoldersBatch(sql: PgSqlClient, slotHolders: DbRewardSlotHolder[]): Promise<void> {
-    const slotValues: RewardSlotHolderInsertValues[] = slotHolders.map(slot => ({
-      canonical: true,
-      burn_block_hash: slot.burn_block_hash,
-      burn_block_height: slot.burn_block_height,
-      address: slot.address,
-      slot_index: slot.slot_index,
-    }));
-
-    const result = await sql`
-      INSERT INTO reward_slot_holders ${sql(slotValues)}
-    `;
-
-    if (result.count !== slotValues.length) {
-      throw new Error(`Failed to insert slot holder for ${slotValues}`);
-    }
-  }
-
-  async insertBurnchainRewardsBatch(sql: PgSqlClient, rewards: DbBurnchainReward[]): Promise<void> {
-    const rewardValues: BurnchainRewardInsertValues[] = rewards.map(reward => ({
-      canonical: true,
-      burn_block_hash: reward.burn_block_hash,
-      burn_block_height: reward.burn_block_height,
-      burn_amount: reward.burn_amount.toString(),
-      reward_recipient: reward.reward_recipient,
-      reward_amount: reward.reward_amount,
-      reward_index: reward.reward_index,
-    }));
-
-    const res = await sql`
-      INSERT into burnchain_rewards ${sql(rewardValues)}
-    `;
-
-    if (res.count !== rewardValues.length) {
-      throw new Error(`Failed to insert burnchain reward for ${rewardValues}`);
     }
   }
 
@@ -4578,7 +4635,6 @@ export class PgWriteStore extends PgStore {
   async markEntitiesCanonical(
     sql: PgSqlClient,
     indexBlockHash: string,
-    burnBlockHash: string,
     canonical: boolean,
     updatedEntities: ReOrgUpdatedEntities
   ): Promise<{
@@ -5253,43 +5309,10 @@ export class PgWriteStore extends PgStore {
         updatedEntities.markedNonCanonical.poxCycles += poxCycleResult.count;
       }
     });
-    // Entities scoped to the block's `burn_block_hash` are only marked non-canonical when no
-    // canonical block still anchors to that burn block. Multiple Nakamoto blocks in a tenure share
-    // the same burn block, so orphaning part of a tenure (e.g. its trailing blocks) must not
-    // invalidate the burn block's own rows. The `blocks.canonical` flip for this block runs before
-    // this method, so the check reflects the post-re-org state.
-    q.enqueue(async () => {
-      await sql`
-        UPDATE burnchain_rewards
-        SET canonical = ${canonical}
-        WHERE burn_block_hash = ${burnBlockHash} AND canonical != ${canonical}
-          AND (${canonical} OR NOT EXISTS (
-            SELECT 1 FROM blocks WHERE burn_block_hash = ${burnBlockHash} AND canonical = true
-          ))
-      `;
-    });
-    q.enqueue(async () => {
-      await sql`
-        WITH updates AS (
-          UPDATE burn_block_pox_txs
-          SET canonical = ${canonical}
-          WHERE burn_block_hash = ${burnBlockHash} AND canonical != ${canonical}
-            AND (${canonical} OR NOT EXISTS (
-              SELECT 1 FROM blocks WHERE burn_block_hash = ${burnBlockHash} AND canonical = true
-            ))
-          RETURNING recipient
-        ),
-        count_deltas AS (
-          SELECT recipient, COUNT(*) AS count
-          FROM updates
-          GROUP BY recipient
-        )
-        UPDATE burn_block_pox_tx_counts AS pc
-        SET count = ${canonical ? sql`pc.count + cd.count` : sql`pc.count - cd.count`}
-        FROM count_deltas AS cd
-        WHERE pc.recipient = cd.recipient
-      `;
-    });
+    // Note: `burnchain_rewards` and `burn_block_pox_txs` record burnchain-level facts and are
+    // deliberately not flipped here. A Stacks-level re-org (even one orphaning a full tenure) does
+    // not un-pay bitcoin: their canonical status is maintained exclusively by `/new_burn_block`
+    // ingestion, which orphans same-height rows when the burnchain itself forks.
 
     await q.done();
 
@@ -5339,7 +5362,6 @@ export class PgWriteStore extends PgStore {
     const markNonCanonicalResult = await this.markEntitiesCanonical(
       sql,
       block.index_block_hash,
-      block.burn_block_hash,
       false,
       updatedEntities
     );
@@ -5358,14 +5380,12 @@ export class PgWriteStore extends PgStore {
    * Recursively restore previously orphaned blocks to canonical.
    * @param sql - The SQL client
    * @param indexBlockHash - The index block hash that we will restore first
-   * @param burnBlockHash - The burn block hash that we will restore first
    * @param updatedEntities - The updated entities
    * @returns The updated entities
    */
   async restoreOrphanedChain(
     sql: PgSqlClient,
     indexBlockHash: string,
-    burnBlockHash: string,
     updatedEntities: ReOrgUpdatedEntities
   ): Promise<ReOrgUpdatedEntities> {
     // Restore the previously orphaned block to canonical
@@ -5454,7 +5474,6 @@ export class PgWriteStore extends PgStore {
     const markCanonicalResult = await this.markEntitiesCanonical(
       sql,
       indexBlockHash,
-      burnBlockHash,
       true,
       updatedEntities
     );
@@ -5465,8 +5484,8 @@ export class PgWriteStore extends PgStore {
     updatedEntities.prunedMempoolTxs += prunedMempoolTxs.removedTxs.length;
 
     // Do we have a parent that is non-canonical? If so, restore it recursively.
-    const parentResult = await sql<{ index_block_hash: string; burn_block_hash: string }[]>`
-      SELECT index_block_hash, burn_block_hash
+    const parentResult = await sql<{ index_block_hash: string }[]>`
+      SELECT index_block_hash
       FROM blocks
       WHERE
         block_height = ${restoredBlockResult[0].block_height - 1} AND
@@ -5477,12 +5496,7 @@ export class PgWriteStore extends PgStore {
       throw new Error('Found more than one non-canonical parent to restore during reorg');
     }
     if (parentResult.length > 0) {
-      await this.restoreOrphanedChain(
-        sql,
-        parentResult[0].index_block_hash,
-        parentResult[0].burn_block_hash,
-        updatedEntities
-      );
+      await this.restoreOrphanedChain(sql, parentResult[0].index_block_hash, updatedEntities);
     }
     return updatedEntities;
   }
@@ -5571,12 +5585,7 @@ export class PgWriteStore extends PgStore {
     if (!parentResult[0].canonical) {
       // The new block builds off a previously orphaned chain. Restore canonical status for this
       // chain, orphaning any conflicting blocks along the way.
-      await this.restoreOrphanedChain(
-        sql,
-        parentResult[0].index_block_hash,
-        parentResult[0].burn_block_hash,
-        updatedEntities
-      );
+      await this.restoreOrphanedChain(sql, parentResult[0].index_block_hash, updatedEntities);
     }
     await this.updateChainTipTxCountsAfterReorg(sql, updatedEntities);
     logger.info(
@@ -5621,12 +5630,7 @@ export class PgWriteStore extends PgStore {
         );
       // This block builds off a previously orphaned chain. Restore canonical status for this chain.
       if (!parentResult[0].canonical && block.block_height > chainTipHeight) {
-        await this.restoreOrphanedChain(
-          sql,
-          parentResult[0].index_block_hash,
-          parentResult[0].burn_block_hash,
-          updatedEntities
-        );
+        await this.restoreOrphanedChain(sql, parentResult[0].index_block_hash, updatedEntities);
         logger.info(
           updatedEntities,
           `Re-org resolved. Block ${block.block_height} builds off a previously orphaned chain.`

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -128,7 +128,6 @@ async function handleBurnBlockMessage(
       canonical: true,
       burn_block_hash: burnBlockMsg.burn_block_hash,
       burn_block_height: burnBlockMsg.burn_block_height,
-      burn_amount: BigInt(burnBlockMsg.burn_amount),
       reward_recipient: r.recipient,
       reward_amount: BigInt(r.amt),
       reward_index: index,
@@ -145,14 +144,6 @@ async function handleBurnBlockMessage(
     };
     return slotHolder;
   });
-  await db.updateBurnchainRewards({
-    rewards: rewards,
-  });
-  await db.updateBurnchainRewardSlotHolders({
-    burnchainBlockHash: burnBlockMsg.burn_block_hash,
-    burnchainBlockHeight: burnBlockMsg.burn_block_height,
-    slotHolders: slotHolders,
-  });
   const burnBlockPoxTxs: DbBurnBlockPoxTx[] = [];
   for (const tx of burnBlockMsg.pox_transactions ?? []) {
     for (const recipient of tx.reward_recipients ?? []) {
@@ -167,8 +158,33 @@ async function handleBurnBlockMessage(
       });
     }
   }
-  await db.updateBurnBlockPoxTxs({ burnBlockPoxTxs });
-  await db.updateBurnChainBlockHeight({ blockHeight: burnBlockMsg.burn_block_height });
+  // A single transaction so a failure in any step leaves nothing committed: the node re-delivers
+  // the whole event on a non-200 response, and a partially committed event would otherwise be
+  // ingested twice.
+  await db.sqlWriteTransaction(async () => {
+    await db.updateBurnchainBlock({
+      burnchainBlockHash: burnBlockMsg.burn_block_hash,
+      burnchainBlockHeight: burnBlockMsg.burn_block_height,
+      burnAmount: BigInt(burnBlockMsg.burn_amount),
+      rewardAmount: rewards.reduce((total, r) => total + r.reward_amount, 0n),
+    });
+    await db.updateBurnchainRewards({
+      burnchainBlockHash: burnBlockMsg.burn_block_hash,
+      burnchainBlockHeight: burnBlockMsg.burn_block_height,
+      rewards: rewards,
+    });
+    await db.updateBurnchainRewardSlotHolders({
+      burnchainBlockHash: burnBlockMsg.burn_block_hash,
+      burnchainBlockHeight: burnBlockMsg.burn_block_height,
+      slotHolders: slotHolders,
+    });
+    await db.updateBurnBlockPoxTxs({
+      burnchainBlockHash: burnBlockMsg.burn_block_hash,
+      burnchainBlockHeight: burnBlockMsg.burn_block_height,
+      burnBlockPoxTxs,
+    });
+    await db.updateBurnChainBlockHeight({ blockHeight: burnBlockMsg.burn_block_height });
+  });
 }
 
 async function handleMempoolTxsMessage(rawTxs: string[], db: PgWriteStore): Promise<void> {

--- a/tests/api/burnchain/burnchain-reorg.test.ts
+++ b/tests/api/burnchain/burnchain-reorg.test.ts
@@ -656,6 +656,29 @@ describe('burnchain re-org handling', () => {
         VALUES (${f.canonical}, ${f.hash}, 103, ${f.burn}, ${ADDR_1}, 1000, 0)
       `;
     }
+    // A fork at height 104 where block 0xff01 paid rewards but the later-arriving replacement
+    // 0xff02 paid none: the legacy tables cannot represent 0xff02 (it left 0xff01's rewards
+    // canonical), so the raw-event arrival order must win and be propagated back to them.
+    for (const e of [
+      { hash: '0xff01', burn: 100, recipients: [{ recipient: ADDR_1, amt: 800 }] },
+      { hash: '0xff02', burn: 900, recipients: [] as { recipient: string; amt: number }[] },
+    ]) {
+      await client`
+        INSERT INTO event_observer_requests (event_path, payload)
+        VALUES ('/new_burn_block', ${{
+          burn_block_hash: e.hash,
+          burn_block_height: 104,
+          burn_amount: e.burn,
+          reward_recipients: e.recipients,
+          reward_slot_holders: [],
+        }})
+      `;
+    }
+    await client`
+      INSERT INTO burnchain_rewards
+        (canonical, burn_block_hash, burn_block_height, burn_amount, reward_recipient, reward_amount, reward_index)
+      VALUES (true, ${'0xff01'}, 104, 100, ${ADDR_1}, 800, 0)
+    `;
     // Re-run only the burn_blocks migration (the delivery above also wrote to the live
     // table; drop it so the migration recreates and backfills from scratch).
     await client`DROP TABLE burn_blocks`;
@@ -678,7 +701,46 @@ describe('burnchain re-org handling', () => {
         ['0xdd01', 102, '2000', '1000', true],
         ['0xee01', 103, '500', '1000', false],
         ['0xee02', 103, '600', '1000', true],
+        ['0xff01', 104, '100', '800', false],
+        ['0xff02', 104, '900', '0', true],
       ]
     );
+    // The 0xff01 rewards the legacy tables held canonical are orphaned by the propagation pass.
+    const rewards = await rewardRows();
+    assert.deepEqual(
+      rewards.map(r => [r.burn_block_hash, r.burn_block_height, r.canonical]),
+      [
+        ['0xdd01', 102, true],
+        ['0xee01', 103, false],
+        ['0xee02', 103, true],
+        ['0xff01', 104, false],
+      ]
+    );
+  });
+
+  test('burn block ingestion is atomic across all tables', async () => {
+    // Nested `sqlWriteTransaction` calls join the outer transaction via AsyncLocalStorage (see
+    // `BasePgStore.sqlTransaction`), so a failure after some steps of `handleBurnBlockMessage`
+    // must leave nothing committed. If the inner calls opened their own transactions, the rows
+    // written before the failure would survive.
+    await assert.rejects(
+      db.sqlWriteTransaction(async () => {
+        await db.updateBurnchainBlock({
+          burnchainBlockHash: '0xaa01',
+          burnchainBlockHeight: 100,
+          burnAmount: 5000n,
+          rewardAmount: 1000n,
+        });
+        await db.updateBurnchainRewards({
+          burnchainBlockHash: '0xaa01',
+          burnchainBlockHeight: 100,
+          rewards: [reward({ hash: '0xaa01', height: 100 })],
+        });
+        throw new Error('mid-ingestion failure');
+      }),
+      /mid-ingestion failure/
+    );
+    assert.equal((await burnchainBlockRows()).length, 0);
+    assert.equal((await rewardRows()).length, 0);
   });
 });

--- a/tests/api/burnchain/burnchain-reorg.test.ts
+++ b/tests/api/burnchain/burnchain-reorg.test.ts
@@ -617,6 +617,18 @@ describe('burnchain re-org handling', () => {
       rewards: [reward({ hash: '0xdd01', height: 102 })],
     });
     await client`UPDATE burnchain_rewards SET burn_amount = 2000 WHERE burn_block_hash = ${'0xdd01'}`;
+    // A burnchain fork at height 103 present only in burnchain_rewards (no raw events): the
+    // gap-fill must stay consistent with the repaired rewards table, where 0xee02 won.
+    for (const f of [
+      { hash: '0xee01', burn: 500, canonical: false },
+      { hash: '0xee02', burn: 600, canonical: true },
+    ]) {
+      await client`
+        INSERT INTO burnchain_rewards
+          (canonical, burn_block_hash, burn_block_height, burn_amount, reward_recipient, reward_amount, reward_index)
+        VALUES (${f.canonical}, ${f.hash}, 103, ${f.burn}, ${ADDR_1}, 1000, 0)
+      `;
+    }
     // Re-run only the burn_blocks migration (the delivery above also wrote to the live
     // table; drop it so the migration recreates and backfills from scratch).
     await client`DROP TABLE burn_blocks`;
@@ -637,6 +649,8 @@ describe('burnchain re-org handling', () => {
         ['0xbb01', 100, '2000', '1200', true],
         ['0xcc01', 101, '30000', '0', true],
         ['0xdd01', 102, '2000', '1000', true],
+        ['0xee01', 103, '500', '1000', false],
+        ['0xee02', 103, '600', '1000', true],
       ]
     );
   });

--- a/tests/api/burnchain/burnchain-reorg.test.ts
+++ b/tests/api/burnchain/burnchain-reorg.test.ts
@@ -524,6 +524,10 @@ describe('burnchain re-org handling', () => {
       // tie-break (which would pick 0xdd09).
       { hash: '0xdd09', height: 102, canonical: true, recipient: ADDR_2 },
       { hash: '0xdd01', height: 102, canonical: true, recipient: ADDR_1 },
+      // Height 103: a fork where the hash sets are disjoint across tables -- this table only saw
+      // 0xee0b while reward_slot_holders only saw 0xee0a. The shared winner (0xee0a, by slot
+      // holder arrival) must orphan this row even though its hash never appears here.
+      { hash: '0xee0b', height: 103, canonical: true, recipient: ADDR_2 },
     ];
     for (const t of seedPoxTxs) {
       await client`
@@ -548,6 +552,8 @@ describe('burnchain re-org handling', () => {
       // burn_block_pox_txs.
       { hash: '0xdd09', height: 102, index: 0, canonical: true },
       { hash: '0xdd01', height: 102, index: 0, canonical: true },
+      // Height 103: the disjoint-table fork side this table saw (see the pox tx seeds).
+      { hash: '0xee0a', height: 103, index: 0, canonical: true },
     ];
     for (const s of seedSlotHolders) {
       await client`
@@ -594,6 +600,7 @@ describe('burnchain re-org handling', () => {
         ['0xaa02', true],
         ['0xdd01', true],
         ['0xdd09', false],
+        ['0xee0b', false],
       ]
     );
     assert.equal(await poxTxCount(ADDR_1), 2);
@@ -608,6 +615,7 @@ describe('burnchain re-org handling', () => {
         ['0xaa02', 101, 0, true],
         ['0xdd01', 102, 0, true],
         ['0xdd09', 102, 0, false],
+        ['0xee0a', 103, 0, true],
       ]
     );
   });

--- a/tests/api/burnchain/burnchain-reorg.test.ts
+++ b/tests/api/burnchain/burnchain-reorg.test.ts
@@ -1,0 +1,643 @@
+import { DbBurnBlockPoxTx, DbBurnchainReward, DbRewardSlotHolder } from '../../../src/datastore/common.ts';
+import { PgWriteStore } from '../../../src/datastore/pg-write-store.ts';
+import { MIGRATIONS_DIR } from '../../../src/datastore/pg-store.ts';
+import { getConnectionArgs } from '../../../src/datastore/connection.ts';
+import { PgSqlClient, runMigrations } from '@stacks/api-toolkit';
+import { TestBlockBuilder } from '../test-builders.ts';
+import { migrate } from '../../test-helpers.ts';
+import { beforeEach, afterEach, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+describe('burnchain re-org handling', () => {
+  let db: PgWriteStore;
+  let client: PgSqlClient;
+
+  const ADDR_1 = '1G4ayBXJvxZMoZpaNdZG6VyWwWq2mHpMjQ';
+  const ADDR_2 = '1DDUAqoyXvhF4cxznN9uL6j9ok1oncsT2z';
+
+  function reward(args: {
+    hash: string;
+    height: number;
+    index?: number;
+    recipient?: string;
+    amount?: bigint;
+  }): DbBurnchainReward {
+    return {
+      canonical: true,
+      burn_block_hash: args.hash,
+      burn_block_height: args.height,
+      reward_recipient: args.recipient ?? ADDR_1,
+      reward_amount: args.amount ?? 1000n,
+      reward_index: args.index ?? 0,
+    };
+  }
+
+  function poxTx(args: {
+    hash: string;
+    height: number;
+    txId?: string;
+    utxoIdx?: number;
+    recipient?: string;
+    amount?: bigint;
+  }): DbBurnBlockPoxTx {
+    return {
+      canonical: true,
+      burn_block_hash: args.hash,
+      burn_block_height: args.height,
+      tx_id: args.txId ?? '0x0001',
+      recipient: args.recipient ?? ADDR_1,
+      utxo_idx: args.utxoIdx ?? 0,
+      amount: args.amount ?? 1000n,
+    };
+  }
+
+  function slotHolder(args: {
+    hash: string;
+    height: number;
+    index?: number;
+    address?: string;
+  }): DbRewardSlotHolder {
+    return {
+      canonical: true,
+      burn_block_hash: args.hash,
+      burn_block_height: args.height,
+      address: args.address ?? ADDR_1,
+      slot_index: args.index ?? 0,
+    };
+  }
+
+  /** Ingests one `/new_burn_block` event the way the event server does. */
+  async function deliverBurnBlock(args: {
+    hash: string;
+    height: number;
+    burnAmount?: bigint;
+    rewards?: DbBurnchainReward[];
+    slotHolders?: DbRewardSlotHolder[];
+    poxTxs?: DbBurnBlockPoxTx[];
+  }) {
+    await db.sqlWriteTransaction(async () => {
+      await db.updateBurnchainBlock({
+        burnchainBlockHash: args.hash,
+        burnchainBlockHeight: args.height,
+        burnAmount: args.burnAmount ?? 0n,
+        rewardAmount: (args.rewards ?? []).reduce((total, r) => total + r.reward_amount, 0n),
+      });
+      await db.updateBurnchainRewards({
+        burnchainBlockHash: args.hash,
+        burnchainBlockHeight: args.height,
+        rewards: args.rewards ?? [],
+      });
+      await db.updateBurnchainRewardSlotHolders({
+        burnchainBlockHash: args.hash,
+        burnchainBlockHeight: args.height,
+        slotHolders: args.slotHolders ?? [],
+      });
+      await db.updateBurnBlockPoxTxs({
+        burnchainBlockHash: args.hash,
+        burnchainBlockHeight: args.height,
+        burnBlockPoxTxs: args.poxTxs ?? [],
+      });
+    });
+  }
+
+  async function rewardRows(): Promise<
+    { burn_block_hash: string; burn_block_height: number; reward_index: number; canonical: boolean }[]
+  > {
+    return await client`
+      SELECT burn_block_hash, burn_block_height, reward_index, canonical
+      FROM burnchain_rewards
+      ORDER BY burn_block_height, burn_block_hash, reward_index
+    `;
+  }
+
+  async function canonicalRewardSum(): Promise<bigint> {
+    const result = await client<{ sum: string | null }[]>`
+      SELECT SUM(reward_amount) AS sum FROM burnchain_rewards WHERE canonical = true
+    `;
+    return BigInt(result[0].sum ?? 0);
+  }
+
+  async function poxTxCount(recipient: string): Promise<number> {
+    const result = await client<{ count: number }[]>`
+      SELECT count FROM burn_block_pox_tx_counts WHERE recipient = ${recipient}
+    `;
+    return result.length > 0 ? result[0].count : 0;
+  }
+
+  async function slotHolderRows(): Promise<
+    { burn_block_hash: string; burn_block_height: number; slot_index: number; canonical: boolean }[]
+  > {
+    return await client`
+      SELECT burn_block_hash, burn_block_height, slot_index, canonical
+      FROM reward_slot_holders
+      ORDER BY burn_block_height, burn_block_hash, slot_index
+    `;
+  }
+
+  async function burnchainBlockRows(): Promise<
+    {
+      burn_block_hash: string;
+      burn_block_height: number;
+      burn_amount: string;
+      reward_amount: string;
+      canonical: boolean;
+    }[]
+  > {
+    return await client`
+      SELECT burn_block_hash, burn_block_height, burn_amount::text AS burn_amount,
+        reward_amount::text AS reward_amount, canonical
+      FROM burn_blocks
+      ORDER BY burn_block_height, burn_block_hash
+    `;
+  }
+
+  beforeEach(async () => {
+    await migrate('up');
+    db = await PgWriteStore.connect({
+      usageName: 'tests',
+      withNotifier: false,
+      skipMigrations: true,
+    });
+    client = db.sql;
+  });
+
+  afterEach(async () => {
+    await db?.close();
+    await migrate('down');
+  });
+
+  test('re-delivered burn block events are idempotent', async () => {
+    const block = {
+      hash: '0xaa01',
+      height: 100,
+      burnAmount: 5000n,
+      rewards: [
+        reward({ hash: '0xaa01', height: 100, index: 0, recipient: ADDR_1 }),
+        reward({ hash: '0xaa01', height: 100, index: 1, recipient: ADDR_2 }),
+      ],
+      slotHolders: [
+        slotHolder({ hash: '0xaa01', height: 100, index: 0, address: ADDR_1 }),
+        slotHolder({ hash: '0xaa01', height: 100, index: 1, address: ADDR_2 }),
+      ],
+      poxTxs: [
+        poxTx({ hash: '0xaa01', height: 100, txId: '0x0001', utxoIdx: 0, recipient: ADDR_1 }),
+        poxTx({ hash: '0xaa01', height: 100, txId: '0x0001', utxoIdx: 1, recipient: ADDR_2 }),
+      ],
+    };
+    await deliverBurnBlock(block);
+    // The node re-delivers the same event, e.g. after a restart or a retried request.
+    await deliverBurnBlock(block);
+
+    const rewards = await rewardRows();
+    assert.equal(rewards.length, 2);
+    assert.ok(rewards.every(r => r.canonical));
+    assert.equal(await canonicalRewardSum(), 2000n);
+
+    const holders = await slotHolderRows();
+    assert.equal(holders.length, 2);
+    assert.ok(holders.every(h => h.canonical));
+
+    const burnBlocks = await burnchainBlockRows();
+    assert.deepEqual([...burnBlocks], [
+      {
+        burn_block_hash: '0xaa01',
+        burn_block_height: 100,
+        burn_amount: '5000',
+        reward_amount: '2000',
+        canonical: true,
+      },
+    ]);
+
+    const poxTxs = await client<{ count: string }[]>`SELECT COUNT(*)::text AS count FROM burn_block_pox_txs`;
+    assert.equal(poxTxs[0].count, '2');
+    assert.equal(await poxTxCount(ADDR_1), 1);
+    assert.equal(await poxTxCount(ADDR_2), 1);
+  });
+
+  test('a same-height burnchain fork orphans the rival block', async () => {
+    await deliverBurnBlock({
+      hash: '0xaa01',
+      height: 100,
+      rewards: [
+        reward({ hash: '0xaa01', height: 100, index: 0, recipient: ADDR_1 }),
+        reward({ hash: '0xaa01', height: 100, index: 1, recipient: ADDR_1, amount: 500n }),
+      ],
+      slotHolders: [slotHolder({ hash: '0xaa01', height: 100, address: ADDR_1 })],
+      poxTxs: [poxTx({ hash: '0xaa01', height: 100, recipient: ADDR_1 })],
+    });
+    // The burnchain forks: a replacement block at the same height pays different recipients.
+    await deliverBurnBlock({
+      hash: '0xbb01',
+      height: 100,
+      rewards: [reward({ hash: '0xbb01', height: 100, index: 0, recipient: ADDR_2, amount: 700n })],
+      slotHolders: [slotHolder({ hash: '0xbb01', height: 100, address: ADDR_2 })],
+      poxTxs: [poxTx({ hash: '0xbb01', height: 100, recipient: ADDR_2, amount: 700n })],
+    });
+
+    const rewards = await rewardRows();
+    assert.equal(rewards.length, 3);
+    for (const row of rewards) {
+      assert.equal(row.canonical, row.burn_block_hash === '0xbb01');
+    }
+    const holders = await slotHolderRows();
+    assert.equal(holders.length, 2);
+    for (const row of holders) {
+      assert.equal(row.canonical, row.burn_block_hash === '0xbb01');
+    }
+    assert.equal(await canonicalRewardSum(), 700n);
+    const total1 = await db.getBurnchainRewardsTotal(ADDR_1);
+    assert.equal(total1.reward_amount, 0n);
+    const total2 = await db.getBurnchainRewardsTotal(ADDR_2);
+    assert.equal(total2.reward_amount, 700n);
+
+    assert.equal(await poxTxCount(ADDR_1), 0);
+    assert.equal(await poxTxCount(ADDR_2), 1);
+  });
+
+  test('a zero-reward replacement block orphans the rival block', async () => {
+    await deliverBurnBlock({
+      hash: '0xaa01',
+      height: 100,
+      rewards: [reward({ hash: '0xaa01', height: 100 })],
+      slotHolders: [slotHolder({ hash: '0xaa01', height: 100 })],
+      poxTxs: [poxTx({ hash: '0xaa01', height: 100 })],
+    });
+    // The replacement block paid no rewards (e.g. all commits burned, like a pox-1 through pox-4
+    // prepare-phase block): the node still announces it, with empty recipients and the burned
+    // total in `burn_amount`. This is the only signal that the previous block was orphaned.
+    await deliverBurnBlock({ hash: '0xbb01', height: 100, burnAmount: 40000n });
+
+    const rewards = await rewardRows();
+    assert.equal(rewards.length, 1);
+    assert.equal(rewards[0].canonical, false);
+    assert.equal(await canonicalRewardSum(), 0n);
+    const holders = await slotHolderRows();
+    assert.equal(holders.length, 1);
+    assert.equal(holders[0].canonical, false);
+    assert.equal(await poxTxCount(ADDR_1), 0);
+    // The zero-recipient block still persists its burned amount.
+    const burnBlocks = await burnchainBlockRows();
+    assert.deepEqual([...burnBlocks], [
+      {
+        burn_block_hash: '0xaa01',
+        burn_block_height: 100,
+        burn_amount: '0',
+        reward_amount: '1000',
+        canonical: false,
+      },
+      {
+        burn_block_hash: '0xbb01',
+        burn_block_height: 100,
+        burn_amount: '40000',
+        reward_amount: '0',
+        canonical: true,
+      },
+    ]);
+  });
+
+  test('forking back to a previously orphaned burn block restores it', async () => {
+    const blockA = {
+      hash: '0xaa01',
+      height: 100,
+      rewards: [reward({ hash: '0xaa01', height: 100 })],
+      slotHolders: [slotHolder({ hash: '0xaa01', height: 100, address: ADDR_1 })],
+      poxTxs: [poxTx({ hash: '0xaa01', height: 100 })],
+    };
+    await deliverBurnBlock(blockA);
+    await deliverBurnBlock({
+      hash: '0xbb01',
+      height: 100,
+      rewards: [reward({ hash: '0xbb01', height: 100, recipient: ADDR_2, amount: 700n })],
+      slotHolders: [slotHolder({ hash: '0xbb01', height: 100, address: ADDR_2 })],
+      poxTxs: [poxTx({ hash: '0xbb01', height: 100, recipient: ADDR_2, amount: 700n })],
+    });
+    // The burnchain forks back to the original block; the node re-announces it.
+    await deliverBurnBlock(blockA);
+
+    const rewards = await rewardRows();
+    assert.equal(rewards.length, 2);
+    for (const row of rewards) {
+      assert.equal(row.canonical, row.burn_block_hash === '0xaa01');
+    }
+    assert.equal(await canonicalRewardSum(), 1000n);
+    const holders = await slotHolderRows();
+    assert.equal(holders.length, 2);
+    for (const row of holders) {
+      assert.equal(row.canonical, row.burn_block_hash === '0xaa01');
+    }
+    const burnBlocks = await burnchainBlockRows();
+    assert.equal(burnBlocks.length, 2);
+    for (const row of burnBlocks) {
+      assert.equal(row.canonical, row.burn_block_hash === '0xaa01');
+    }
+    assert.equal(await poxTxCount(ADDR_1), 1);
+    assert.equal(await poxTxCount(ADDR_2), 0);
+  });
+
+  test('a deep burnchain fork is resolved as each replacement block arrives', async () => {
+    for (const [hash, height] of [
+      ['0xaa01', 100],
+      ['0xaa02', 101],
+      ['0xaa03', 102],
+    ] as const) {
+      await deliverBurnBlock({ hash, height, rewards: [reward({ hash, height })] });
+    }
+    assert.equal(await canonicalRewardSum(), 3000n);
+
+    // A 3-block burnchain re-org: the node announces each replacement block individually.
+    await deliverBurnBlock({
+      hash: '0xbb01',
+      height: 100,
+      rewards: [reward({ hash: '0xbb01', height: 100, amount: 100n })],
+    });
+    // Not-yet-replaced heights are only orphaned once their replacement arrives.
+    assert.equal(await canonicalRewardSum(), 2100n);
+    await deliverBurnBlock({
+      hash: '0xbb02',
+      height: 101,
+      rewards: [reward({ hash: '0xbb02', height: 101, amount: 100n })],
+    });
+    await deliverBurnBlock({
+      hash: '0xbb03',
+      height: 102,
+      rewards: [reward({ hash: '0xbb03', height: 102, amount: 100n })],
+    });
+
+    const rewards = await rewardRows();
+    assert.equal(rewards.length, 6);
+    for (const row of rewards) {
+      assert.equal(row.canonical, row.burn_block_hash.startsWith('0xbb'));
+    }
+    assert.equal(await canonicalRewardSum(), 300n);
+  });
+
+  test('re-delivering an old burn block does not orphan newer blocks', async () => {
+    for (const [hash, height] of [
+      ['0xaa01', 100],
+      ['0xaa02', 101],
+      ['0xaa03', 102],
+    ] as const) {
+      await deliverBurnBlock({
+        hash,
+        height,
+        rewards: [reward({ hash, height })],
+        slotHolders: [slotHolder({ hash, height })],
+      });
+    }
+    // The node may re-emit an old burn block outside a full ordered replay. Data at heights above
+    // it must be left alone.
+    await deliverBurnBlock({
+      hash: '0xaa01',
+      height: 100,
+      rewards: [reward({ hash: '0xaa01', height: 100 })],
+      slotHolders: [slotHolder({ hash: '0xaa01', height: 100 })],
+    });
+
+    const rewards = await rewardRows();
+    assert.equal(rewards.length, 3);
+    assert.ok(rewards.every(r => r.canonical));
+    assert.equal(await canonicalRewardSum(), 3000n);
+    const holders = await slotHolderRows();
+    assert.equal(holders.length, 3);
+    assert.ok(holders.every(h => h.canonical));
+  });
+
+  test('stacks-level re-orgs do not affect burnchain rewards or pox transactions', async () => {
+    await deliverBurnBlock({
+      hash: '0xbb02',
+      height: 101,
+      rewards: [reward({ hash: '0xbb02', height: 101 })],
+      poxTxs: [poxTx({ hash: '0xbb02', height: 101 })],
+    });
+    // Tenure 1 (burn block 0xbb01) mines block 1; tenure 2 (burn block 0xbb02) mines block 2.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        block_hash: '0xa1',
+        index_block_hash: '0xa1',
+        parent_index_block_hash: '0x00',
+        burn_block_hash: '0xbb01',
+        burn_block_height: 100,
+        signer_bitvec: '1111',
+      }).build()
+    );
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        block_hash: '0xa2',
+        index_block_hash: '0xa2',
+        parent_index_block_hash: '0xa1',
+        parent_block_hash: '0xa1',
+        burn_block_hash: '0xbb02',
+        burn_block_height: 101,
+        signer_bitvec: '1111',
+      }).build()
+    );
+    // A stacks-level re-org replaces all of tenure 2 with a sibling tenure anchored to a different
+    // burn block. No canonical block anchors to 0xbb02 anymore, but the rewards paid on it are a
+    // burnchain-level fact and must remain canonical.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        block_hash: '0xb2',
+        index_block_hash: '0xb2',
+        parent_index_block_hash: '0xa1',
+        parent_block_hash: '0xa1',
+        burn_block_hash: '0xbb03',
+        burn_block_height: 102,
+        signer_bitvec: '1111',
+      }).build()
+    );
+
+    const blocks = await client<{ index_block_hash: string; canonical: boolean }[]>`
+      SELECT index_block_hash, canonical FROM blocks ORDER BY block_height, index_block_hash
+    `;
+    assert.deepEqual(
+      blocks.map(b => [b.index_block_hash, b.canonical]),
+      [
+        ['0xa1', true],
+        ['0xa2', false],
+        ['0xb2', true],
+      ]
+    );
+
+    const rewards = await rewardRows();
+    assert.equal(rewards.length, 1);
+    assert.equal(rewards[0].canonical, true);
+    assert.equal(await canonicalRewardSum(), 1000n);
+    assert.equal(await poxTxCount(ADDR_1), 1);
+  });
+
+  test('repair migration dedupes rewards and recomputes canonical state', async () => {
+    const repairMigration = '1779800000014_burnchain-canonical-repair';
+    // Recreate the corrupted state left behind by the previous write paths: the unique constraints
+    // did not exist, duplicate rows accumulated from re-delivered events, both sides of burnchain
+    // forks stayed canonical, and stacks-level re-orgs wrongly orphaned rows.
+    await client`ALTER TABLE burnchain_rewards DROP CONSTRAINT burnchain_rewards_unique_idx`;
+    await client`ALTER TABLE reward_slot_holders DROP CONSTRAINT reward_slot_holders_unique_idx`;
+    const seedRewards = [
+      // Height 100: a fork where both hashes are canonical, plus a duplicated delivery of 0xaa01.
+      // 0xbb01 is inserted first (lower ids) so that only its anchoring canonical stacks block --
+      // not insertion order -- can make it win.
+      { hash: '0xbb01', height: 100, index: 0, canonical: true },
+      { hash: '0xaa01', height: 100, index: 0, canonical: true },
+      { hash: '0xaa01', height: 100, index: 0, canonical: true },
+      // Height 101: single hash wrongly orphaned by a stacks-level re-org (undercount damage).
+      { hash: '0xaa02', height: 101, index: 0, canonical: false },
+      { hash: '0xaa02', height: 101, index: 1, canonical: false },
+    ];
+    for (const r of seedRewards) {
+      await client`
+        INSERT INTO burnchain_rewards
+          (canonical, burn_block_hash, burn_block_height, reward_recipient, reward_amount, reward_index)
+        VALUES (${r.canonical}, ${r.hash}, ${r.height}, ${ADDR_1}, 1000, ${r.index})
+      `;
+    }
+    const seedPoxTxs = [
+      { hash: '0xaa01', height: 100, canonical: true, recipient: ADDR_1 },
+      { hash: '0xbb01', height: 100, canonical: true, recipient: ADDR_2 },
+      { hash: '0xaa02', height: 101, canonical: false, recipient: ADDR_1 },
+    ];
+    for (const t of seedPoxTxs) {
+      await client`
+        INSERT INTO burn_block_pox_txs
+          (canonical, burn_block_hash, burn_block_height, tx_id, recipient, utxo_idx, amount)
+        VALUES (${t.canonical}, ${t.hash}, ${t.height}, '0x0001', ${t.recipient}, 0, 1000)
+      `;
+    }
+    // Both fork sides counted: the corruption the reseed must fix.
+    await client`
+      INSERT INTO burn_block_pox_tx_counts (recipient, count) VALUES (${ADDR_1}, 1), (${ADDR_2}, 1)
+    `;
+    const seedSlotHolders = [
+      // Height 100: duplicated delivery of the losing fork side, both sides canonical. 0xbb01 is
+      // inserted first so only its anchoring canonical stacks block can make it win.
+      { hash: '0xbb01', height: 100, index: 0, canonical: true },
+      { hash: '0xaa01', height: 100, index: 0, canonical: true },
+      { hash: '0xaa01', height: 100, index: 0, canonical: true },
+      // Height 101: wrongly orphaned by the legacy `>= height` invalidation (undercount damage).
+      { hash: '0xaa02', height: 101, index: 0, canonical: false },
+    ];
+    for (const s of seedSlotHolders) {
+      await client`
+        INSERT INTO reward_slot_holders (canonical, burn_block_hash, burn_block_height, address, slot_index)
+        VALUES (${s.canonical}, ${s.hash}, ${s.height}, ${ADDR_1}, ${s.index})
+      `;
+    }
+    // A canonical stacks block anchors to 0xbb01, proving it canonical at height 100 despite the
+    // 0xaa01 rows being inserted later.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        block_hash: '0xa1',
+        index_block_hash: '0xa1',
+        parent_index_block_hash: '0x00',
+        burn_block_hash: '0xbb01',
+        burn_block_height: 100,
+      }).build()
+    );
+
+    // Re-run only the repair migration.
+    await client`DELETE FROM pgmigrations WHERE name = ${repairMigration}`;
+    await runMigrations(MIGRATIONS_DIR, 'up', getConnectionArgs());
+
+    const rewards = await rewardRows();
+    assert.deepEqual(
+      rewards.map(r => [r.burn_block_hash, r.burn_block_height, r.reward_index, r.canonical]),
+      [
+        ['0xaa01', 100, 0, false],
+        ['0xbb01', 100, 0, true],
+        ['0xaa02', 101, 0, true],
+        ['0xaa02', 101, 1, true],
+      ]
+    );
+    const poxTxs = await client<{ burn_block_hash: string; canonical: boolean }[]>`
+      SELECT burn_block_hash, canonical FROM burn_block_pox_txs
+      ORDER BY burn_block_height, burn_block_hash
+    `;
+    assert.deepEqual(
+      poxTxs.map(t => [t.burn_block_hash, t.canonical]),
+      [
+        ['0xaa01', false],
+        ['0xbb01', true],
+        ['0xaa02', true],
+      ]
+    );
+    assert.equal(await poxTxCount(ADDR_1), 1);
+    assert.equal(await poxTxCount(ADDR_2), 1);
+
+    const holders = await slotHolderRows();
+    assert.deepEqual(
+      holders.map(h => [h.burn_block_hash, h.burn_block_height, h.slot_index, h.canonical]),
+      [
+        ['0xaa01', 100, 0, false],
+        ['0xbb01', 100, 0, true],
+        ['0xaa02', 101, 0, true],
+      ]
+    );
+  });
+
+  test('burnchain blocks migration backfills burn amounts from raw events', async () => {
+    const burnBlocksMigration = '1779800000015_burn-blocks';
+    // Raw `/new_burn_block` payloads: a fork at height 100 (0xbb01 received last wins by arrival
+    // order), a re-delivered duplicate of 0xbb01 (latest payload per hash wins), and a
+    // zero-recipient prepare-phase-style block at 101 whose burn amount only exists here.
+    const rawEvents = [
+      { hash: '0xaa01', height: 100, burn: 1000, recipients: [] as { recipient: string; amt: number }[] },
+      { hash: '0xbb01', height: 100, burn: 2000, recipients: [
+        { recipient: ADDR_1, amt: 500 },
+        { recipient: ADDR_2, amt: 700 },
+      ] },
+      { hash: '0xbb01', height: 100, burn: 2000, recipients: [
+        { recipient: ADDR_1, amt: 500 },
+        { recipient: ADDR_2, amt: 700 },
+      ] },
+      { hash: '0xcc01', height: 101, burn: 30000, recipients: [] },
+    ];
+    for (const e of rawEvents) {
+      const payload = {
+        burn_block_hash: e.hash,
+        burn_block_height: e.height,
+        burn_amount: e.burn,
+        reward_recipients: e.recipients,
+        reward_slot_holders: [],
+      };
+      await client`
+        INSERT INTO event_observer_requests (event_path, payload)
+        VALUES ('/new_burn_block', ${payload})
+      `;
+    }
+    // A block at height 102 missing from raw events but present in burnchain_rewards: the
+    // gap-fill path must pick it up from there. Restore the legacy `burn_amount` column the
+    // migration's gap-fill reads (and then drops again) to recreate pre-migration state.
+    await client`ALTER TABLE burnchain_rewards ADD COLUMN burn_amount numeric NOT NULL DEFAULT 0`;
+    await deliverBurnBlock({
+      hash: '0xdd01',
+      height: 102,
+      rewards: [reward({ hash: '0xdd01', height: 102 })],
+    });
+    await client`UPDATE burnchain_rewards SET burn_amount = 2000 WHERE burn_block_hash = ${'0xdd01'}`;
+    // Re-run only the burn_blocks migration (the delivery above also wrote to the live
+    // table; drop it so the migration recreates and backfills from scratch).
+    await client`DROP TABLE burn_blocks`;
+    await client`DELETE FROM pgmigrations WHERE name = ${burnBlocksMigration}`;
+    await runMigrations(MIGRATIONS_DIR, 'up', getConnectionArgs());
+
+    const burnBlocks = await burnchainBlockRows();
+    assert.deepEqual(
+      burnBlocks.map(b => [
+        b.burn_block_hash,
+        b.burn_block_height,
+        b.burn_amount,
+        b.reward_amount,
+        b.canonical,
+      ]),
+      [
+        ['0xaa01', 100, '1000', '0', false],
+        ['0xbb01', 100, '2000', '1200', true],
+        ['0xcc01', 101, '30000', '0', true],
+        ['0xdd01', 102, '2000', '1000', true],
+      ]
+    );
+  });
+});

--- a/tests/api/burnchain/burnchain-reorg.test.ts
+++ b/tests/api/burnchain/burnchain-reorg.test.ts
@@ -2,15 +2,19 @@ import { DbBurnBlockPoxTx, DbBurnchainReward, DbRewardSlotHolder } from '../../.
 import { PgWriteStore } from '../../../src/datastore/pg-write-store.ts';
 import { MIGRATIONS_DIR } from '../../../src/datastore/pg-store.ts';
 import { getConnectionArgs } from '../../../src/datastore/connection.ts';
+import { EventStreamServer, startEventServer } from '../../../src/event-stream/event-server.ts';
+import { httpPostRequest } from '../../../src/helpers.ts';
 import { PgSqlClient, runMigrations } from '@stacks/api-toolkit';
 import { TestBlockBuilder } from '../test-builders.ts';
 import { migrate } from '../../test-helpers.ts';
 import { beforeEach, afterEach, describe, test } from 'node:test';
 import assert from 'node:assert/strict';
+import { STACKS_MAINNET } from '@stacks/network';
 
 describe('burnchain re-org handling', () => {
   let db: PgWriteStore;
   let client: PgSqlClient;
+  let eventServer: EventStreamServer;
 
   const ADDR_1 = '1G4ayBXJvxZMoZpaNdZG6VyWwWq2mHpMjQ';
   const ADDR_2 = '1DDUAqoyXvhF4cxznN9uL6j9ok1oncsT2z';
@@ -66,7 +70,10 @@ describe('burnchain re-org handling', () => {
     };
   }
 
-  /** Ingests one `/new_burn_block` event the way the event server does. */
+  /**
+   * Builds a simulated `/new_burn_block` JSON payload and POSTs it to the event server, exercising
+   * the real ingestion path.
+   */
   async function deliverBurnBlock(args: {
     hash: string;
     height: number;
@@ -75,28 +82,36 @@ describe('burnchain re-org handling', () => {
     slotHolders?: DbRewardSlotHolder[];
     poxTxs?: DbBurnBlockPoxTx[];
   }) {
-    await db.sqlWriteTransaction(async () => {
-      await db.updateBurnchainBlock({
-        burnchainBlockHash: args.hash,
-        burnchainBlockHeight: args.height,
-        burnAmount: args.burnAmount ?? 0n,
-        rewardAmount: (args.rewards ?? []).reduce((total, r) => total + r.reward_amount, 0n),
-      });
-      await db.updateBurnchainRewards({
-        burnchainBlockHash: args.hash,
-        burnchainBlockHeight: args.height,
-        rewards: args.rewards ?? [],
-      });
-      await db.updateBurnchainRewardSlotHolders({
-        burnchainBlockHash: args.hash,
-        burnchainBlockHeight: args.height,
-        slotHolders: args.slotHolders ?? [],
-      });
-      await db.updateBurnBlockPoxTxs({
-        burnchainBlockHash: args.hash,
-        burnchainBlockHeight: args.height,
-        burnBlockPoxTxs: args.poxTxs ?? [],
-      });
+    const poxTxsByTxid = new Map<string, DbBurnBlockPoxTx[]>();
+    for (const tx of args.poxTxs ?? []) {
+      poxTxsByTxid.set(tx.tx_id, [...(poxTxsByTxid.get(tx.tx_id) ?? []), tx]);
+    }
+    const payload = {
+      burn_block_hash: args.hash,
+      burn_block_height: args.height,
+      burn_amount: Number(args.burnAmount ?? 0n),
+      reward_recipients: [...(args.rewards ?? [])]
+        .sort((a, b) => a.reward_index - b.reward_index)
+        .map(r => ({ recipient: r.reward_recipient, amt: Number(r.reward_amount) })),
+      reward_slot_holders: [...(args.slotHolders ?? [])]
+        .sort((a, b) => a.slot_index - b.slot_index)
+        .map(s => s.address),
+      pox_transactions: [...poxTxsByTxid.entries()].map(([txid, txs]) => ({
+        txid,
+        reward_recipients: txs.map(t => ({
+          recipient: t.recipient,
+          amt: Number(t.amount),
+          utxo_idx: t.utxo_idx,
+        })),
+      })),
+    };
+    await httpPostRequest({
+      host: '127.0.0.1',
+      port: eventServer.serverAddress.port,
+      path: '/new_burn_block',
+      headers: { 'Content-Type': 'application/json' },
+      body: Buffer.from(JSON.stringify(payload), 'utf8'),
+      throwOnNotOK: true,
     });
   }
 
@@ -159,9 +174,16 @@ describe('burnchain re-org handling', () => {
       skipMigrations: true,
     });
     client = db.sql;
+    eventServer = await startEventServer({
+      datastore: db,
+      chainId: STACKS_MAINNET.chainId,
+      serverHost: '127.0.0.1',
+      serverPort: 0,
+    });
   });
 
   afterEach(async () => {
+    await eventServer.closeAsync();
     await db?.close();
     await migrate('down');
   });
@@ -609,7 +631,8 @@ describe('burnchain re-org handling', () => {
     }
     // A block at height 102 missing from raw events but present in burnchain_rewards: the
     // gap-fill path must pick it up from there. Restore the legacy `burn_amount` column the
-    // migration's gap-fill reads (and then drops again) to recreate pre-migration state.
+    // migration's gap-fill reads (and then drops again) to recreate pre-migration state, and prune
+    // the raw event the ingestion stored so the block only exists in burnchain_rewards.
     await client`ALTER TABLE burnchain_rewards ADD COLUMN burn_amount numeric NOT NULL DEFAULT 0`;
     await deliverBurnBlock({
       hash: '0xdd01',
@@ -617,6 +640,10 @@ describe('burnchain re-org handling', () => {
       rewards: [reward({ hash: '0xdd01', height: 102 })],
     });
     await client`UPDATE burnchain_rewards SET burn_amount = 2000 WHERE burn_block_hash = ${'0xdd01'}`;
+    await client`
+      DELETE FROM event_observer_requests
+      WHERE event_path = '/new_burn_block' AND payload->>'burn_block_hash' = '0xdd01'
+    `;
     // A burnchain fork at height 103 present only in burnchain_rewards (no raw events): the
     // gap-fill must stay consistent with the repaired rewards table, where 0xee02 won.
     for (const f of [

--- a/tests/api/burnchain/burnchain-reorg.test.ts
+++ b/tests/api/burnchain/burnchain-reorg.test.ts
@@ -700,6 +700,34 @@ describe('burnchain re-org handling', () => {
         (canonical, burn_block_hash, burn_block_height, burn_amount, reward_recipient, reward_amount, reward_index)
       VALUES (true, ${'0xff01'}, 104, 100, ${ADDR_1}, 800, 0)
     `;
+    // Height 105: a partially pruned raw archive kept only the losing fork side's (0xaa05) raw
+    // event, while the true winner 0xbb05 exists only in burnchain_rewards -- but a canonical
+    // stacks block anchors 0xbb05, which must override the surviving raw event.
+    await client`
+      INSERT INTO event_observer_requests (event_path, payload)
+      VALUES ('/new_burn_block', ${{
+        burn_block_hash: '0xaa05',
+        burn_block_height: 105,
+        burn_amount: 700,
+        reward_recipients: [],
+        reward_slot_holders: [],
+      }})
+    `;
+    await client`
+      INSERT INTO burnchain_rewards
+        (canonical, burn_block_hash, burn_block_height, burn_amount, reward_recipient, reward_amount, reward_index)
+      VALUES (true, ${'0xbb05'}, 105, 800, ${ADDR_1}, 1000, 0)
+    `;
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        block_hash: '0xa1',
+        index_block_hash: '0xa1',
+        parent_index_block_hash: '0x00',
+        burn_block_hash: '0xbb05',
+        burn_block_height: 105,
+      }).build()
+    );
     // Re-run only the burn_blocks migration (the delivery above also wrote to the live
     // table; drop it so the migration recreates and backfills from scratch).
     await client`DROP TABLE burn_blocks`;
@@ -724,6 +752,8 @@ describe('burnchain re-org handling', () => {
         ['0xee02', 103, '600', '1000', true],
         ['0xff01', 104, '100', '800', false],
         ['0xff02', 104, '900', '0', true],
+        ['0xaa05', 105, '700', '0', false],
+        ['0xbb05', 105, '800', '1000', true],
       ]
     );
     // The 0xff01 rewards the legacy tables held canonical are orphaned by the propagation pass.
@@ -735,6 +765,7 @@ describe('burnchain re-org handling', () => {
         ['0xee01', 103, false],
         ['0xee02', 103, true],
         ['0xff01', 104, false],
+        ['0xbb05', 105, true],
       ]
     );
   });

--- a/tests/api/burnchain/burnchain-reorg.test.ts
+++ b/tests/api/burnchain/burnchain-reorg.test.ts
@@ -519,6 +519,11 @@ describe('burnchain re-org handling', () => {
       { hash: '0xaa01', height: 100, canonical: true, recipient: ADDR_1 },
       { hash: '0xbb01', height: 100, canonical: true, recipient: ADDR_2 },
       { hash: '0xaa02', height: 101, canonical: false, recipient: ADDR_1 },
+      // Height 102: a fork with no blocks anchor and no reward rows. The winner must come from the
+      // slot holders' arrival order (0xdd01, seeded below), not this table's lexicographic
+      // tie-break (which would pick 0xdd09).
+      { hash: '0xdd09', height: 102, canonical: true, recipient: ADDR_2 },
+      { hash: '0xdd01', height: 102, canonical: true, recipient: ADDR_1 },
     ];
     for (const t of seedPoxTxs) {
       await client`
@@ -539,6 +544,10 @@ describe('burnchain re-org handling', () => {
       { hash: '0xaa01', height: 100, index: 0, canonical: true },
       // Height 101: wrongly orphaned by the legacy `>= height` invalidation (undercount damage).
       { hash: '0xaa02', height: 101, index: 0, canonical: false },
+      // Height 102: fork sides in arrival order -- 0xdd01 arrives last and must win here and in
+      // burn_block_pox_txs.
+      { hash: '0xdd09', height: 102, index: 0, canonical: true },
+      { hash: '0xdd01', height: 102, index: 0, canonical: true },
     ];
     for (const s of seedSlotHolders) {
       await client`
@@ -583,9 +592,11 @@ describe('burnchain re-org handling', () => {
         ['0xaa01', false],
         ['0xbb01', true],
         ['0xaa02', true],
+        ['0xdd01', true],
+        ['0xdd09', false],
       ]
     );
-    assert.equal(await poxTxCount(ADDR_1), 1);
+    assert.equal(await poxTxCount(ADDR_1), 2);
     assert.equal(await poxTxCount(ADDR_2), 1);
 
     const holders = await slotHolderRows();
@@ -595,6 +606,8 @@ describe('burnchain re-org handling', () => {
         ['0xaa01', 100, 0, false],
         ['0xbb01', 100, 0, true],
         ['0xaa02', 101, 0, true],
+        ['0xdd01', 102, 0, true],
+        ['0xdd09', 102, 0, false],
       ]
     );
   });

--- a/tests/api/burnchain/burnchain.test.ts
+++ b/tests/api/burnchain/burnchain.test.ts
@@ -175,7 +175,6 @@ describe('burnchain tests', () => {
       canonical: true,
       burn_block_hash: '0x1234',
       burn_block_height: 200,
-      burn_amount: 2000n,
       reward_recipient: addr1,
       reward_amount: 900n,
       reward_index: 0,
@@ -184,7 +183,6 @@ describe('burnchain tests', () => {
       canonical: true,
       burn_block_hash: '0x1234',
       burn_block_height: 200,
-      burn_amount: 2001n,
       reward_recipient: addr1,
       reward_amount: 901n,
       reward_index: 1,
@@ -193,7 +191,6 @@ describe('burnchain tests', () => {
       canonical: true,
       burn_block_hash: '0x2345',
       burn_block_height: 201,
-      burn_amount: 3001n,
       reward_recipient: addr2,
       reward_amount: 902n,
       reward_index: 0,
@@ -207,10 +204,21 @@ describe('burnchain tests', () => {
       reward_index: 2,
     };
     await db.updateBurnchainRewards({
+      burnchainBlockHash: '0x1234',
+      burnchainBlockHeight: 200,
       rewards: [reward1, reward2],
     });
     await db.updateBurnchainRewards({
+      burnchainBlockHash: '0x2345',
+      burnchainBlockHeight: 201,
       rewards: [reward3, reward4, reward5],
+    });
+    // `burn_amount` in responses is block-level, joined from `burn_blocks`.
+    await db.updateBurnchainBlock({
+      burnchainBlockHash: '0x2345',
+      burnchainBlockHeight: 201,
+      burnAmount: 3001n,
+      rewardAmount: 2706n,
     });
 
     const rewardResult = await supertest(api.server).get(
@@ -260,7 +268,6 @@ describe('burnchain tests', () => {
       canonical: true,
       burn_block_hash: '0x1234',
       burn_block_height: 200,
-      burn_amount: 2000n,
       reward_recipient: addr,
       reward_amount: 1000n,
       reward_index: 0,
@@ -269,7 +276,6 @@ describe('burnchain tests', () => {
       canonical: true,
       burn_block_hash: '0x2234',
       burn_block_height: 201,
-      burn_amount: 2000n,
       reward_recipient: addr,
       reward_amount: 1001n,
       reward_index: 0,
@@ -278,18 +284,29 @@ describe('burnchain tests', () => {
       canonical: true,
       burn_block_hash: '0x3234',
       burn_block_height: 202,
-      burn_amount: 2000n,
       reward_recipient: addr,
       reward_amount: 1002n,
       reward_index: 0,
     };
+    await db.updateBurnchainBlock({
+      burnchainBlockHash: '0x1234',
+      burnchainBlockHeight: 200,
+      burnAmount: 2000n,
+      rewardAmount: 900n,
+    });
     await db.updateBurnchainRewards({
+      burnchainBlockHash: '0x1234',
+      burnchainBlockHeight: 200,
       rewards: [reward1],
     });
     await db.updateBurnchainRewards({
+      burnchainBlockHash: '0x2234',
+      burnchainBlockHeight: 201,
       rewards: [reward2],
     });
     await db.updateBurnchainRewards({
+      burnchainBlockHash: '0x3234',
+      burnchainBlockHeight: 202,
       rewards: [reward3],
     });
     const rewardResult = await supertest(api.server).get(
@@ -310,12 +327,19 @@ describe('burnchain tests', () => {
       canonical: true,
       burn_block_hash: '0x1234',
       burn_block_height: 200,
-      burn_amount: 2000n,
       reward_recipient: addr1,
       reward_amount: 900n,
       reward_index: 0,
     };
+    await db.updateBurnchainBlock({
+      burnchainBlockHash: '0x1234',
+      burnchainBlockHeight: 200,
+      burnAmount: 2000n,
+      rewardAmount: 900n,
+    });
     await db.updateBurnchainRewards({
+      burnchainBlockHash: '0x1234',
+      burnchainBlockHeight: 200,
       rewards: [reward1],
     });
     const rewardResult = await supertest(api.server).get(`/extended/v1/burnchain/rewards/${addr1}`);
@@ -348,12 +372,19 @@ describe('burnchain tests', () => {
       canonical: true,
       burn_block_hash: '0x1234',
       burn_block_height: 200,
-      burn_amount: 2000n,
       reward_recipient: mainnetBtcAddr,
       reward_amount: 900n,
       reward_index: 0,
     };
+    await db.updateBurnchainBlock({
+      burnchainBlockHash: '0x1234',
+      burnchainBlockHeight: 200,
+      burnAmount: 2000n,
+      rewardAmount: 900n,
+    });
     await db.updateBurnchainRewards({
+      burnchainBlockHash: '0x1234',
+      burnchainBlockHeight: 200,
       rewards: [reward1],
     });
     const rewardResult = await supertest(api.server).get(
@@ -388,12 +419,19 @@ describe('burnchain tests', () => {
       canonical: true,
       burn_block_hash: '0x1234',
       burn_block_height: 200,
-      burn_amount: 2000n,
       reward_recipient: testnetBtcAddr,
       reward_amount: 900n,
       reward_index: 0,
     };
+    await db.updateBurnchainBlock({
+      burnchainBlockHash: '0x1234',
+      burnchainBlockHeight: 200,
+      burnAmount: 2000n,
+      rewardAmount: 900n,
+    });
     await db.updateBurnchainRewards({
+      burnchainBlockHash: '0x1234',
+      burnchainBlockHeight: 200,
       rewards: [reward1],
     });
     const rewardResult = await supertest(api.server).get(
@@ -428,12 +466,19 @@ describe('burnchain tests', () => {
       canonical: true,
       burn_block_hash: '0x1234',
       burn_block_height: 200,
-      burn_amount: 2000n,
       reward_recipient: testnetBtcAddr,
       reward_amount: 900n,
       reward_index: 0,
     };
+    await db.updateBurnchainBlock({
+      burnchainBlockHash: '0x1234',
+      burnchainBlockHeight: 200,
+      burnAmount: 2000n,
+      rewardAmount: 900n,
+    });
     await db.updateBurnchainRewards({
+      burnchainBlockHash: '0x1234',
+      burnchainBlockHeight: 200,
       rewards: [reward1],
     });
     const rewardResult = await supertest(api.server).get(
@@ -489,9 +534,14 @@ describe('burnchain tests', () => {
         });
       }
 
-      await db.updateBurnBlockPoxTxs({
-        burnBlockPoxTxs: poxTransactions,
-      });
+      // Deliver per burn block, matching how `/new_burn_block` events arrive.
+      for (const burnBlock of burnBlocks) {
+        await db.updateBurnBlockPoxTxs({
+          burnchainBlockHash: burnBlock.hash,
+          burnchainBlockHeight: burnBlock.height,
+          burnBlockPoxTxs: poxTransactions.filter(tx => tx.burn_block_hash === burnBlock.hash),
+        });
+      }
 
       // Fetch for first block by hash with a limit
       let result = await supertest(api.server).get(

--- a/tests/api/datastore/datastore.test.ts
+++ b/tests/api/datastore/datastore.test.ts
@@ -3107,7 +3107,6 @@ describe('postgres datastore', () => {
       canonical: true,
       burn_block_hash: '0x1234',
       burn_block_height: 200,
-      burn_amount: 2000n,
       reward_recipient: addr1,
       reward_amount: 900n,
       reward_index: 0,
@@ -3116,7 +3115,6 @@ describe('postgres datastore', () => {
       canonical: true,
       burn_block_hash: '0x1234',
       burn_block_height: 200,
-      burn_amount: 2001n,
       reward_recipient: addr1,
       reward_amount: 901n,
       reward_index: 1,
@@ -3125,15 +3123,30 @@ describe('postgres datastore', () => {
       canonical: true,
       burn_block_hash: '0x2345',
       burn_block_height: 201,
-      burn_amount: 3001n,
       reward_recipient: addr1,
       reward_amount: 902n,
       reward_index: 0,
     };
-    await db.updateBurnchainRewards({
-      rewards: [reward1, reward2],
+    await db.updateBurnchainBlock({
+      burnchainBlockHash: '0x1234',
+      burnchainBlockHeight: 200,
+      burnAmount: 2000n,
+      rewardAmount: 1801n,
     });
     await db.updateBurnchainRewards({
+      burnchainBlockHash: '0x1234',
+      burnchainBlockHeight: 200,
+      rewards: [reward1, reward2],
+    });
+    await db.updateBurnchainBlock({
+      burnchainBlockHash: '0x2345',
+      burnchainBlockHeight: 201,
+      burnAmount: 3001n,
+      rewardAmount: 902n,
+    });
+    await db.updateBurnchainRewards({
+      burnchainBlockHash: '0x2345',
+      burnchainBlockHeight: 201,
       rewards: [reward3],
     });
     const rewardQuery = await db.getBurnchainRewards({
@@ -3141,6 +3154,7 @@ describe('postgres datastore', () => {
       limit: 100,
       offset: 0,
     });
+    // `burn_amount` is block-level, joined from `burn_blocks`.
     assert.deepEqual(rewardQuery, [
       {
         canonical: true,
@@ -3155,7 +3169,7 @@ describe('postgres datastore', () => {
         canonical: true,
         burn_block_hash: '0x1234',
         burn_block_height: 200,
-        burn_amount: 2001n,
+        burn_amount: 2000n,
         reward_recipient: addr1,
         reward_amount: 901n,
         reward_index: 1,
@@ -3188,12 +3202,13 @@ describe('postgres datastore', () => {
     }) => {
       // Add some rewards
       await db.updateBurnchainRewards({
+        burnchainBlockHash: args.burn_block_hash,
+        burnchainBlockHeight: args.burn_block_height,
         rewards: [
           {
             canonical: true,
             burn_block_hash: args.burn_block_hash,
             burn_block_height: args.burn_block_height,
-            burn_amount: 2000n,
             reward_recipient: addr1,
             reward_amount: 900n,
             reward_index: 0,
@@ -3202,7 +3217,6 @@ describe('postgres datastore', () => {
             canonical: true,
             burn_block_hash: args.burn_block_hash,
             burn_block_height: args.burn_block_height,
-            burn_amount: 2001n,
             reward_recipient: addr2,
             reward_amount: 901n,
             reward_index: 1,

--- a/tests/api/datastore/nakamoto-reorg.test.ts
+++ b/tests/api/datastore/nakamoto-reorg.test.ts
@@ -212,12 +212,13 @@ describe('nakamoto re-org handling', () => {
     // All blocks share the same burn block (one Nakamoto tenure).
     const burnBlockHash = '0xbb01';
     await db.updateBurnchainRewards({
+      burnchainBlockHash: burnBlockHash,
+      burnchainBlockHeight: 200,
       rewards: [
         {
           canonical: true,
           burn_block_hash: burnBlockHash,
           burn_block_height: 200,
-          burn_amount: 2000n,
           reward_recipient: '1G4ayBXJvxZMoZpaNdZG6VyWwWq2mHpMjQ',
           reward_amount: 900n,
           reward_index: 0,
@@ -230,22 +231,22 @@ describe('nakamoto re-org handling', () => {
     // Sibling switch at height 3 within the same tenure.
     await db.update(nakamotoBlock({ height: 3, hash: '0xb3', parent: '0xa2', burnBlockHash }).build());
 
-    // The stacks-level re-org must not orphan the burn block's rewards: the burn block itself is
-    // still canonical (blocks 1, 2 and 3' anchor to it).
+    // The stacks-level re-org must not orphan the burn block's rewards.
     const rewards = await db.getBurnchainRewards({ limit: 10, offset: 0 });
     assert.equal(rewards.length, 1);
     assert.equal(rewards[0].burn_block_hash, burnBlockHash);
     assert.equal(rewards[0].canonical, true);
   });
 
-  test('orphans burnchain entities when a full tenure is orphaned', async () => {
+  test('keeps burnchain entities canonical when a full tenure is orphaned', async () => {
     await db.updateBurnchainRewards({
+      burnchainBlockHash: '0xbb02',
+      burnchainBlockHeight: 201,
       rewards: [
         {
           canonical: true,
           burn_block_hash: '0xbb02',
           burn_block_height: 201,
-          burn_amount: 2000n,
           reward_recipient: '1G4ayBXJvxZMoZpaNdZG6VyWwWq2mHpMjQ',
           reward_amount: 900n,
           reward_index: 0,
@@ -266,14 +267,25 @@ describe('nakamoto re-org handling', () => {
       nakamotoBlock({ height: 4, hash: '0xa4', parent: '0xa3', burnBlockHash: '0xbb02' }).build()
     );
 
-    // A re-org (e.g. after a burnchain fork) replaces all of tenure 2 with a new tenure built on
-    // burn block 0xbb03. No canonical block anchors to 0xbb02 anymore, so its rewards must be
-    // orphaned along with the blocks.
+    // A stacks-level re-org replaces all of tenure 2 with a new tenure. The rewards paid on burn
+    // block 0xbb02 are a burnchain-level fact and must remain canonical: only a `/new_burn_block`
+    // event for a different hash at the same burn height (an actual burnchain fork) orphans them.
     await db.update(
-      nakamotoBlock({ height: 3, hash: '0xb3', parent: '0xa2', burnBlockHash: '0xbb03' }).build()
+      nakamotoBlock({ height: 3, hash: '0xb3', parent: '0xa2', burnBlockHash: '0xbb02' }).build()
     );
 
-    const rewards = await db.getBurnchainRewards({ limit: 10, offset: 0 });
+    let rewards = await db.getBurnchainRewards({ limit: 10, offset: 0 });
+    assert.equal(rewards.length, 1);
+    assert.equal(rewards[0].burn_block_hash, '0xbb02');
+    assert.equal(rewards[0].canonical, true);
+
+    // The burnchain forks at height 201: the replacement burn block's event orphans the rewards.
+    await db.updateBurnchainRewards({
+      burnchainBlockHash: '0xbb03',
+      burnchainBlockHeight: 201,
+      rewards: [],
+    });
+    rewards = await db.getBurnchainRewards({ limit: 10, offset: 0 });
     assert.equal(rewards.length, 0);
   });
 


### PR DESCRIPTION
Fixes all known canonical-state corruption in the burnchain (BTC) reward tables, and persists per-burn-block burn/reward totals that were previously discarded in a new `burn_blocks` table.

### Fixed re-org scenarios

1. **Nakamoto-era undercount bug**: out-of-order burn block re-deliveries orphaning rewards.
1. **Duplicate rows**: re-delivered `/new_burn_block` events (node restarts, retries after mid-handler failures) inserted duplicate canonical rows.
1. **Orphaned burnchain forks never invalidated**: rewards paid on orphaned bitcoin blocks stayed canonical forever when no Stacks block anchored to them (e.g. empty sortitions).
1. **Stacks-level reorgs flipping bitcoin-level facts**: orphaning a full tenure marked its burn block's rewards non-canonical, even though the BTC was genuinely paid.

### Migration backfill

A DB migration was introduced to re-compute total burned BTC from the original Stacks core events stored in the `event_observer_requests` table.
