### PR TITLE
chore: remove dead replay mode, env vars, exports and test-only datastore code; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Fastify-based REST API with real-time WebSocket and Socket.IO support for the 
 
 - [Features](#features)
 - [Quick Start](#quick-start)
-- [API Endpoints](#api-endpoints)
+- [API Reference](#api-reference)
 - [Run Modes](#run-modes)
 - [Configuration](#configuration)
 - [Development](#development)
@@ -23,8 +23,7 @@ A Fastify-based REST API with real-time WebSocket and Socket.IO support for the 
 
 ## Features
 
-- **Nakamoto support** — full support for Nakamoto blocks, tenures, signer signatures, and `NakamotoCoinbase` / `TenureChange` transaction types
-- **Comprehensive REST API** — v1 and v2 endpoints covering blocks, transactions, accounts, smart contracts, NFTs, fungible tokens, BNS (Bitcoin Name System), PoX / stacking, burn chain rewards, and more
+- **Comprehensive REST API** — versioned endpoints covering blocks, transactions, principals, smart contracts, fungible and non-fungible tokens, staking / PoX, and burn chain data (see [API Reference](#api-reference)).
 - **Real-time streaming** — subscribe to blocks, mempool transactions, address activity, STX balance changes, and NFT events via WebSocket (JSON-RPC) or Socket.IO
 - **Client library** — type-safe TypeScript/JS client for REST and real-time APIs ([`@stacks/blockchain-api-client`](client/README.md))
 - **OpenAPI specification** — auto-generated from route definitions; powers Redoc documentation, Postman collections, and the TypeScript client
@@ -32,8 +31,7 @@ A Fastify-based REST API with real-time WebSocket and Socket.IO support for the 
 - **Multiple run modes** — default (read-write), read-only, and write-only modes for flexible scaling
 - **Prometheus metrics** — built-in `/metrics` endpoint for monitoring
 - **SNP integration** — Stacks Nakamoto Protocol event streaming via Redis
-- **BNS** — full Bitcoin Name System support including name lookups, namespaces, subdomains, zonefiles, and pricing
-- **BTC & STX faucets** — testnet/regtest faucet endpoints for development
+- **Faucets** — STX, BTC and sBTC testnet/regtest faucet endpoints for development
 
 ## Quick Start
 
@@ -57,51 +55,10 @@ docker pull hirosystems/stacks-blockchain-api
 
 The API cannot run standalone — it requires a running Stacks node and a PostgreSQL database. See [Deployment](#deployment) for details, or refer to the [Stacks node operator guide](https://docs.stacks.co/operate).
 
-## API Endpoints
+## API Reference
 
-### Extended API v2
+The full endpoint reference, with request and response schemas for every route, is published at [docs.hiro.so/en/apis/stacks-blockchain-api](https://docs.hiro.so/en/apis/stacks-blockchain-api). It is generated from the OpenAPI specification in this repository ([`openapi.yaml`](openapi.yaml)), which is itself generated from the Fastify route definitions at release time.
 
-The recommended versioned endpoints:
-
-| Group | Prefix | Key Endpoints |
-|-------|--------|---------------|
-| **Blocks** | `/extended/v2/blocks` | List blocks, get by height/hash, list transactions, signer signatures, average block times |
-| **Burn Blocks** | `/extended/v2/burn-blocks` | List burn blocks, get by height/hash, list Stacks blocks per burn block, PoX transactions |
-| **Block Tenures** | `/extended/v2/block-tenures` | List blocks for a given tenure height |
-| **Addresses** | `/extended/v2/addresses` | Transactions for address, transaction events, STX balance, FT balances, PoX transactions by BTC address |
-| **PoX** | `/extended/v2/pox` | PoX cycles, signers per cycle, stackers per signer |
-| **Smart Contracts** | `/extended/v2/smart-contracts` | Contract deployment status |
-| **Mempool** | `/extended/v2/mempool` | Mempool fee priorities |
-
-### Extended API v1
-
-| Group | Prefix | Key Endpoints |
-|-------|--------|---------------|
-| **Transactions** | `/extended/v1/tx` | Recent, by ID, raw, by block hash/height, mempool, mempool stats, events |
-| **Blocks** | `/extended/v1/block` | List, by height, by hash, by burn block height/hash |
-| **Accounts** | `/extended/v1/address` | STX balance, all balances, transactions, assets, inbound transfers, nonces, mempool |
-| **Tokens** | `/extended/v1/tokens` | NFT holdings, NFT history, NFT mints, FT holders |
-| **Smart Contracts** | `/extended/v1/contract` | By trait, by ID, contract events |
-| **Search** | `/extended/v1/search` | Universal search (blocks, transactions, contracts, addresses) |
-| **PoX** | `/extended/v1/pox2`, `pox3`, `pox4` | PoX events, stacker info, delegations |
-| **STX Supply** | `/extended/v1/stx_supply` | Total, circulating, legacy format |
-| **Burn Chain** | `/extended/v1/burnchain` | Reward slot holders, rewards, total rewards |
-| **Fee Rate** | `/extended/v1/fee_rate` | Fee rate estimation |
-| **Info** | `/extended/v1/info` | Network block times |
-| **Faucets** | `/extended/v1/faucets` | BTC and STX testnet faucets |
-
-### BNS (Bitcoin Name System)
-
-| Prefix | Endpoints |
-|--------|-----------|
-| `/v1/names` | List names, get name details, zonefiles, subdomains |
-| `/v1/namespaces` | List namespaces, names in a namespace |
-| `/v1/addresses` | Resolve blockchain address to names |
-| `/v2/prices` | Namespace and name pricing |
-
-### Stacks Node RPC Proxy
-
-All requests to `/v2/*` (e.g. `/v2/info`, `/v2/fees/transaction`) are proxied to the connected Stacks core node.
 
 ## Run Modes
 
@@ -155,7 +112,7 @@ Configuration is done via environment variables. A `.env` file in the project ro
 |----------|-------------|---------|
 | `PG_CONNECTION_URI` | Full connection URI (overrides individual vars) | — |
 | `PG_HOST` | Database host | — |
-| `PG_PORT` | Database port | `5432` |
+| `PG_PORT` | Database port | `5490` |
 | `PG_USER` | Database user | — |
 | `PG_PASSWORD` | Database password | — |
 | `PG_DATABASE` | Database name | — |
@@ -201,14 +158,14 @@ A `PG_PRIMARY_*` prefix is available for all PostgreSQL variables to configure a
 | `STACKS_API_LOG_LEVEL` | Log level | — |
 | `STACKS_PROFILER_PORT` | Enable profiler on this port | — |
 | `IBD_MODE_UNTIL_BLOCK` | Initial block download mode until block height | — |
-| `BNS_IMPORT_DIR` | Directory with V1 BNS export data | — |
+| `ENABLE_DEPRECATED_ENDPOINTS` | Serve deprecated `v1`/`v2` routes; `false` makes them respond `410 Gone` | `true` |
 | `STACKS_SHUTDOWN_FORCE_KILL_TIMEOUT` | Graceful shutdown timeout (seconds) | `60` |
 
 ## Development
 
 ### Prerequisites
 
-- Node.js >= 22
+- Node.js >= 24
 - Docker (for service dependencies)
 
 ### Setup
@@ -221,46 +178,39 @@ npm install
 
 ### Running Locally
 
-The quickest way to start with all dependencies (PostgreSQL, Stacks node, Bitcoin node):
+Build and start the API against a running PostgreSQL and Stacks node configured through the environment variables in [Configuration](#configuration):
 
 ```shell
-npm run dev:integrated
+npm run build
+npm start
 ```
 
-This uses Docker Compose to start the service dependencies and runs the API in development mode.
-
-Alternatively, use the VS Code "Launch: w/ postgres" debug configuration.
+Alternatively, use the VS Code `start: api` or `start: mocknet` debug configurations.
 
 Verify the server is running:
 
 ```
-http://localhost:3999/extended/v1/status
+http://localhost:3999/extended
 ```
 
 ### Building
 
 ```shell
 npm run build        # Compile TypeScript
-npm run build:docs   # Generate OpenAPI spec and Redoc docs
-npm run build:client # Generate client types from OpenAPI spec
+npm run build:client # Generate the OpenAPI spec and client types
 ```
 
 ### Testing
 
+Tests are split into suites, one npm script per suite (see `package.json`):
+
 ```shell
-npm test                        # Run all tests
-npm run test:api                # API endpoint tests
-npm run test:bns                # BNS tests
-npm run test:2.5                # PoX-4 / stacking tests
-npm run test:event-replay       # Event replay tests
+npm run test:api:transactions   # e.g. transactions suite; also blocks, principal-v3, pox5, ...
+npm run test:api:event-replay   # Event replay tests
 npm run test:snp                # SNP ingestion tests
 ```
 
-Integration tests spin up their own PostgreSQL via Docker:
-
-```shell
-npm run test:integration
-```
+Each suite spins up its own PostgreSQL via Docker (the `tests/api/setup.ts` global setup), so Docker must be running.
 
 ### Linting
 
@@ -274,11 +224,11 @@ npm run lint:fix    # Auto-fix
 The OpenAPI specification is generated directly from Fastify route definitions:
 
 ```shell
-npm run generate:openapi    # Generate docs/openapi.yaml and docs/openapi.json
-npm run generate:redoc      # Generate Redoc HTML documentation
-npm run generate:postman    # Generate Postman collection
+npm run generate:openapi    # Generate openapi.yaml (deprecated routes excluded)
 npm run generate:client     # Generate TypeScript client types
 ```
+
+The committed `openapi.yaml` and the client types are regenerated as part of the release process; do not regenerate them by hand in feature branches.
 
 ## Event Replay
 
@@ -324,11 +274,9 @@ docker pull hirosystems/stacks-blockchain-api
 
 The image runs `node ./lib/index.js` and expects the environment variables described in [Configuration](#configuration).
 
-A standalone regtest Dockerfile is also available at `docker/standalone-regtest.Dockerfile`, which bundles the API, Stacks node, Bitcoin node, and PostgreSQL into a single image for testing.
-
 ### Upgrading
 
-Major version upgrades (e.g., `7.x` to `8.x`) may include breaking database schema changes. Use [Event Replay](#event-replay) to rebuild the database. Check the [CHANGELOG](CHANGELOG.md) for details on each release.
+Major version upgrades (e.g., `7.x` to `8.x`) may include breaking database schema changes. Use [Event Replay](#event-replay) to rebuild the database. Check the [release notes](https://github.com/hirosystems/stacks-blockchain-api/releases) for details on each release.
 
 ## Bugs and Feature Requests
 

--- a/src/api/routes/v2/schemas.ts
+++ b/src/api/routes/v2/schemas.ts
@@ -211,7 +211,6 @@ export const BlockParamsSchema = Type.Object(
   },
   { additionalProperties: false }
 );
-export type BlockParams = Static<typeof BlockParamsSchema>;
 
 export const BurnBlockParamsSchema = Type.Object(
   {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -75,14 +75,6 @@ export interface DbBurnchainRewardWithBurnAmount extends DbBurnchainReward {
   burn_amount: bigint;
 }
 
-export interface DbBurnchainBlock {
-  canonical: boolean;
-  burn_block_hash: string;
-  burn_block_height: number;
-  burn_amount: bigint;
-  reward_amount: bigint;
-}
-
 export interface DbPoxSetSigners {
   cycle_number: number;
   pox_ustx_threshold: bigint;

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -2062,22 +2062,6 @@ export class PgStore extends BasePgStore {
     return { found: true, result: smartContracts };
   }
 
-  async getStxBalance({ stxAddress }: { stxAddress: string }): Promise<DbStxBalance> {
-    return await this.sqlTransaction(async sql => {
-      const blockQuery = await this.getCurrentBlockInternal(sql);
-      if (!blockQuery.found) {
-        throw new Error(`Could not find current block`);
-      }
-      const result = await this.internalGetStxBalanceAtBlock(
-        sql,
-        stxAddress,
-        blockQuery.result.block_height,
-        blockQuery.result.burn_block_height
-      );
-      return result;
-    });
-  }
-
   async getStxBalanceAtBlock(stxAddress: string, blockHeight: number): Promise<DbStxBalance> {
     return await this.sqlTransaction(async sql => {
       const chainTip = await this.getChainTip(sql);
@@ -3814,27 +3798,6 @@ export class PgStore extends BasePgStore {
           AND canonical = true
           AND microblock_canonical = true
         ORDER BY fully_qualified_subdomain, block_height DESC, microblock_sequence DESC, tx_index DESC
-      `;
-    });
-    const results = queryResult.map(r => r.fully_qualified_subdomain);
-    return { results };
-  }
-
-  /**
-   * @deprecated This function is only used for testing.
-   */
-  async getSubdomainsList({ page }: { page: number }) {
-    const offset = page * 100;
-    const queryResult = await this.sqlTransaction(async sql => {
-      const maxBlockHeight = (await this.getChainTip(sql)).block_height;
-      return await sql<{ fully_qualified_subdomain: string }[]>`
-        SELECT DISTINCT ON (fully_qualified_subdomain) fully_qualified_subdomain
-        FROM subdomains
-        WHERE block_height <= ${maxBlockHeight}
-        AND canonical = true AND microblock_canonical = true
-        ORDER BY fully_qualified_subdomain, block_height DESC, microblock_sequence DESC, tx_index DESC
-        LIMIT 100
-        OFFSET ${offset}
       `;
     });
     const results = queryResult.map(r => r.fully_qualified_subdomain);

--- a/src/env.ts
+++ b/src/env.ts
@@ -38,11 +38,6 @@ const schema = Type.Object({
   PG_STATEMENT_TIMEOUT: Type.Optional(Type.Integer()),
   /** Can be any string, use to specify a use case specific to a deployment */
   PG_APPLICATION_NAME: Type.String({ default: 'stacks-blockchain-api' }),
-  /**
-   * The connection URI below can be used in place of the PG variables above, but if enabled it must
-   * be defined without others or omitted.
-   */
-  PG_CONNECTION_URI: Type.Optional(Type.String()),
   /** Limit to how many concurrent connections can be created, defaults to 10 */
   PG_CONNECTION_POOL_MAX: Type.Integer({ default: 10, minimum: 0 }),
   /**
@@ -63,9 +58,7 @@ const schema = Type.Object({
   PG_PRIMARY_SSL: Type.Optional(Type.Boolean()),
   PG_PRIMARY_IDLE_TIMEOUT: Type.Optional(Type.Integer({ minimum: 0 })),
   PG_PRIMARY_MAX_LIFETIME: Type.Optional(Type.Integer({ minimum: 0 })),
-  PG_PRIMARY_CLOSE_TIMEOUT: Type.Optional(Type.Integer({ minimum: 0 })),
   PG_PRIMARY_STATEMENT_TIMEOUT: Type.Optional(Type.Integer({ minimum: 0 })),
-  PG_PRIMARY_CONNECTION_URI: Type.Optional(Type.String()),
   PG_PRIMARY_CONNECTION_POOL_MAX: Type.Optional(Type.Integer({ minimum: 0 })),
 
   /**
@@ -160,11 +153,6 @@ const schema = Type.Object({
    * given port. This port should not be publicly exposed.
    */
   STACKS_PROFILER_PORT: Type.Optional(Type.Integer({ minimum: 0, maximum: 65535 })),
-  /**
-   * Specify max number of STX address to store in an in-memory LRU cache (CPU optimization).
-   * Defaults to 50,000, which should result in around 25 megabytes of additional memory usage.
-   */
-  STACKS_ADDRESS_CACHE_SIZE: Type.Integer({ default: 50000, minimum: 0 }),
   /**
    * Insert concurrency when processing new blocks. If your PostgreSQL is operating on SSD and has
    * multiple CPU cores, consider raising this value, for instance, to 8 or 16.

--- a/src/event-replay/event-replay.ts
+++ b/src/event-replay/event-replay.ts
@@ -15,21 +15,6 @@ import {
 import { MIGRATIONS_DIR } from '../datastore/pg-store.js';
 import { PgServer, getConnectionArgs } from '../datastore/connection.js';
 
-enum EventImportMode {
-  /**
-   * The Event Server will ingest and process every single Stacks node event contained in the TSV file
-   * from block 0 to the latest block. This is the default mode.
-   */
-  archival = 'archival',
-  /**
-   * The Event Server will ingore certain "prunable" events (see `IBD_PRUNABLE_ROUTES`) from
-   * the imported TSV file if they are received outside of a block window, usually set to
-   * TSV's `block_height` - 256.
-   * This allows the import to be faster at the expense of historical blockchain information.
-   */
-  pruned = 'pruned',
-}
-
 /**
  * Exports all Stacks node events stored in the `event_observer_requests` table to a TSV file.
  * @param filePath - Path to TSV file to write
@@ -66,16 +51,13 @@ export async function exportEventsAsTsv(
 /**
  * Imports Stacks node events from a TSV file and ingests them through the Event Server.
  * @param filePath - Path to TSV file to read
- * @param importMode - Event import mode
  * @param wipeDb - If we should wipe the DB before importing
  * @param force - If we should force drop all tables
  */
 export async function importEventsFromTsv(
   filePath?: string,
-  importMode?: string,
   wipeDb: boolean = false,
-  force: boolean = false,
-  prunedBlockHeightOption?: number
+  force: boolean = false
 ): Promise<HttpClientResponse[]> {
   if (!filePath) {
     throw new Error(`A file path should be specified with the --file option`);
@@ -83,18 +65,6 @@ export async function importEventsFromTsv(
   const resolvedFilePath = path.resolve(filePath);
   if (!fs.existsSync(resolvedFilePath)) {
     throw new Error(`File does not exist: ${resolvedFilePath}`);
-  }
-  let eventImportMode: EventImportMode;
-  switch (importMode) {
-    case 'pruned':
-      eventImportMode = EventImportMode.pruned;
-      break;
-    case 'archival':
-    case undefined:
-      eventImportMode = EventImportMode.archival;
-      break;
-    default:
-      throw new Error(`Invalid event import mode: ${importMode}`);
   }
   const connectionArgs = getConnectionArgs(PgServer.primary);
   const hasData = await databaseHasData(connectionArgs);
@@ -120,16 +90,9 @@ export async function importEventsFromTsv(
     );
   }
 
-  // Look for the TSV's block height and determine the prunable block window.
   const tsvBlockHeight = await findTsvBlockHeight(resolvedFilePath);
-  const blockWindowSize = 256;
-  const prunedBlockHeight =
-    prunedBlockHeightOption ?? Math.max(tsvBlockHeight - blockWindowSize, 0);
   console.log(`Event file's block height: ${tsvBlockHeight}`);
-  console.log(`Starting event import and playback in ${eventImportMode} mode`);
-  if (eventImportMode === EventImportMode.pruned) {
-    console.log(`Ignoring all prunable events before block height: ${prunedBlockHeight}`);
-  }
+  console.log(`Starting event import and playback`);
 
   const db = await PgWriteStore.connect({
     usageName: 'import-events',
@@ -155,15 +118,10 @@ export async function importEventsFromTsv(
   // in the equivalent of months/years of API log output.
   logger.level = 'warn';
   // The current import block height. Will be updated with every `/new_block` event.
-  let blockHeight = 0;
+  let blockHeight: number;
   const responses = [];
   for await (const rawEvents of rawEventsIterator) {
     for (const rawEvent of rawEvents) {
-      if (eventImportMode === EventImportMode.pruned) {
-        if (blockHeight === prunedBlockHeight) {
-          console.log(`Resuming prunable event import...`);
-        }
-      }
       const response = await httpPostRequest({
         host: '127.0.0.1',
         port: eventServer.serverAddress.port,

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -611,15 +611,6 @@ async function handleNewAttachmentMessage(msg: AttachmentsNewMessage[], db: PgWr
   await db.updateAttachments(attachments);
 }
 
-export const DummyEventMessageHandler: EventMessageHandler = {
-  handleRawEventRequest: () => {},
-  handleBlockMessage: () => {},
-  handleBurnBlock: () => {},
-  handleMempoolTxs: () => {},
-  handleDroppedMempoolTxs: () => {},
-  handleNewAttachment: () => {},
-};
-
 interface EventMessageHandler {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   handleRawEventRequest(eventPath: string, payload: any, db: PgWriteStore): Promise<void> | void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,7 +227,6 @@ function getProgramArgs() {
         operand: 'import-events';
         options: {
           ['file']?: string;
-          ['mode']?: string;
           ['wipe-db']?: boolean;
           ['force']?: boolean;
         };
@@ -240,12 +239,7 @@ async function handleProgramArgs() {
   if (args.operand === 'export-events') {
     await exportEventsAsTsv(args.options.file, args.options['overwrite-file']);
   } else if (args.operand === 'import-events') {
-    await importEventsFromTsv(
-      args.options.file,
-      args.options.mode,
-      args.options['wipe-db'],
-      args.options.force
-    );
+    await importEventsFromTsv(args.options.file, args.options['wipe-db'], args.options.force);
   } else if (parsedOpts._[0]) {
     throw new Error(`Unexpected program argument: ${parsedOpts._[0]}`);
   } else {

--- a/tests/api/datastore/datastore.test.ts
+++ b/tests/api/datastore/datastore.test.ts
@@ -29,6 +29,7 @@ import { bnsNameCV, I32_MAX } from '../../../src/helpers.ts';
 import { TestBlockBuilder } from '../test-builders.ts';
 import { PgSqlClient, bufferToHex } from '@stacks/api-toolkit';
 import { migrate } from '../../test-helpers.ts';
+import { getCurrentStxBalance } from '../test-helpers.ts';
 import { beforeEach, afterEach, describe, test } from 'node:test';
 import { STACKS_MAINNET } from '@stacks/network';
 
@@ -207,10 +208,10 @@ describe('postgres datastore', () => {
     await db.updateTx(client, tx);
     await db.updateTx(client, tx2);
 
-    const addrAResult = await db.getStxBalance({ stxAddress: 'addrA' });
-    const addrBResult = await db.getStxBalance({ stxAddress: 'addrB' });
-    const addrCResult = await db.getStxBalance({ stxAddress: 'addrC' });
-    const addrDResult = await db.getStxBalance({ stxAddress: 'addrD' });
+    const addrAResult = await getCurrentStxBalance(db, 'addrA');
+    const addrBResult = await getCurrentStxBalance(db, 'addrB');
+    const addrCResult = await getCurrentStxBalance(db, 'addrC');
+    const addrDResult = await getCurrentStxBalance(db, 'addrD');
 
     assert.deepEqual(addrAResult, {
       balance: 198291n,
@@ -4622,21 +4623,13 @@ describe('postgres datastore', () => {
     assert.equal(b3b.result?.canonical, true);
     assert.equal(b4.result?.canonical, true);
 
-    const r1 = await db.getStxBalance({
-      stxAddress: minerReward1.recipient,
-    });
-    const r2 = await db.getStxBalance({
-      stxAddress: minerReward2.recipient,
-    });
+    const r1 = await getCurrentStxBalance(db, minerReward1.recipient);
+    const r2 = await getCurrentStxBalance(db, minerReward2.recipient);
     assert.equal(r1.totalMinerRewardsReceived, 1014n);
     assert.equal(r2.totalMinerRewardsReceived, 0n);
 
-    const lock1 = await db.getStxBalance({
-      stxAddress: stxLockEvent1.locked_address,
-    });
-    const lock2 = await db.getStxBalance({
-      stxAddress: stxLockEvent2.locked_address,
-    });
+    const lock1 = await getCurrentStxBalance(db, stxLockEvent1.locked_address);
+    const lock2 = await getCurrentStxBalance(db, stxLockEvent2.locked_address);
     assert.equal(lock1.locked, 1234n);
     assert.equal(lock2.locked, 0n);
 
@@ -4653,9 +4646,7 @@ describe('postgres datastore', () => {
     // Ensure STX holder balances have tracked correctly through the reorgs
     const holders1 = await db.getTokenHolders({ token: 'stx', limit: 100, offset: 0 });
     for (const holder of holders1.results) {
-      const holderBalance = await db.getStxBalance({
-        stxAddress: holder.address,
-      });
+      const holderBalance = await getCurrentStxBalance(db, holder.address);
       assert.equal(holder.balance, holderBalance.balance.toString());
     }
   });
@@ -5280,9 +5271,7 @@ describe('postgres datastore', () => {
 
     // Ensure STX holder balances have tracked correctly through the reorgs
     for (const holder of holders1.results) {
-      const holderBalance = await db.getStxBalance({
-        stxAddress: holder.address,
-      });
+      const holderBalance = await getCurrentStxBalance(db, holder.address);
       assert.equal(holder.balance, holderBalance.balance.toString());
     }
 
@@ -5832,9 +5821,12 @@ describe('postgres datastore', () => {
       },
       subdomains
     );
-    const { results } = await db.getSubdomainsList({ page: 0 });
+    const results = await db.sql<{ fully_qualified_subdomain: string }[]>`
+      SELECT fully_qualified_subdomain FROM subdomains
+      WHERE canonical = true AND microblock_canonical = true
+    `;
     assert.equal(results.length, 1);
-    assert.equal(results[0], 'test.nametest.namespacetest');
+    assert.equal(results[0].fully_qualified_subdomain, 'test.nametest.namespacetest');
   });
 
   test('pg get transactions in a block', async () => {

--- a/tests/api/event-replay/import-export.test.ts
+++ b/tests/api/event-replay/import-export.test.ts
@@ -28,7 +28,7 @@ describe('import/export tests', () => {
     const args = getConnectionArgs();
     // Import from mocknet TSV
     await createSchema(args);
-    await importEventsFromTsv('tests/api/event-replay/tsv/mocknet.tsv', 'archival', true, true);
+    await importEventsFromTsv('tests/api/event-replay/tsv/mocknet.tsv', true, true);
     const chainTip = await db.getChainTip(db.sql);
     assert.equal(chainTip.block_height, 28);
     assert.equal(
@@ -47,7 +47,7 @@ describe('import/export tests', () => {
 
     // Re-import with exported TSV and check that chain tip matches.
     try {
-      await importEventsFromTsv(`${tmpDir}/export.tsv`, 'archival', true, true);
+      await importEventsFromTsv(`${tmpDir}/export.tsv`, true, true);
       const newChainTip = await db.getChainTip(db.sql);
       assert.equal(newChainTip.block_height, 28);
       assert.equal(
@@ -67,7 +67,7 @@ describe('import/export tests', () => {
     const args = getConnectionArgs();
     // Import from mocknet TSV
     await createSchema(args);
-    await importEventsFromTsv('tests/api/event-replay/tsv/mocknet.tsv', 'archival', true, true);
+    await importEventsFromTsv('tests/api/event-replay/tsv/mocknet.tsv', true, true);
     const chainTip = await db.getChainTip(db.sql);
     assert.equal(chainTip.block_height, 28);
     assert.equal(
@@ -86,7 +86,7 @@ describe('import/export tests', () => {
 
     // Re-import with exported TSV and check that chain tip matches.
     try {
-      await importEventsFromTsv(`${tmpDir}/export.tsv`, 'archival', true, true);
+      await importEventsFromTsv(`${tmpDir}/export.tsv`, true, true);
       const newChainTip = await db.getChainTip(db.sql);
       assert.equal(newChainTip.block_height, 28);
       assert.equal(
@@ -106,20 +106,20 @@ describe('import/export tests', () => {
     // Migrate first so we have some data.
     await migrate('up');
     await assert.rejects(
-      importEventsFromTsv('tests/api/event-replay/tsv/mocknet.tsv', 'archival', false, false),
+      importEventsFromTsv('tests/api/event-replay/tsv/mocknet.tsv', false, false),
       /contains existing data/
     );
 
     // Create strange table
     await db.sql`CREATE TABLE IF NOT EXISTS test (a varchar(10))`;
     await assert.rejects(
-      importEventsFromTsv('tests/api/event-replay/tsv/mocknet.tsv', 'archival', true, false),
+      importEventsFromTsv('tests/api/event-replay/tsv/mocknet.tsv', true, false),
       /migration cycle failed/
     );
 
     // Force and test
     await assert.doesNotReject(
-      importEventsFromTsv('tests/api/event-replay/tsv/mocknet.tsv', 'archival', true, true)
+      importEventsFromTsv('tests/api/event-replay/tsv/mocknet.tsv', true, true)
     );
   });
 
@@ -145,7 +145,7 @@ describe('import/export tests', () => {
 
   test('Bns import occurs (block 1 genesis)', async () => {
     ENV.BNS_IMPORT_DIR = 'tests/api/bns/import-test-files';
-    await importEventsFromTsv('tests/api/event-replay/tsv/mocknet.tsv', 'archival', true, true);
+    await importEventsFromTsv('tests/api/event-replay/tsv/mocknet.tsv', true, true);
     const configState = await db.getConfigState();
     assert.equal(configState.bns_names_onchain_imported, true);
     assert.equal(configState.bns_subdomains_imported, true);
@@ -153,10 +153,9 @@ describe('import/export tests', () => {
 
   test('Bns import occurs (block 0 genesis)', async () => {
     ENV.BNS_IMPORT_DIR = 'tests/api/bns/import-test-files';
-    await importEventsFromTsv('tests/api/event-replay/tsv/mainnet-block0.tsv', 'archival', true, true);
+    await importEventsFromTsv('tests/api/event-replay/tsv/mainnet-block0.tsv', true, true);
     const configState = await db.getConfigState();
     assert.equal(configState.bns_names_onchain_imported, true);
     assert.equal(configState.bns_subdomains_imported, true);
   });
-
 });

--- a/tests/api/event-replay/poison-microblock.test.ts
+++ b/tests/api/event-replay/poison-microblock.test.ts
@@ -20,12 +20,7 @@ describe('poison microblock for height 80743', () => {
   });
 
   test('test that it does not give 500 error', async () => {
-    await importEventsFromTsv(
-      'tests/api/event-replay/tsv/poisonmicroblock.tsv',
-      'archival',
-      true,
-      true
-    );
+    await importEventsFromTsv('tests/api/event-replay/tsv/poisonmicroblock.tsv', true, true);
     const poisonTxId = '0x58ffe62029f94f7101b959536ea4953b9bce0ec3f6e2a06254c511bdd5cfa9e7';
     const chainTip = await db.getChainTip(db.sql);
     // query the txs table and check the transaction type

--- a/tests/api/event-server/out-of-order-multisig.test.ts
+++ b/tests/api/event-server/out-of-order-multisig.test.ts
@@ -43,7 +43,6 @@ describe('Out-of-order-multisig tx tests', () => {
   test('tsv replay with out-of-order-multisig tx', async () => {
     await importEventsFromTsv(
       'tests/api/event-server/tsv/regtest-env-pox-4-out-of-order-multisig-tx.tsv',
-      'archival',
       true,
       true
     );

--- a/tests/api/event-server/pox.test.ts
+++ b/tests/api/event-server/pox.test.ts
@@ -46,12 +46,7 @@ describe('PoX tests', () => {
   });
 
   test('api', async () => {
-    await importEventsFromTsv(
-      'tests/api/event-server/tsv/epoch-3-transition.tsv',
-      'archival',
-      true,
-      true
-    );
+    await importEventsFromTsv('tests/api/event-server/tsv/epoch-3-transition.tsv', true, true);
     const cycles = await supertest(api.server).get(`/extended/v2/pox/cycles`);
     assert.equal(cycles.status, 200);
     assert.equal(cycles.type, 'application/json');
@@ -195,7 +190,6 @@ describe('PoX tests', () => {
     test('snapshot 1', async () => {
       await importEventsFromTsv(
         'tests/api/event-server/tsv/regtest-env-pox-4-stack-stx-in-reward-phase-S1.tsv',
-        'archival',
         true,
         true
       );
@@ -209,7 +203,6 @@ describe('PoX tests', () => {
     test('snapshot 2', async () => {
       await importEventsFromTsv(
         'tests/api/event-server/tsv/regtest-env-pox-4-stack-stx-in-reward-phase-S2.tsv',
-        'archival',
         true,
         true
       );
@@ -225,7 +218,6 @@ describe('PoX tests', () => {
     test('snapshot 3', async () => {
       await importEventsFromTsv(
         'tests/api/event-server/tsv/regtest-env-pox-4-stack-stx-in-reward-phase-S3.tsv',
-        'archival',
         true,
         true
       );

--- a/tests/api/pox5/stx-lock.test.ts
+++ b/tests/api/pox5/stx-lock.test.ts
@@ -6,6 +6,7 @@ import { Pox5EventName } from '@stacks/codec';
 import { ApiServer, startApiServer } from '../../../src/api/init.ts';
 import { PgWriteStore } from '../../../src/datastore/pg-write-store.ts';
 import { migrate } from '../../test-helpers.ts';
+import { getCurrentStxBalance } from '../test-helpers.ts';
 import { TestBlockBuilder } from '../test-builders.ts';
 
 /**
@@ -30,7 +31,12 @@ describe('pox-5 stake locked balances', () => {
 
   async function lockedRow(principal: string) {
     const rows = await db.sql<
-      { locked_amount: string; unlock_burn_height: string; pox_version: number; lock_block_height: number }[]
+      {
+        locked_amount: string;
+        unlock_burn_height: string;
+        pox_version: number;
+        lock_block_height: number;
+      }[]
     >`
       SELECT locked_amount, unlock_burn_height, pox_version, lock_block_height
       FROM stx_locked_balances WHERE principal = ${principal}
@@ -74,7 +80,11 @@ describe('pox-5 stake locked balances', () => {
 
   beforeEach(async () => {
     await migrate('up');
-    db = await PgWriteStore.connect({ usageName: 'tests', withNotifier: false, skipMigrations: true });
+    db = await PgWriteStore.connect({
+      usageName: 'tests',
+      withNotifier: false,
+      skipMigrations: true,
+    });
     api = await startApiServer({ datastore: db, chainId: STACKS_TESTNET.chainId });
     // Block 1: alice stakes.
     await db.update(
@@ -171,7 +181,11 @@ describe('pox-5 locked STX in balance read path', () => {
 
   beforeEach(async () => {
     await migrate('up');
-    db = await PgWriteStore.connect({ usageName: 'tests', withNotifier: false, skipMigrations: true });
+    db = await PgWriteStore.connect({
+      usageName: 'tests',
+      withNotifier: false,
+      skipMigrations: true,
+    });
     api = await startApiServer({ datastore: db, chainId: STACKS_TESTNET.chainId });
   });
 
@@ -193,7 +207,7 @@ describe('pox-5 locked STX in balance read path', () => {
         .addTxPox5Event({ name: Pox5EventName.Stake, data: stakeData(STAKE_AMOUNT, ACTIVE_UNLOCK) })
         .build()
     );
-    const balance = await db.getStxBalance({ stxAddress: ALICE });
+    const balance = await getCurrentStxBalance(db, ALICE);
     assert.equal(balance.locked, STAKE_AMOUNT);
     assert.equal(balance.burnchainUnlockHeight, ACTIVE_UNLOCK);
     assert.equal(balance.lockHeight, 1);
@@ -209,10 +223,13 @@ describe('pox-5 locked STX in balance read path', () => {
         burn_block_height: TIP_BURN_HEIGHT,
       })
         .addTx({ tx_id: '0x' + 'a1'.repeat(32) })
-        .addTxPox5Event({ name: Pox5EventName.Stake, data: stakeData(STAKE_AMOUNT, EXPIRED_UNLOCK) })
+        .addTxPox5Event({
+          name: Pox5EventName.Stake,
+          data: stakeData(STAKE_AMOUNT, EXPIRED_UNLOCK),
+        })
         .build()
     );
-    const balance = await db.getStxBalance({ stxAddress: ALICE });
+    const balance = await getCurrentStxBalance(db, ALICE);
     assert.equal(balance.locked, 0n);
     assert.equal(balance.lockTxId, '');
     assert.equal(balance.burnchainUnlockHeight, 0);
@@ -263,9 +280,13 @@ describe('pox-5 locked STX in balance read path', () => {
     );
     // The reported bug: after unstake the STX showed as unlocked immediately.
     // It must stay locked until the (end-of-cycle) unlock height.
-    const balance = await db.getStxBalance({ stxAddress: ALICE });
+    const balance = await getCurrentStxBalance(db, ALICE);
     assert.equal(balance.locked, STAKE_AMOUNT, 'STX still locked right after unstake');
-    assert.equal(balance.burnchainUnlockHeight, STILL_LOCKED_UNLOCK, 'unlock deferred to cycle end');
+    assert.equal(
+      balance.burnchainUnlockHeight,
+      STILL_LOCKED_UNLOCK,
+      'unlock deferred to cycle end'
+    );
   });
 
   test('after the cycle-end unlock height passes, an unstaked position reports zero locked STX', async () => {
@@ -291,10 +312,13 @@ describe('pox-5 locked STX in balance read path', () => {
         burn_block_height: TIP_BURN_HEIGHT,
       })
         .addTx({ tx_id: '0x' + 'a2'.repeat(32) })
-        .addTxPox5Event({ name: Pox5EventName.Unstake, data: unstakeData(STAKE_AMOUNT, EXPIRED_UNLOCK) })
+        .addTxPox5Event({
+          name: Pox5EventName.Unstake,
+          data: unstakeData(STAKE_AMOUNT, EXPIRED_UNLOCK),
+        })
         .build()
     );
-    const balance = await db.getStxBalance({ stxAddress: ALICE });
+    const balance = await getCurrentStxBalance(db, ALICE);
     assert.equal(balance.locked, 0n, 'unlocked once the cycle-end height has passed');
   });
 
@@ -379,7 +403,11 @@ describe('pox-4 stx_lock inheritance', () => {
 
   beforeEach(async () => {
     await migrate('up');
-    db = await PgWriteStore.connect({ usageName: 'tests', withNotifier: false, skipMigrations: true });
+    db = await PgWriteStore.connect({
+      usageName: 'tests',
+      withNotifier: false,
+      skipMigrations: true,
+    });
     api = await startApiServer({ datastore: db, chainId: STACKS_TESTNET.chainId });
   });
 
@@ -484,7 +512,12 @@ describe('stx_locked_balances reorg handling', () => {
 
   async function lockedRow(principal: string) {
     const rows = await db.sql<
-      { locked_amount: string; unlock_burn_height: string; pox_version: number; lock_block_height: number }[]
+      {
+        locked_amount: string;
+        unlock_burn_height: string;
+        pox_version: number;
+        lock_block_height: number;
+      }[]
     >`
       SELECT locked_amount, unlock_burn_height, pox_version, lock_block_height
       FROM stx_locked_balances WHERE principal = ${principal}
@@ -494,11 +527,19 @@ describe('stx_locked_balances reorg handling', () => {
 
   beforeEach(async () => {
     await migrate('up');
-    db = await PgWriteStore.connect({ usageName: 'tests', withNotifier: false, skipMigrations: true });
+    db = await PgWriteStore.connect({
+      usageName: 'tests',
+      withNotifier: false,
+      skipMigrations: true,
+    });
     api = await startApiServer({ datastore: db, chainId: STACKS_TESTNET.chainId });
     // Genesis.
     await db.update(
-      new TestBlockBuilder({ block_height: 1, block_hash: '0x01', index_block_hash: '0x01' }).build()
+      new TestBlockBuilder({
+        block_height: 1,
+        block_hash: '0x01',
+        index_block_hash: '0x01',
+      }).build()
     );
   });
 

--- a/tests/api/test-helpers.ts
+++ b/tests/api/test-helpers.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { PgStore } from '../../src/datastore/pg-store.ts';
 
 type Disposable<T> = () =>
   | readonly [item: T, dispose: () => any | Promise<any>]
@@ -81,4 +82,10 @@ export function assertMatchesObject(actual: any, expected: any): void {
 
 export function hex(value: number): string {
   return `0x${value.toString(16).padStart(64, '0')}`;
+}
+
+/** Returns the STX balance of `address` at the current chain tip. */
+export async function getCurrentStxBalance(db: PgStore, address: string) {
+  const chainTip = await db.getChainTip(db.sql);
+  return db.getStxBalanceAtBlock(address, chainTip.block_height);
 }


### PR DESCRIPTION
Removes dead code and brings the README in line with the current endpoint deprecation state. No endpoint behavior or response shape changes.

- **`pruned` event replay mode.** Unused
- **Env vars that nothing reads:** `PG_CONNECTION_URI`, `PG_PRIMARY_CONNECTION_URI`, `PG_PRIMARY_CLOSE_TIMEOUT`, `STACKS_ADDRESS_CACHE_SIZE`. 
- **Unused exports:** `DummyEventMessageHandler`, the `DbBurnchainBlock` interface, the `BlockParams` type alias in the v2 schemas.
- **Test-only datastore methods:** `PgStore.getStxBalance` (production uses `getStxBalanceAtBlock`) and `getSubdomainsList` (already annotated as test-only).