### PR TITLE
fix: serialize post_condition_mode on v3 transaction responses

### DIFF
--- a/src/api/schemas/v3/entities/mempool-transactions.ts
+++ b/src/api/schemas/v3/entities/mempool-transactions.ts
@@ -1,12 +1,19 @@
 import { Static, Type } from '@sinclair/typebox';
 import { BaseMempoolTransactionSummarySchema } from './mempool-transaction-summaries.js';
-import { PostConditionSchema } from './post-conditions.js';
+import { PostConditionModeSchema, PostConditionSchema } from './post-conditions.js';
 import { Nullable } from '../../v1/util.js';
 import { DecodedClarityValueSchema, DecodedStxTransferMemoSchema } from './common.js';
 
 const BaseMempoolTransactionSchema = Type.Composite([
   BaseMempoolTransactionSummarySchema,
   Type.Object({
+    post_condition_mode: Type.Optional(
+      Type.Union(PostConditionModeSchema.anyOf, {
+        description:
+          'Post condition mode of the transaction. Only present when requested via the ' +
+          '`include=post_conditions` query param.',
+      })
+    ),
     post_conditions: Type.Optional(
       Type.Array(PostConditionSchema, {
         description: 'Only present when requested via the `include=post_conditions` query param.',

--- a/src/api/schemas/v3/entities/transactions.ts
+++ b/src/api/schemas/v3/entities/transactions.ts
@@ -1,6 +1,6 @@
 import { Static, Type } from '@sinclair/typebox';
 import { BaseTransactionSummarySchema, TenureChangeCauseSchema } from './transaction-summaries.js';
-import { PostConditionSchema } from './post-conditions.js';
+import { PostConditionModeSchema, PostConditionSchema } from './post-conditions.js';
 import { Nullable } from '../../v1/util.js';
 import {
   DecodedClarityValueSchema,
@@ -19,6 +19,13 @@ const BaseTransactionSchema = Type.Composite([
         description: 'Index block hash of the parent block',
       }),
     }),
+    post_condition_mode: Type.Optional(
+      Type.Union(PostConditionModeSchema.anyOf, {
+        description:
+          'Post condition mode of the transaction. Only present when requested via the ' +
+          '`include=post_conditions` query param.',
+      })
+    ),
     post_conditions: Type.Optional(
       Type.Array(PostConditionSchema, {
         description: 'Only present when requested via the `include=post_conditions` query param.',

--- a/src/api/serializers/v3/mempool-transactions.ts
+++ b/src/api/serializers/v3/mempool-transactions.ts
@@ -22,7 +22,7 @@ import {
   TokenTransferMempoolTransaction,
 } from '../../schemas/v3/entities/mempool-transactions.js';
 import { TransactionIncludeField } from '../../schemas/v3/entities/transactions.js';
-import { serializePostCondition } from './post-conditions.js';
+import { serializePostCondition, serializePostConditionMode } from './post-conditions.js';
 import { decodeClarityValueList, decodePostConditions, memoToString } from '@stacks/codec';
 
 /**
@@ -162,9 +162,9 @@ export function serializeDbMempoolTransaction(
     replaced_by_tx_id: transaction.replaced_by_tx_id,
   };
   if (include?.includes('post_conditions')) {
-    result.post_conditions = decodePostConditions(transaction.post_conditions).post_conditions.map(
-      pc => serializePostCondition(pc)
-    );
+    const decoded = decodePostConditions(transaction.post_conditions);
+    result.post_condition_mode = serializePostConditionMode(decoded.post_condition_mode);
+    result.post_conditions = decoded.post_conditions.map(pc => serializePostCondition(pc));
   }
   switch (transaction.type_id) {
     case DbTxTypeId.TokenTransfer: {

--- a/src/api/serializers/v3/transactions.ts
+++ b/src/api/serializers/v3/transactions.ts
@@ -36,7 +36,7 @@ import {
   decodePostConditions,
   memoToString,
 } from '@stacks/codec';
-import { serializePostCondition } from './post-conditions.js';
+import { serializePostCondition, serializePostConditionMode } from './post-conditions.js';
 import { serializeDbMempoolTransaction } from './mempool-transactions.js';
 
 /**
@@ -251,9 +251,9 @@ export function serializeDbTransaction(
     vm_error: transaction.vm_error,
   };
   if (include?.includes('post_conditions')) {
-    result.post_conditions = decodePostConditions(transaction.post_conditions).post_conditions.map(
-      pc => serializePostCondition(pc)
-    );
+    const decoded = decodePostConditions(transaction.post_conditions);
+    result.post_condition_mode = serializePostConditionMode(decoded.post_condition_mode);
+    result.post_conditions = decoded.post_conditions.map(pc => serializePostCondition(pc));
   }
   if (include?.includes('result')) {
     result.result = {

--- a/tests/api/mempool/mempool-v3.test.ts
+++ b/tests/api/mempool/mempool-v3.test.ts
@@ -445,6 +445,7 @@ describe('v3 mempool', () => {
       assert.equal(body.contract_call.function_name, 'stack-stx');
       // Heavy fields omitted by default.
       assert.equal(body.contract_call.function_args, undefined);
+      assert.equal(body.post_condition_mode, undefined);
       assert.equal(body.post_conditions, undefined);
       // `result` does not apply to mempool transactions (they have not executed) — the
       // schema doesn't even declare it on the mempool type, so it must stay absent
@@ -493,7 +494,54 @@ describe('v3 mempool', () => {
         { hex: '0x010000000000000000000000000001e240', repr: 'u123456' },
         { hex: '0x0d0000000568656c6c6f', repr: '"hello"' },
       ]);
+      // '0x01f5' → allow mode, empty list.
+      assert.equal(body.post_condition_mode, 'allow');
       assert.deepEqual(body.post_conditions, []);
+    });
+
+    test('should serialize the post condition mode alongside the post conditions', async () => {
+      const txId = hex(0x4004);
+      await db.update(
+        new TestBlockBuilder({
+          block_height: 1,
+          index_block_hash: hex(1),
+          parent_index_block_hash: hex(0),
+          parent_block_hash: hex(0),
+        })
+          .addTx({ tx_id: hex(0xaa), sender_address: BLOCK_SENDER, nonce: 0 })
+          .build()
+      );
+      await db.updateMempoolTxs({
+        mempoolTxs: [
+          testMempoolTx({
+            tx_id: txId,
+            receipt_time: 2000,
+            type_id: DbTxTypeId.TokenTransfer,
+            sender_address: SENDER,
+            fee_rate: 100n,
+            nonce: 5,
+            // Deny mode (0x02), one STX post condition: origin principal, sent_equal_to, 100 µSTX.
+            post_conditions: '0x02000000010001010000000000000064',
+          }),
+        ],
+      });
+      const response = await api.fastifyApp.inject({
+        method: 'GET',
+        url: `/extended/v3/transactions/${txId}`,
+        query: { include: 'post_conditions' },
+      });
+      assert.equal(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.equal(body.status, 'pending');
+      assert.equal(body.post_condition_mode, 'deny');
+      assert.deepEqual(body.post_conditions, [
+        {
+          type: 'stx',
+          condition_code: 'sent_equal_to',
+          amount: '100',
+          principal: { type_id: 'principal_origin' },
+        },
+      ]);
     });
 
     test('should return 304 when ETag matches and refresh ETag when the mempool tx is confirmed', async () => {

--- a/tests/api/test-builders.ts
+++ b/tests/api/test-builders.ts
@@ -293,6 +293,7 @@ interface TestMempoolTxArgs {
   sponsor_address?: string;
   sponsored?: boolean;
   receipt_time?: number;
+  post_conditions?: string;
 }
 
 /**
@@ -311,7 +312,7 @@ export function testMempoolTx(args?: TestMempoolTxArgs): DbMempoolTxRaw {
     receipt_time: args?.receipt_time ?? (new Date().getTime() / 1000) | 0,
     status: args?.status ?? DbTxStatus.Pending,
     replaced_by_tx_id: args?.replaced_by_tx_id,
-    post_conditions: '0x01f5',
+    post_conditions: args?.post_conditions ?? '0x01f5',
     fee_rate: args?.fee_rate ?? 1234n,
     sponsored: args?.sponsored ?? false,
     sponsor_address: args?.sponsor_address,

--- a/tests/api/transactions/tx-v3.test.ts
+++ b/tests/api/transactions/tx-v3.test.ts
@@ -502,6 +502,7 @@ describe('v3 transactions', () => {
       assert.equal(body.contract_call.function_name, 'stack-stx');
       // None of the opt-in fields should be present.
       assert.equal(body.contract_call.function_args, undefined);
+      assert.equal(body.post_condition_mode, undefined);
       assert.equal(body.post_conditions, undefined);
       assert.equal(body.result, undefined);
     });
@@ -520,8 +521,57 @@ describe('v3 transactions', () => {
         { hex: '0x010000000000000000000000000001e240', repr: 'u123456' },
         { hex: '0x0d0000000568656c6c6f', repr: '"hello"' },
       ]);
+      // '0x01f5' → allow mode, empty list.
+      assert.equal(body.post_condition_mode, 'allow');
       assert.deepEqual(body.post_conditions, []);
       assert.deepEqual(body.result, { hex: '0x0703', repr: '(ok true)' });
+    });
+
+    test('should serialize the post condition mode alongside the post conditions', async () => {
+      const txDeny = hex(0x5003);
+      await db.update(
+        new TestBlockBuilder({
+          block_height: 1,
+          index_block_hash: hex(1),
+          parent_index_block_hash: hex(0),
+          parent_block_hash: hex(0),
+        })
+          .addTx({
+            tx_id: txDeny,
+            block_hash: hex(1),
+            index_block_hash: hex(1),
+            block_time: 1000,
+            burn_block_height: 1,
+            burn_block_time: 1000,
+            tx_index: 0,
+            fee_rate: 50n,
+            type_id: DbTxTypeId.ContractCall,
+            status: DbTxStatus.Success,
+            sender_address: SENDER,
+            contract_call_contract_id: CONTRACT_ID,
+            contract_call_function_name: 'stack-stx',
+            contract_call_function_args: bufferToHex(createClarityValueArray(uintCV(1))),
+            // Deny mode (0x02), one STX post condition: origin principal, sent_equal_to, 100 µSTX.
+            post_conditions: '0x02000000010001010000000000000064',
+          })
+          .build()
+      );
+      const response = await api.fastifyApp.inject({
+        method: 'GET',
+        url: `/extended/v3/transactions/${txDeny}`,
+        query: { include: 'post_conditions' },
+      });
+      assert.equal(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.equal(body.post_condition_mode, 'deny');
+      assert.deepEqual(body.post_conditions, [
+        {
+          type: 'stx',
+          condition_code: 'sent_equal_to',
+          amount: '100',
+          principal: { type_id: 'principal_origin' },
+        },
+      ]);
     });
 
     test('should populate source_code when requested', async () => {
@@ -537,6 +587,7 @@ describe('v3 transactions', () => {
       assert.equal(body.type, 'smart_contract');
       assert.equal(body.smart_contract.source_code, SOURCE_CODE);
       // The other heavy fields stay omitted.
+      assert.equal(body.post_condition_mode, undefined);
       assert.equal(body.post_conditions, undefined);
       assert.equal(body.result, undefined);
     });


### PR DESCRIPTION
The v3 single-transaction endpoint decoded each transaction's post conditions but dropped the **post condition mode**. This adds an optional `post_condition_mode` field to the v3 transaction and mempool transaction schemas, populated alongside `post_conditions` when `include=post_conditions` is requested.

```json
{
  "tx_id": "0x0000000000000000000000000000000000000000000000000000000000005003",
  "sender": {
    "address": "SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27",
    "nonce": 0
  },
  "sponsor": null,
  "fee_rate": "50",
  "block": {
    "height": 1,
    "hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
    "index_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
    "time": 1000,
    "tx_index": 0
  },
  "bitcoin_block": {
    "height": 1,
    "time": 1000
  },
  "status": "success",
  "parent_block": {
    "hash": "0x123456",
    "index_hash": "0xdeadbeef"
  },
  "event_count": 0,
  "execution_cost": {
    "read_count": 0,
    "read_length": 0,
    "runtime": 0,
    "write_count": 0,
    "write_length": 0
  },
  "vm_error": null,
  "type": "contract_call",
  "contract_call": {
    "contract_id": "SP000000000000000000002Q6VF78.pox-4",
    "function_name": "stack-stx"
  },
  "post_condition_mode": "deny",
  "post_conditions": [
    {
      "principal": {
        "type_id": "principal_origin"
      },
      "condition_code": "sent_equal_to",
      "amount": "100",
      "type": "stx"
    }
  ]
}
```
